### PR TITLE
docs(logistics): introduce domain shell

### DIFF
--- a/docs/implementation/logistics-domain-shell.md
+++ b/docs/implementation/logistics-domain-shell.md
@@ -1,0 +1,97 @@
+# Implementación — ARCH-4: Logistics read-only domain shell
+
+> **Tipo:** Nota de implementación **docs-only**. No implementa runtime, no mueve
+> código, no re-exporta, no toca rutas, DB, schema, CSS, tests de runtime,
+> `package.json`, lockfiles ni CI.
+> **Base:** `main` limpio · **HEAD:** `cacfe3f` docs(architecture): inventory shared lib boundaries (#1298).
+> **Rama:** `refactor/logistics-domain-shell`.
+> **Documentos rectores:** [ARCH-1](../audit/repository-domain-architecture-audit.md) · [ARCH-2](../architecture/backend-boundary-adr.md) · [ARCH-3](../architecture/shared-lib-boundary-inventory.md).
+> **Modelo / esfuerzo:** Claude Opus 4.8 · high.
+> **ID:** ARCH-4.
+
+## Objetivo del PR
+
+Introducir la **frontera de módulo** del contexto Logistics en
+`server/features/logistics/`, alineada con [ARCH-1](../audit/repository-domain-architecture-audit.md),
+[ARCH-2](../architecture/backend-boundary-adr.md) y
+[ARCH-3](../architecture/shared-lib-boundary-inventory.md), **sin migrar
+comportamiento**. Deja el terreno listo para los PRs de extracción (ARCH-5+) con el
+contrato de dependencia por capa documentado en el lugar donde vivirá cada capa.
+
+## Por qué es un read-only shell
+
+El ADR (ARCH-2) advierte que el mayor riesgo de esta secuencia es crear
+**abstracciones vacías**: carpetas, barrels o interfaces sin código real que las
+habite. Para evitarlo, este PR **prefiere README/docs antes que archivos TS
+vacíos**:
+
+- No crea `index.ts`, barrels ni re-exports (eso ya sería runtime/API interna).
+- No crea services, puertos ni interfaces vacías.
+- No mueve `server/lib/logistics/*` ni `server/db-logistics.ts`.
+- No toca `server/routes/logistics-*.fastify.ts` ni ningún import de runtime.
+
+Así la frontera queda **declarada y contractual** (prosa verificable en review),
+mientras el comportamiento observable permanece exactamente donde estaba. Cada capa
+materializará código sólo cuando haya algo real que mover (ARCH-5 en adelante).
+
+## Archivos creados
+
+Sólo archivos de documentación:
+
+- `server/features/logistics/README.md` — frontera del contexto: responsabilidad,
+  relación temporal con `server/lib/logistics`, reglas de dependencia, qué migrar
+  en ARCH-5, qué NO mover, testing matrix y links a ARCH-1/2/3.
+- `server/features/logistics/domain/README.md` — capa de reglas puras.
+- `server/features/logistics/application/README.md` — capa de orquestación.
+- `server/features/logistics/infrastructure/README.md` — implementación de puertos.
+- `server/features/logistics/routes/README.md` — adaptación HTTP.
+- `docs/implementation/logistics-domain-shell.md` — esta nota.
+
+## Comportamiento preservado
+
+Cero cambios de runtime. La fuente de verdad ejecutable de Logistics sigue intacta:
+
+- `server/lib/logistics/{metrics,route-planning,sla-breach,time-window}.ts` — sin cambios.
+- `server/lib/logistics-route-plans-cache.ts` — sin cambios.
+- `server/db-logistics.ts` — sin cambios.
+- `server/routes/logistics-{route-plans,field-visits,route-events,sla}.fastify.ts` — sin cambios.
+
+Ningún import de runtime se modifica. No hay cambios de rutas, DB, schema ni
+migraciones. Los paths y contratos públicos son idénticos.
+
+## Próximos PRs
+
+- **ARCH-5** — Extraer 1 helper de dominio puro (candidato: `sla-breach` o
+  `time-window`) a `server/features/logistics/domain/`, con su test,
+  comportamiento idéntico.
+- **ARCH-6** — Extraer 1 application service detrás de una ruta existente, dejando
+  el god-handler thin, detrás del contrato por-ruta.
+- **ARCH-7** — Auditoría de eventos (opcional), sólo si ARCH-5..6 revelan fan-out
+  real; si no, documentar "no eventos" y cerrar.
+
+## Guardrails
+
+- Docs-only: sin código de runtime, sin re-exports, sin CSS, sin tests de runtime,
+  sin deps, sin lockfiles, sin CI, sin stashes, sin `.claude`, sin worktrees.
+- No mover `server/lib/logistics/*` ni `server/db-logistics.ts` todavía.
+- No tocar `server/routes/logistics-*.fastify.ts` ni imports de runtime.
+- No crear `index.ts`, services, puertos ni interfaces vacías.
+- No event bus. No fragmentar `drizzle/schema.ts`. No tocar migraciones.
+- No auth/security. No API pública. No frontend.
+- 1 contexto por PR; los futuros moves van detrás de contratos con tests verdes y
+  guardrail de literal actualizado en el mismo PR.
+
+## Validación
+
+- Revisión de documentación (docs review).
+- `pnpm test`, `pnpm build` verdes (sin cambios de runtime que puedan romperlos).
+- `git diff --check`, `git status --short --untracked-files=all`, `git diff --stat`,
+  `git diff --name-only` confirman que el único cambio son los 6 archivos de docs
+  bajo `server/features/logistics/**` y `docs/implementation/`.
+
+## Documentos relacionados
+
+- [ARCH-1 — Repository Domain Architecture Audit](../audit/repository-domain-architecture-audit.md).
+- [ARCH-2 — Backend Domain Boundary ADR](../architecture/backend-boundary-adr.md).
+- [ARCH-3 — Shared / Lib Boundary Inventory](../architecture/shared-lib-boundary-inventory.md).
+- [`server/features/logistics/README.md`](../../server/features/logistics/README.md) — frontera del contexto.

--- a/server/features/logistics/README.md
+++ b/server/features/logistics/README.md
@@ -1,0 +1,119 @@
+# Logistics — domain shell (read-only)
+
+> **Tipo:** Frontera de módulo **docs-only**. No implementa, no mueve código, no
+> re-exporta, no toca rutas, CSS, tests de runtime, `package.json`, lockfiles, CI
+> ni schema. Sólo README bajo `server/features/logistics/`.
+> **Base:** `main` limpio · **HEAD:** `cacfe3f` docs(architecture): inventory shared lib boundaries (#1298).
+> **Rama:** `refactor/logistics-domain-shell`.
+> **Documentos rectores:** [ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md) · [ARCH-2](../../../docs/architecture/backend-boundary-adr.md) · [ARCH-3](../../../docs/architecture/shared-lib-boundary-inventory.md).
+> **Modelo / esfuerzo:** Claude Opus 4.8 · high.
+> **ID:** ARCH-4.
+
+Este directorio es un **shell de frontera** para el contexto Logistics. Declara
+las reglas de dependencia del ADR ([ARCH-2](../../../docs/architecture/backend-boundary-adr.md))
+en el lugar donde vivirán las capas, **sin migrar todavía ni una línea de código**.
+No hay `index.ts`, no hay barrels, no hay re-exports: sólo documentación de
+frontera. El comportamiento en tiempo de ejecución sigue viviendo, sin cambios, en
+`server/lib/logistics/`, `server/db-logistics.ts` y `server/routes/logistics-*.fastify.ts`.
+
+## 1. Responsabilidad del contexto Logistics
+
+Logistics es el contexto de **planificación y operación de rutas de recolección y
+entrega** del portal: planes de ruta, visitas de campo, eventos de ruta y control
+de SLA. Según [ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md)
+es el mini-dominio con **cohesión muy alta**, **acoplamiento bajo** y **riesgo
+bajo**, y por eso es el piloto de migración por dominios. Concentra además los
+god-handlers más grandes del backend (`logistics-route-plans.fastify.ts` ≈ 2.241
+LOC), donde extraer application/domain tiene el mayor retorno de mantenibilidad.
+
+Su superficie actual (por *naming*, no por carpeta) es:
+
+- **Dominio puro** — `server/lib/logistics/{metrics,route-planning,sla-breach,time-window}.ts`
+  (~1.5k LOC). Importan **sólo tipos** de `drizzle/schema.ts`; cero `fastify`,
+  cero `db`. Ya cumplen la regla "domain sin framework" del ADR.
+- **Persistencia + dominio mezclados** — `server/db-logistics.ts` (~1.322 LOC). Único
+  `db-*` que delega en helpers de dominio (`time-window`, `route-planning`);
+  candidato natural a repositorio del contexto.
+- **Infra de contexto** — `server/lib/logistics-route-plans-cache.ts`.
+- **Adaptadores HTTP** — `server/routes/logistics-{route-plans,field-visits,route-events,sla}.fastify.ts`.
+
+## 2. Relación temporal con `server/lib/logistics` actual
+
+Esta carpeta **convive** con la estructura actual; no la reemplaza en este PR. El
+código de runtime **no se ha movido**: `server/lib/logistics/*`, `server/db-logistics.ts`
+y `server/routes/logistics-*.fastify.ts` siguen siendo la única fuente de verdad
+ejecutable. `server/features/logistics/` es, por ahora, sólo el **destino
+documentado** de la migración incremental descrita en el ADR.
+
+Es un estado transitorio y deliberado: primero se fija la frontera y su contrato
+en prosa; recién después (ARCH-5+) se mueve código real, capa por capa, detrás de
+los contratos por-ruta existentes y sólo con tests verdes.
+
+## 3. Reglas de dependencia
+
+Dirección permitida: `routes/http → application → domain`. `application` habla con
+`infrastructure` **por puertos**; `infrastructure` implementa esos puertos. El
+*shared kernel* (`drizzle/schema.ts`, sólo tipos) puede ser importado por
+cualquier capa; nunca al revés. La dependencia **siempre apunta hacia adentro**.
+
+| Capa | Rol | Puede importar | No puede importar |
+| --- | --- | --- | --- |
+| **[domain](./domain/README.md)** | Reglas puras. | shared kernel (sólo tipos), utilidades puras del propio contexto | `fastify`, Drizzle runtime, `env`, `http`, auth middleware, React/Next, `db-*` |
+| **[application](./application/README.md)** | Orquesta casos de uso. | domain, puertos (interfaces), shared kernel | `fastify`, `db-*` concreto, Drizzle runtime, React/Next, `http` |
+| **[infrastructure](./infrastructure/README.md)** | Implementa puertos. | domain, shared kernel, Drizzle runtime, clientes externos | routes/http, application (no invierte la dirección) |
+| **[routes](./routes/README.md)** | Adapta HTTP. | application, domain (tipos), shared kernel, adaptadores http, middlewares | `db-*` directo, Drizzle runtime, reglas de negocio inline |
+
+Cada capa detalla su propio contrato en su README. Ninguna capa contiene código
+todavía; los READMEs describen dónde vivirá cada cosa cuando se migre.
+
+## 4. Qué se puede migrar en ARCH-5 (y siguientes)
+
+Migración incremental, **un paso por PR**, siempre detrás de contratos y con tests
+verdes:
+
+- **ARCH-5 — Extraer 1 helper de dominio puro.** Mover un helper puro (candidato:
+  `sla-breach.ts` o `time-window.ts`, los más chicos y sin dependencias) de
+  `server/lib/logistics/` a `server/features/logistics/domain/`, con su test,
+  comportamiento idéntico. Valida la regla "domain sin framework".
+- **ARCH-6 — Extraer 1 application service detrás de una ruta existente.** Sacar un
+  caso de uso de un god-handler (candidato: parte de `logistics-route-plans`) a
+  `server/features/logistics/application/`, detrás del contrato por-ruta existente;
+  el handler queda thin. Valida la regla "routes/http delega".
+- **ARCH-7 — Auditoría de eventos (opcional).** Sólo si ARCH-5..6 revelan fan-out
+  real. Si no, documentar "no eventos" y cerrar.
+
+Cada carpeta materializa código **sólo cuando hay algo real que la habite** — nunca
+carpetas/barrels vacíos por dogma.
+
+## 5. Qué NO se debe mover todavía
+
+- **No** mover `server/lib/logistics/*` a este directorio en este PR.
+- **No** mover `server/db-logistics.ts`.
+- **No** tocar `server/routes/logistics-*.fastify.ts`.
+- **No** crear `index.ts`, barrels, re-exports, services vacíos ni puertos/interfaces vacíos.
+- **No** introducir event bus.
+- **No** fragmentar `drizzle/schema.ts` ni tocar migraciones.
+- **No** cambiar auth/security/middlewares.
+- **No** cambiar la API pública (paths ni contratos).
+
+## 6. Testing matrix (para futuros PRs)
+
+| Check | Cuándo aplica |
+| --- | --- |
+| `pnpm test` | Siempre. |
+| `pnpm build` | Siempre. |
+| Backend route tests (contrato por-ruta) | Si el PR toca `server/routes/**` o mueve lógica detrás de una ruta. |
+| Test de dominio movido | ARCH-5+: el test del helper migra junto al helper y debe quedar verde. |
+| E2E (Playwright) | Sólo si el PR toca frontend (no aplica a este contexto backend). |
+| Guardrail de literal-de-fuente | Si el PR mueve un literal fijado por un test; se actualiza en el **mismo PR**. |
+| **No** lockfiles / deps / CI | Ningún PR de esta secuencia toca `package.json`, lockfiles ni workflows. |
+
+Los contratos por-ruta existentes (audit, session-last-access, runtime-timing) son
+la red de seguridad que habilita reorganizar sin cambiar comportamiento.
+
+## 7. Documentos rectores
+
+- [ARCH-1 — Repository Domain Architecture Audit](../../../docs/audit/repository-domain-architecture-audit.md) — documento rector: clasifica Logistics como piloto.
+- [ARCH-2 — Backend Domain Boundary ADR](../../../docs/architecture/backend-boundary-adr.md) — reglas de dependencia por capa y secuencia de migración.
+- [ARCH-3 — Shared / Lib Boundary Inventory](../../../docs/architecture/shared-lib-boundary-inventory.md) — inventario a nivel de archivo del terreno a migrar.
+- [Nota de implementación — ARCH-4 shell](../../../docs/implementation/logistics-domain-shell.md) — objetivo, alcance y guardrails de este PR.

--- a/server/features/logistics/application/README.md
+++ b/server/features/logistics/application/README.md
@@ -1,0 +1,33 @@
+# Logistics · application (orquestación)
+
+> Capa **application** del contexto Logistics. Docs-only: hoy no contiene código.
+> Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
+> [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
+
+## Responsabilidad
+
+Orquesta **casos de uso** de logística: coordina reglas de `domain` con datos
+provistos por `infrastructure`, aplicando la secuencia de un flujo (validar →
+resolver → persistir → responder) sin conocer detalles de HTTP ni de persistencia
+concreta.
+
+## Regla de dependencia
+
+- **Puede importar:** `domain`, **puertos** (interfaces) y el shared kernel.
+- **No puede importar:** `fastify`, un `db-*` concreto, el runtime de Drizzle,
+  React/Next ni `http`.
+- Habla con el exterior a través de **puertos**, no de implementaciones concretas.
+  `infrastructure` implementa esos puertos; `application` no los implementa.
+
+## Qué vivirá aquí (futuro, no ahora)
+
+En **ARCH-6** se extraerá **un** caso de uso desde un god-handler existente
+(candidato: parte de `logistics-route-plans.fastify.ts`) a un service aquí, detrás
+del contrato por-ruta existente, dejando el handler thin. El puerto de repositorio
+se introduce **junto con** su primer consumidor y su implementación real — nunca
+como interfaz vacía anticipada.
+
+## Qué NO hacer
+
+No crear services vacíos ni puertos/interfaces sin implementación. No introducir
+event bus. No mover lógica antes de tener el contrato por-ruta verde.

--- a/server/features/logistics/domain/README.md
+++ b/server/features/logistics/domain/README.md
@@ -1,0 +1,33 @@
+# Logistics · domain (reglas puras)
+
+> Capa **domain** del contexto Logistics. Docs-only: hoy no contiene código.
+> Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
+> [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
+
+## Responsabilidad
+
+Reglas de negocio **puras** de logística: cálculo de ventanas de tiempo,
+planificación de rutas, detección de breach de SLA y métricas. Sin efectos
+secundarios, sin I/O, sin framework. Determinista y testeable en aislamiento.
+
+## Regla de dependencia
+
+- **Puede importar:** el shared kernel (`drizzle/schema.ts`) **sólo como tipos**, y
+  otras utilidades puras del propio contexto.
+- **No puede importar:** `fastify`, el runtime de Drizzle, `env`, `http`, middleware
+  de auth, React/Next ni ningún `db-*`.
+- La dependencia apunta hacia adentro: `domain` no conoce el transporte HTTP ni el
+  motor de persistencia. `infrastructure` depende de `domain`, nunca al revés.
+
+## Qué vivirá aquí (futuro, no ahora)
+
+Los helpers puros que hoy están en `server/lib/logistics/`
+(`metrics`, `route-planning`, `sla-breach`, `time-window`) ya cumplen esta regla
+(importan sólo tipos de schema). En **ARCH-5** se migrará **uno** de ellos aquí,
+con su test, comportamiento idéntico. No se crea ningún archivo hasta que haya
+código real que mover.
+
+## Qué NO hacer
+
+No mover `server/lib/logistics/*` en el PR del shell. No crear stubs, interfaces ni
+barrels vacíos.

--- a/server/features/logistics/infrastructure/README.md
+++ b/server/features/logistics/infrastructure/README.md
@@ -1,0 +1,31 @@
+# Logistics · infrastructure (implementación de puertos)
+
+> Capa **infrastructure** del contexto Logistics. Docs-only: hoy no contiene código.
+> Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
+> [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
+
+## Responsabilidad
+
+Implementa los **puertos** que define `application`: repositorios sobre Drizzle,
+cache de planes de ruta, clientes externos. Es el único lugar que conoce el motor
+de persistencia y el I/O real del contexto.
+
+## Regla de dependencia
+
+- **Puede importar:** `domain` (para implementar sus puertos), el shared kernel, el
+  runtime de Drizzle y clientes externos.
+- **No puede importar:** `routes/http` ni `application` (no invierte la dirección de
+  la dependencia).
+
+## Qué vivirá aquí (futuro, no ahora)
+
+El candidato natural a repositorio del contexto es `server/db-logistics.ts` (~1.322
+LOC), único `db-*` que ya delega en helpers de dominio (`time-window`,
+`route-planning`); y la cache `server/lib/logistics-route-plans-cache.ts`. Su
+migración es **posterior** a la extracción de un puerto en `application` que les dé
+forma. **No se mueve `db-logistics.ts` en el PR del shell** ni en ARCH-5.
+
+## Qué NO hacer
+
+No mover `server/db-logistics.ts` ni la cache todavía. No crear adaptadores vacíos.
+No tocar `drizzle/schema.ts` ni migraciones.

--- a/server/features/logistics/routes/README.md
+++ b/server/features/logistics/routes/README.md
@@ -1,0 +1,31 @@
+# Logistics · routes (adaptación HTTP)
+
+> Capa **routes/http** del contexto Logistics. Docs-only: hoy no contiene código.
+> Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
+> [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
+
+## Responsabilidad
+
+Adapta **request/response** HTTP: parseo de entrada, autorización y delegación al
+service de `application`. Thin handlers, sin reglas de negocio inline.
+
+## Regla de dependencia
+
+- **Puede importar:** `application`, `domain` (sólo tipos), el shared kernel, los
+  adaptadores http (`lib/http`) y los middlewares.
+- **No puede importar:** un `db-*` directo, el runtime de Drizzle, ni contener
+  reglas de negocio inline.
+
+## Qué vivirá aquí (futuro, no ahora)
+
+Los handlers actuales viven en `server/routes/logistics-{route-plans,field-visits,route-events,sla}.fastify.ts`
+y son god-handlers (`logistics-route-plans` ≈ 2.241 LOC). En **ARCH-6** se
+adelgazan extrayendo un caso de uso a `application`, **detrás del contrato por-ruta
+existente** y sin cambiar paths ni contratos públicos. La ruta permanece registrada
+donde está hoy hasta que su lógica esté migrada.
+
+## Qué NO hacer
+
+No tocar `server/routes/logistics-*.fastify.ts` en el PR del shell. No cambiar
+paths, contratos ni registro de rutas. No mover reglas de negocio antes de tener el
+service y el contrato verde.


### PR DESCRIPTION
ARCH-4. Adds a read-only Logistics domain shell with README boundary documentation for domain, application, infrastructure, and routes. No runtime code, route changes, DB/schema changes, API changes, frontend, CSS, dependencies, lockfiles, CI, stashes, .claude, or worktrees.

Local validation:
- pnpm build: OK
- git diff --check: OK
- pnpm test: blocked by historical dashboard scope guards that reject any server/features/logistics README path in the current diff. This PR is docs/README-only and intentionally creates the Logistics domain shell declared by ARCH-1/2/3.