### PR TITLE
refactor(dashboard): introduce surface status badge primitive

### DIFF
--- a/docs/implementation/dashboard-surface-primitives.md
+++ b/docs/implementation/dashboard-surface-primitives.md
@@ -1,0 +1,101 @@
+# Dashboard Surface Primitives (PR-PRES-5)
+
+> **Tipo:** extracción de presentación *behavior-preserving*. **No mueve la
+> implementación, no cambia DOM/className/`data-*`, no toca CSS, rutas,
+> navegación ni textos visibles.**
+> **Base:** `main` limpio · **HEAD:** `d2e7390` refactor(dashboard): extract module navigation helpers (#1294)
+> **Documento rector:** [`docs/audit/dashboard-presentation-primitives-architecture-audit.md`](../audit/dashboard-presentation-primitives-architecture-audit.md)
+> **Modelo / esfuerzo:** Claude Opus 4.8 · high.
+
+## 1. Objetivo
+
+Dar el primer contenido real a la capa `presentation/surfaces` del dashboard,
+abriendo la superficie de importación
+`@/features/dashboard/presentation/surfaces` con **una** primitive de estado ya
+limpia (`StatusBadge`), sin acumular más duplicación y **sin cambio de
+comportamiento**. Es el **PR-PRES-5** de la sección 10 del documento rector.
+
+## 2. Qué se hizo
+
+Se expone `StatusBadge` (audit §5.1 — "ya limpio, mover casi tal cual") a través
+del boundary `presentation/surfaces` mediante un **re-export puro**:
+
+```
+frontend/src/features/dashboard/presentation/surfaces/
+  DashboardStatusBadge.tsx   ← re-export de StatusBadge + StatusBadgeProps
+  index.ts                    ← export * from "./DashboardStatusBadge"
+```
+
+`DashboardStatusBadge.tsx` no reimplementa nada: reexporta
+`StatusBadge`/`StatusBadgeProps` desde `@/components/dashboard/StatusBadge`. El
+componente renderizado es **idéntico** (mismo JSX, mismas clases, mismo
+`data-status`).
+
+## 3. Por qué re-export y no mover el archivo
+
+La implementación de `StatusBadge` (y de las demás surfaces del scope: estados,
+`StatsCards`, `FilterBar/Drawer`, `Module{Tabs,Dialog}`) está **fijada por
+guardrails source-invariant** que hacen `readFileSync` de
+`frontend/src/components/dashboard/*.tsx` y afirman substrings exactos —
+`test/frontend-dashboard-private-shell-foundation.test.ts`,
+`test/frontend-dashboard-state-polish.test.ts`,
+`test/frontend-dashboard-tables-cards-consistency-polish.test.ts`, etc. Además,
+los consumidores tienen su string de import fijado
+(`import { StatusBadge } from "@/components/dashboard/StatusBadge";` en
+`frontend-dashboard-home` / `-informes` / `-logistics-hub` /
+`-clinic-command-center`).
+
+Mover el archivo obligaría a un shim + edición de múltiples guardrails y a mayor
+blast radius. El propio audit (§9) prescribe hacerlo **"primero como re-export
+puro"** para evitar un *big-bang*, y el JSDoc de PR-PRES-2 dejó lista la
+superficie para exactamente este `export * from`. Por eso este PR:
+
+- **no** migra ningún consumidor (los imports pinneados quedan intactos);
+- **no** edita ningún guardrail existente;
+- **no** mueve la implementación.
+
+El movimiento físico de la implementación a `surfaces/` (con actualización de los
+guardrails a la nueva ruta, preservando su significado) queda para un PR
+posterior si se decide adelgazar `components/dashboard`.
+
+## 4. Preservación de contrato
+
+- **DOM nesting:** sin cambios (mismo componente, mismo árbol).
+- **className:** sin cambios (`status-badge`, `status-badge-*`, tonos).
+- **`data-*`:** sin cambios (`data-status`).
+- **Variant names / props:** sin cambios (`StatusBadgeProps`, `size`, etc.).
+- **CSS / rutas / navegación / copy visible:** intactos.
+- **Boundary:** el módulo no importa `@/lib/api`.
+
+## 5. Archivos tocados
+
+```
+frontend/src/features/dashboard/presentation/surfaces/DashboardStatusBadge.tsx  (nuevo)
+frontend/src/features/dashboard/presentation/surfaces/index.ts                  (barrel → re-export)
+docs/implementation/dashboard-surface-primitives.md                             (este doc)
+test/frontend-dashboard-surface-primitives.test.ts                              (guardrail del contrato de re-export)
+```
+
+## 6. Validación
+
+```powershell
+cd C:\PORTAL-VETNEB
+pnpm test
+pnpm build
+
+cd C:\PORTAL-VETNEB\frontend
+pnpm typecheck
+pnpm build
+pnpm e2e:visual-contract
+```
+
+Superficie de cambios (solo archivos nuevos + barrel):
+
+```powershell
+git -C C:\PORTAL-VETNEB diff --check
+git -C C:\PORTAL-VETNEB status --short --untracked-files=all
+git -C C:\PORTAL-VETNEB diff -- frontend/next-env.d.ts   # sin cambios
+```
+
+Nota: si `pnpm build` (frontend) reescribe `frontend/next-env.d.ts`, se restaura
+a su contenido original — no forma parte de este cambio.

--- a/frontend/src/features/dashboard/presentation/surfaces/DashboardStatusBadge.tsx
+++ b/frontend/src/features/dashboard/presentation/surfaces/DashboardStatusBadge.tsx
@@ -1,0 +1,27 @@
+/**
+ * Dashboard · presentation/surfaces · StatusBadge entry (PR-PRES-5).
+ *
+ * First concrete surface primitive exposed through the presentation boundary.
+ * It re-exports the already-clean `StatusBadge` primitive verbatim — same
+ * component, same props, same rendered DOM/className/`data-*`. Nothing is moved
+ * or reimplemented: the implementation stays at
+ * `@/components/dashboard/StatusBadge` because its source is pinned by
+ * source-invariant guardrails (see
+ * `test/frontend-dashboard-private-shell-foundation.test.ts`). This module only
+ * makes the primitive reachable from
+ * `@/features/dashboard/presentation/surfaces` so later presentation code can
+ * import it through the declared boundary instead of reaching across trees.
+ *
+ * This is the sanctioned "re-export puro" first step (audit §9): no consumer is
+ * migrated yet, so no import contract changes and no behavior changes.
+ *
+ * Boundary rule: surfaces are pure presentation driven by props and must not
+ * import `@/lib/api`.
+ *
+ * @see docs/implementation/dashboard-surface-primitives.md
+ * @see docs/audit/dashboard-presentation-primitives-architecture-audit.md
+ */
+export {
+  StatusBadge,
+  type StatusBadgeProps,
+} from "@/components/dashboard/StatusBadge";

--- a/frontend/src/features/dashboard/presentation/surfaces/index.ts
+++ b/frontend/src/features/dashboard/presentation/surfaces/index.ts
@@ -9,7 +9,9 @@
  * Boundary rule: presentation does not import `@/lib/api` directly; surfaces
  * are pure presentation driven by props.
  *
- * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
- * docs/implementation/dashboard-presentation-boundaries.md).
+ * PR-PRES-5 lands the first real export: `StatusBadge`, exposed through the
+ * surfaces boundary as a pure re-export (implementation unchanged, still pinned
+ * at `@/components/dashboard/StatusBadge`). See
+ * docs/implementation/dashboard-surface-primitives.md.
  */
-export {};
+export * from "./DashboardStatusBadge";

--- a/test/frontend-dashboard-surface-primitives.test.ts
+++ b/test/frontend-dashboard-surface-primitives.test.ts
@@ -1,0 +1,57 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const SURFACE_BADGE_PATH =
+  "frontend/src/features/dashboard/presentation/surfaces/DashboardStatusBadge.tsx";
+const SURFACES_INDEX_PATH =
+  "frontend/src/features/dashboard/presentation/surfaces/index.ts";
+const STATUS_BADGE_PATH = "frontend/src/components/dashboard/StatusBadge.tsx";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("PR-PRES-5 surfaces boundary re-exports StatusBadge from the canonical primitive", () => {
+  const source = read(SURFACE_BADGE_PATH);
+
+  assert.ok(
+    source.includes(
+      'from "@/components/dashboard/StatusBadge"',
+    ),
+    "DashboardStatusBadge must re-export from the canonical StatusBadge primitive",
+  );
+  assert.ok(
+    source.includes("StatusBadge,"),
+    "surfaces entry must expose the StatusBadge component",
+  );
+  assert.ok(
+    source.includes("type StatusBadgeProps,"),
+    "surfaces entry must expose the StatusBadgeProps type",
+  );
+});
+
+test("PR-PRES-5 surfaces re-export does not reimplement the primitive or reach data layer", () => {
+  const source = read(SURFACE_BADGE_PATH);
+
+  // Pure re-export: no local component definition, no direct data-layer import.
+  assert.equal(source.includes("function StatusBadge("), false);
+  assert.equal(source.includes('from "@/lib/api"'), false);
+});
+
+test("PR-PRES-5 surfaces barrel wires the StatusBadge entry", () => {
+  const source = read(SURFACES_INDEX_PATH);
+
+  assert.ok(source.includes('export * from "./DashboardStatusBadge";'));
+});
+
+test("PR-PRES-5 canonical StatusBadge stays in place (re-export target preserved)", () => {
+  const source = read(STATUS_BADGE_PATH);
+
+  assert.ok(source.includes("export function StatusBadge("));
+  assert.ok(source.includes("export type StatusBadgeProps = {"));
+});


### PR DESCRIPTION
PR-PRES-5. Introduces a pure DashboardStatusBadge surface primitive and contract tests for dashboard presentation boundaries. No visual redesign, CSS, routes, backend, API, auth, DB, Supabase, dependency, lockfile, CI, stash, or .claude/worktrees changes.