### PR TITLE
test(dashboard): scope legacy guards to dashboard diffs

### DIFF
--- a/docs/implementation/test-dashboard-scope-guards.md
+++ b/docs/implementation/test-dashboard-scope-guards.md
@@ -1,0 +1,65 @@
+# TEST-ARCH-1 — PR-specific dashboard scope guards
+
+## Problem
+
+Eight legacy dashboard test suites ship a "scope guard" that reads the current
+working-tree diff (`git diff --name-only`) and forbids the change from reaching
+backend / auth / middleware / dependency surfaces:
+
+- `frontend-dashboard-accessibility-focus-aria.test.ts` (PR-8)
+- `frontend-dashboard-action-feedback-focus-polish.test.ts` (PR-4)
+- `frontend-dashboard-admin-section-tabs.test.ts` (PR-7)
+- `frontend-dashboard-filter-drawer-sticky-filters.test.ts` (PR-6)
+- `frontend-dashboard-interaction-foundation.test.ts` (PR-1)
+- `frontend-dashboard-logistics-hub.test.ts` (logistics hub)
+- `frontend-dashboard-mobile-polish-bottom-actions.test.ts` (PR-9)
+- `frontend-dashboard-workspace-layout-polish.test.ts` (PR-2)
+
+These guards ran against the full diff unconditionally. An unrelated
+architectural change — e.g. ARCH-4's docs-only domain shell under
+`server/features/logistics/**` — matched the `server/` blocked prefix and tripped
+every guard, even though the diff never touched the dashboard.
+
+## Fix
+
+The guards are PR-specific by intent. They only mean something when the diff
+actually contains a dashboard-scoped file. A shared helper
+`test/helpers/dashboard-scope-guard.ts` exposes:
+
+```ts
+dashboardScopeGuardApplies(changedFiles: readonly string[]): boolean
+```
+
+which returns `true` only when at least one changed file starts with a dashboard
+scope prefix:
+
+- `frontend/src/app/dashboard`
+- `frontend/src/components/dashboard`
+- `frontend/src/features/dashboard`
+- `frontend/src/styles/dashboard`
+- `frontend/e2e/dashboard`
+- `test/frontend-dashboard`
+
+Each guard now returns early (not-applicable, passes) when
+`dashboardScopeGuardApplies(changedFiles)` is `false`.
+
+## Non-applicability logic (exact)
+
+- Diff touches **no** dashboard-scoped file (e.g. only
+  `server/features/logistics/README.md` or `docs/**`) → guard **does not apply**,
+  test passes without inspecting unrelated paths.
+- Diff touches **at least one** dashboard-scoped file → guard **applies in full**,
+  keeping every existing blocked prefix / blocked exact file / forbidden path.
+
+## What this does NOT do
+
+- It does **not** add a global allowlist for `server/features/logistics/**` (or any
+  backend path) on dashboard PRs.
+- It does **not** relax any prohibition when the diff touches the dashboard: a
+  dashboard PR still cannot touch backend, auth, middleware, routes or dependency
+  manifests.
+- It only removes false positives on non-dashboard PRs.
+
+The logistics-hub backend guard is triggered only by frontend
+dashboard/logistics-hub files (`frontend/src/app/dashboard/logistica/**`), not by
+the backend logistics feature shell under `server/features/logistics/**`.

--- a/test/frontend-dashboard-accessibility-focus-aria.test.ts
+++ b/test/frontend-dashboard-accessibility-focus-aria.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import { isClean7aAllowedDependencyChange } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 
 const ADMIN_SECTION_TABS_PATH =
   "frontend/src/app/dashboard/admin/AdminSectionTabs.tsx";
@@ -153,6 +154,8 @@ test("PR-8 dashboard accessibility scope avoids forbidden files", () => {
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
   const blockedPrefixes = [
     "server/",
     "drizzle/",

--- a/test/frontend-dashboard-action-feedback-focus-polish.test.ts
+++ b/test/frontend-dashboard-action-feedback-focus-polish.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import { isClean7aAllowedDependencyChange } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 import { readDashboardCssSource } from "./helpers/read-dashboard-css-source.ts";
 
 const BUTTON_PATH = "frontend/src/components/ui/button.tsx";
@@ -216,6 +217,9 @@ test("PR-4 action feedback polish stays within allowed file scope", () => {
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
+
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
 
   const blockedPrefixes = [
     "server/",

--- a/test/frontend-dashboard-admin-section-tabs.test.ts
+++ b/test/frontend-dashboard-admin-section-tabs.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import { isClean7aAllowedDependencyChange } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
 const ADMIN_SECTION_TABS_PATH =
@@ -157,6 +158,8 @@ test("dashboard admin tabs stay inside frontend-only PR-7 scope", () => {
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
   const forbiddenChangedPaths = [
     "package.json",
     "pnpm-lock.yaml",

--- a/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
+++ b/test/frontend-dashboard-filter-drawer-sticky-filters.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import { isClean7aAllowedDependencyChange } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 
 const FILTER_DRAWER_PATH = "frontend/src/components/dashboard/FilterDrawer.tsx";
 const STICKY_FILTER_BAR_PATH =
@@ -191,6 +192,8 @@ test("PR-6 scope leaves backend auth API middleware SEO and dependencies untouch
   })
     .split(/\r?\n/)
     .filter(Boolean);
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
   const blockedPrefixes = [
     "server/",
     "drizzle/",

--- a/test/frontend-dashboard-interaction-foundation.test.ts
+++ b/test/frontend-dashboard-interaction-foundation.test.ts
@@ -9,6 +9,7 @@ import {
   isClean7aAllowedDependencyFile,
 } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 import { readDashboardCssSource } from "./helpers/read-dashboard-css-source.ts";
 
 const DASHBOARD_MODULE_HUB_PATH =
@@ -315,6 +316,9 @@ test("PR-1 interaction foundation stays within allowed file scope", () => {
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
+
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
 
   const blockedPrefixes = [
     "server/",

--- a/test/frontend-dashboard-logistics-hub.test.ts
+++ b/test/frontend-dashboard-logistics-hub.test.ts
@@ -8,6 +8,7 @@ import {
   isClean7aAllowedDependencyFile,
 } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 
 const LOGISTICS_PAGE_PATH = "frontend/src/app/dashboard/logistica/page.tsx";
 const COMMAND_CENTER_PATH =
@@ -312,6 +313,13 @@ test("logistics hub changes do not touch backend, API routes, auth, middleware o
     ["diff", "--name-only"],
     { encoding: "utf8" },
   ).trim();
+
+  // PR-specific guard: only enforce when the diff touches dashboard scope. A
+  // backend logistics feature shell (server/features/logistics/**) is not a
+  // frontend dashboard/logistics-hub change, so this guard is not-applicable.
+  if (!dashboardScopeGuardApplies(changedFiles.split(/\r?\n/).filter(Boolean))) {
+    return;
+  }
 
   const forbiddenPaths = [
     "server/",

--- a/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
+++ b/test/frontend-dashboard-mobile-polish-bottom-actions.test.ts
@@ -5,6 +5,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 import { isClean7aAllowedDependencyChange } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 
 const DASHBOARD_HOME_PATH = "frontend/src/app/dashboard/page.tsx";
 const ADMIN_PAGE_PATH = "frontend/src/app/dashboard/admin/page.tsx";
@@ -156,6 +157,8 @@ test("PR-9 mobile polish scope avoids forbidden surfaces and dependencies", () =
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
   const blockedPrefixes = [
     "server/",
     "drizzle/",

--- a/test/frontend-dashboard-workspace-layout-polish.test.ts
+++ b/test/frontend-dashboard-workspace-layout-polish.test.ts
@@ -9,6 +9,7 @@ import {
   isClean7aAllowedDependencyFile,
 } from "./helpers/clean7a-dependency-cleanup-scope.ts";
 import { isReportForeignAccessBackendFile } from "./helpers/report-foreign-access-scope.ts";
+import { dashboardScopeGuardApplies } from "./helpers/dashboard-scope-guard.ts";
 import { readDashboardCssSource } from "./helpers/read-dashboard-css-source.ts";
 
 const WORKSPACE_PATH =
@@ -395,6 +396,9 @@ test("PR-2 workspace layout polish stays within allowed file scope", () => {
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
+
+  // PR-specific guard: only enforce when the diff touches dashboard scope.
+  if (!dashboardScopeGuardApplies(changedFiles)) return;
 
   const blockedPrefixes = [
     "server/",

--- a/test/helpers/dashboard-scope-guard.ts
+++ b/test/helpers/dashboard-scope-guard.ts
@@ -1,0 +1,48 @@
+// Applicability gate for the legacy per-PR dashboard scope guards.
+//
+// Several historical dashboard PRs (PR-1/PR-2/PR-4/PR-6/PR-7/PR-8/PR-9 and the
+// logistics hub) shipped a scope guard that inspects the current working-tree
+// diff and forbids reaching into backend / auth / middleware / dependency
+// surfaces. Those guards ran against the full diff unconditionally, so an
+// unrelated architectural change — e.g. a docs-only domain shell under
+// server/features/logistics/** — tripped every one of them even though it never
+// touched the dashboard.
+//
+// The guards are PR-specific by intent: they only mean something when the diff
+// actually contains dashboard-scoped files. When the changed set has no
+// dashboard file the guard is not-applicable and must pass as a no-op instead
+// of policing unrelated paths.
+//
+// This does NOT relax the guards for real dashboard PRs. Whenever a
+// dashboard-scoped file is present in the diff the guard applies in full, so a
+// dashboard PR still cannot touch backend, auth, middleware, routes or
+// dependency manifests. The gate only removes false positives on
+// non-dashboard PRs.
+
+// A changed file belongs to the dashboard scope when it lives under one of the
+// dashboard source/asset/e2e trees or is one of the dashboard test suites.
+const DASHBOARD_SCOPE_PREFIXES = [
+  "frontend/src/app/dashboard",
+  "frontend/src/components/dashboard",
+  "frontend/src/features/dashboard",
+  "frontend/src/styles/dashboard",
+  "frontend/e2e/dashboard",
+  "test/frontend-dashboard",
+] as const;
+
+export function isDashboardScopedFile(file: string): boolean {
+  const normalized = file.trim();
+  return DASHBOARD_SCOPE_PREFIXES.some((prefix) => normalized.startsWith(prefix));
+}
+
+/**
+ * A legacy dashboard scope guard only applies when the current diff touches at
+ * least one dashboard-scoped file. Returns `false` for diffs that leave the
+ * dashboard untouched (e.g. a server/features/logistics/** docs-only PR), in
+ * which case the caller should treat the guard as not-applicable and pass.
+ */
+export function dashboardScopeGuardApplies(
+  changedFiles: readonly string[],
+): boolean {
+  return changedFiles.some((file) => isDashboardScopedFile(file));
+}


### PR DESCRIPTION
TEST-ARCH-1. Updates legacy dashboard scope guard tests so they only apply when the current diff touches dashboard-specific paths. This preserves the original dashboard guardrails for dashboard PRs while avoiding false positives for unrelated architecture/backend docs or feature-shell work. Adds a shared test helper and implementation note. No production code, CSS, backend runtime, frontend runtime, routes, DB/schema, dependencies, lockfiles, CI, stashes, .claude, or worktrees.