### PR TITLE
refactor(dashboard): extract module navigation helpers

### DIFF
--- a/docs/implementation/dashboard-module-navigation-controller.md
+++ b/docs/implementation/dashboard-module-navigation-controller.md
@@ -1,0 +1,98 @@
+# Dashboard module navigation controller (PR-PRES-4)
+
+> Status: implemented · Scope: `frontend/src/features/dashboard/application/**`
+> plus the two clinic navigation components that consume it.
+> Predecessors: [dashboard-presentation-boundaries](./dashboard-presentation-boundaries.md),
+> [dashboard-module-config-catalog](./dashboard-module-config-catalog.md).
+> Audit: [dashboard-presentation-primitives-architecture-audit](../audit/dashboard-presentation-primitives-architecture-audit.md)
+> (H1 module-truth duplication, H2 application boundary).
+
+## Goal
+
+Extract a **minimal, safe** utility for dashboard module navigation into the
+application layer so the `?module=` grammar (href construction + URL→module
+normalization) is declared once, without changing any visual behavior, public
+route, CSS, permission, or no-scroll contract.
+
+Non-goal: a full navigation rewrite. The intricate per-role controller effects
+(URL sync, last-module restore, optimistic two-commit activation) are **left
+intact** — see "What was deliberately left in the controllers" below.
+
+## What was extracted
+
+New module: `frontend/src/features/dashboard/application/dashboardModuleNavigation.ts`,
+re-exported from `frontend/src/features/dashboard/application/index.ts`.
+
+| Export | Purpose |
+| --- | --- |
+| `MODULE_QUERY_PARAM` | The single `"module"` query-key literal. |
+| `buildDashboardModuleHref(basePath, moduleId)` | Pure, route-agnostic `?module=` href builder. Produces the exact string the surfaces built inline before. |
+| `readClinicModuleFromLocation()` | SSR-safe read of the active clinic module from `window.location.search`, normalized through the catalog's `parseClinicModule` (no re-declared id check). |
+
+Boundary rule (application layer): **no JSX**, SSR-safe (`window` guarded),
+route-agnostic (callers pass `ROUTES.dashboard`). Only depends on the config
+catalog (`../config`), so there is no cycle with the presentation components.
+
+## Duplication removed
+
+Two clinic navigation surfaces previously copied the same two concerns:
+
+- **`DashboardModuleRail`** built `` `${ROUTES.dashboard}?module=${id}` `` in a
+  local `moduleHref` helper.
+- **`ClinicMobileBottomNav`** built the same `` `${ROUTES.dashboard}?module=${id}` ``
+  string inline **and** re-implemented module validation in a private
+  `parseClinicModuleFromLocation` (an ad-hoc `CLINIC_DESTINATIONS.some(...)` id
+  check) instead of using the shared `parseClinicModule`.
+
+After PR-PRES-4:
+
+- Both surfaces build the href through `buildDashboardModuleHref`, so the
+  `?module=` query key lives in exactly one place.
+- `ClinicMobileBottomNav` reads the active module through
+  `readClinicModuleFromLocation`, which delegates validation to the catalog
+  parser — the private id check is gone, so the rail and the bottom-nav can no
+  longer drift on which module ids are valid.
+
+Behavior is byte-identical: `buildDashboardModuleHref(ROUTES.dashboard, id)`
+returns the same href string, and `parseClinicModule` validates against the same
+canonical `CLINIC_MODULE_IDS` set the bottom-nav checked before.
+
+## What was deliberately left in the controllers
+
+`AdminDashboardWorkspaceController` and `ClinicDashboardWorkspaceController` keep
+their own navigation effects (URL sync, last-module restore, optimistic
+two-commit activation, hub-reset handling). They were **not** folded into a
+shared hook because:
+
+1. **Source-invariant guardrails pin them verbatim.** Backend guardrail tests
+   assert exact substrings such as
+   `setActiveModule(parseAdminModule(searchParams.get("module")));`,
+   `parseClinicModule(searchParams.get("module")) ?? DEFAULT_CLINIC_MODULE`,
+   `router.replace(\`/dashboard/admin?module=${lastModule}\`)` and
+   `router.replace(\`${ROUTES.dashboard}?module=${lastModule}\`)`, and require
+   the restore path to stay `replace`-only (no `router.push`). These are an
+   intentional anti-drift contract; relocating those lines behind a helper would
+   break the contract without a behavior change.
+2. **The two controllers diverge structurally.** Admin has a module hub, an
+   alias-aware parse, an access-error store and a two-commit activation buffer;
+   clinic has no hub and resolves a mandatory operational default. A shared hook
+   would have to re-introduce both shapes behind flags — more coupling, not less.
+
+Because the safe, genuinely-shared surface is the clinic rail + bottom-nav pair,
+the extraction targets exactly those, and the controllers are untouched. This is
+the "leave a too-different controller intact and document why" outcome the PR
+brief calls for.
+
+## Out of scope (unchanged)
+
+Public routes, `ROUTES`, CSS/globals, permissions/auth, the config catalog and
+its aliases, the Playwright visual-contract thresholds, visible module labels
+and their order, the admin controller, the admin sidebar/horizontal-nav and
+`DashboardHorizontalNav` (which keeps its own guardrail-pinned `?module=`
+literals), and `page.tsx` files.
+
+## Validation
+
+- `pnpm test` (repo root) — backend + source-invariant guardrails.
+- `pnpm build` (repo root).
+- `pnpm typecheck`, `pnpm build`, `pnpm e2e:visual-contract` (frontend).

--- a/frontend/src/components/dashboard/ClinicMobileBottomNav.tsx
+++ b/frontend/src/components/dashboard/ClinicMobileBottomNav.tsx
@@ -24,6 +24,10 @@ import {
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 import { CLINIC_MODULE_NAV_LABELS } from "@/features/dashboard/config";
+import {
+  buildDashboardModuleHref,
+  readClinicModuleFromLocation,
+} from "@/features/dashboard/application";
 import type { ClinicModule } from "./ClinicDashboardWorkspaceController";
 
 // Icons are React components, so they stay local; the id/label/shortLabel/order
@@ -49,21 +53,13 @@ const CLINIC_DESTINATIONS: Array<{
   icon: CLINIC_BOTTOM_NAV_ICONS[item.moduleId],
 }));
 
-function parseClinicModuleFromLocation(): ClinicModule | null {
-  if (typeof window === "undefined") return null;
-  const value = new URLSearchParams(window.location.search).get("module");
-  return CLINIC_DESTINATIONS.some((item) => item.moduleId === value)
-    ? (value as ClinicModule)
-    : null;
-}
-
 export function ClinicMobileBottomNav() {
   const pathname = usePathname() ?? "";
   const [activeModule, setActiveModule] = useState<ClinicModule | null>(null);
 
   useEffect(() => {
     function syncModuleFromLocation() {
-      setActiveModule(parseClinicModuleFromLocation());
+      setActiveModule(readClinicModuleFromLocation());
     }
 
     syncModuleFromLocation();
@@ -133,7 +129,7 @@ export function ClinicMobileBottomNav() {
         return (
           <PublicRouteControl
             key={destination.moduleId}
-            href={`${ROUTES.dashboard}?module=${destination.moduleId}`}
+            href={buildDashboardModuleHref(ROUTES.dashboard, destination.moduleId)}
             prefetch={false}
             variant="bare"
             aria-label={destination.label}

--- a/frontend/src/components/dashboard/DashboardModuleRail.tsx
+++ b/frontend/src/components/dashboard/DashboardModuleRail.tsx
@@ -15,6 +15,7 @@ import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";
 import { ROUTES } from "@/lib/routes";
 import { cn } from "@/lib/utils";
 import { CLINIC_MODULE_NAV_LABELS } from "@/features/dashboard/config";
+import { buildDashboardModuleHref } from "@/features/dashboard/application";
 import type { ClinicModule } from "./ClinicDashboardWorkspaceController";
 
 /**
@@ -66,7 +67,7 @@ export const CLINIC_MODULE_RAIL_ITEMS: ClinicModuleRailItem[] =
   }));
 
 function moduleHref(moduleId: ClinicModule): string {
-  return `${ROUTES.dashboard}?module=${moduleId}`;
+  return buildDashboardModuleHref(ROUTES.dashboard, moduleId);
 }
 
 const pagerStepClassName =

--- a/frontend/src/features/dashboard/application/dashboardModuleNavigation.ts
+++ b/frontend/src/features/dashboard/application/dashboardModuleNavigation.ts
@@ -1,0 +1,60 @@
+/**
+ * Dashboard · application · module navigation (PR-PRES-4).
+ *
+ * Small, framework-light helpers for the `?module=` navigation grammar shared
+ * by the clinic module surfaces. Before this, the query-key literal and the
+ * URL→module normalization were copied across the shared module rail
+ * (`DashboardModuleRail`) and the mobile bottom-nav (`ClinicMobileBottomNav`):
+ * each built its own `${ROUTES.dashboard}?module=${id}` href inline, and the
+ * bottom-nav re-implemented module validation with a private id check instead
+ * of the catalog's `parseClinicModule`.
+ *
+ * Those surfaces now build the href and read the active module from here, so
+ * the query-param key lives in one place and URL parsing always flows through
+ * the shared catalog parser — the rail and the bottom-nav can no longer drift
+ * on the `?module=` contract.
+ *
+ * Boundary rule (application layer): no JSX — this coordinates URL/state shape,
+ * it does not render UI. It stays route-agnostic (callers pass the base path)
+ * and SSR-safe (`window` is guarded).
+ *
+ * Scope note: the admin/clinic *controllers* keep their own URL-sync,
+ * last-module restore and optimistic two-commit navigation effects. Those are
+ * pinned verbatim by source-invariant guardrail tests (an intentional
+ * anti-drift contract) and diverge structurally between roles (hub vs. no-hub,
+ * alias parse, activation buffer), so folding them into a shared hook would
+ * either break those contracts or change behavior. Only the safe, common pieces
+ * shared by the two clinic nav components live here.
+ *
+ * @see docs/implementation/dashboard-module-navigation-controller.md
+ * @see docs/implementation/dashboard-presentation-boundaries.md
+ */
+import { parseClinicModule, type ClinicModule } from "../config";
+
+/** Query-string key that selects the active dashboard module (`?module=`). */
+export const MODULE_QUERY_PARAM = "module";
+
+/**
+ * Build a `?module=` href for a dashboard module on a given base route. Pure and
+ * route-agnostic: callers pass the base path (e.g. `ROUTES.dashboard`). Produces
+ * the exact same string the clinic rail and bottom-nav built inline before.
+ */
+export function buildDashboardModuleHref(
+  basePath: string,
+  moduleId: string,
+): string {
+  return `${basePath}?${MODULE_QUERY_PARAM}=${moduleId}`;
+}
+
+/**
+ * Read and normalize the active clinic module from the live browser URL.
+ * Returns `null` on the server (no `window`) or for an absent/unknown value,
+ * delegating validation to the catalog's {@link parseClinicModule} instead of a
+ * re-declared id check. Client-only by contract (popstate/location reads).
+ */
+export function readClinicModuleFromLocation(): ClinicModule | null {
+  if (typeof window === "undefined") return null;
+  return parseClinicModule(
+    new URLSearchParams(window.location.search).get(MODULE_QUERY_PARAM),
+  );
+}

--- a/frontend/src/features/dashboard/application/index.ts
+++ b/frontend/src/features/dashboard/application/index.ts
@@ -1,16 +1,18 @@
 /**
- * Dashboard · application layer (boundary placeholder).
+ * Dashboard · application layer.
  *
- * Intended home for orchestration that is not presentation: the optimistic
- * module-navigation hook (URL sync, last-module, one-shot intent, two-commit
- * buffer), the module activation bus, the access-error store, server
- * auth/redirect helpers, and data-load wrappers (audit H2/H5/H6).
+ * Home for orchestration that is not presentation. PR-PRES-4 lands the first
+ * real exports: the shared `?module=` navigation helpers (href construction and
+ * URL→module normalization) reused by the clinic module rail and mobile
+ * bottom-nav. Still to follow (audit H2/H5/H6): the optimistic module-navigation
+ * hook (URL sync, last-module, one-shot intent, two-commit buffer), the module
+ * activation bus, the access-error store, server auth/redirect helpers, and
+ * data-load wrappers.
  *
  * Boundary rule: no JSX rendering — application coordinates state and data;
  * it does not render UI.
  *
- * Empty on purpose: PR-PRES-2 only draws the architecture boundary; real
- * exports land in a later PRES PR (see
- * docs/implementation/dashboard-presentation-boundaries.md).
+ * @see docs/implementation/dashboard-module-navigation-controller.md
+ * @see docs/implementation/dashboard-presentation-boundaries.md
  */
-export {};
+export * from "./dashboardModuleNavigation";


### PR DESCRIPTION
PR-PRES-4. Extracts shared dashboard module navigation helpers for href construction and URL module parsing, reducing duplication between clinic rail and mobile bottom navigation. No visual redesign, CSS, routes, backend, API, auth, DB, Supabase, dependency, lockfile, CI, stash, or .claude/worktrees changes.