### PR TITLE
refactor(logistics): extract field visit id normalization

### DIFF
--- a/docs/implementation/arch-5-logistics-domain-helper.md
+++ b/docs/implementation/arch-5-logistics-domain-helper.md
@@ -1,0 +1,117 @@
+# ARCH-5 · Extracción de 1 helper de dominio puro en Logistics
+
+## Objetivo
+
+Extraer **exactamente un** helper de dominio puro del contexto Logistics hacia
+`server/features/logistics/domain`, con un PR chico y sin cambiar runtime,
+comportamiento observable, API, DB, schema ni contratos. Primer archivo de código
+real de la capa `domain` del contexto Logistics (hasta ahora era docs-only).
+
+## Helper extraído
+
+`normalizeGenerateHeuristicFieldVisitIds(ids: number[]): number[]`
+
+Regla de dominio de **planificación de rutas**: normaliza la lista de ids de
+visitas de campo con la que se genera un plan heurístico. Descarta valores que no
+sean enteros positivos y elimina duplicados, preservando el orden de primera
+aparición.
+
+Cumple los criterios de helper puro:
+
+- Determinístico (misma entrada → misma salida).
+- Sin I/O, sin DB, sin fetch, sin Fastify request/reply, sin cookies, sin env,
+  sin logging, sin side effects.
+- No usa `Date.now` ni ningún reloj; no muta la entrada.
+- Testeable input/output en aislamiento.
+- Cero dependencias externas (ni siquiera tipos de schema).
+
+## Ubicación nueva
+
+`server/features/logistics/domain/route-plan-field-visits.ts`
+
+Respeta la regla de dependencia de la capa `domain`
+(`server/features/logistics/domain/README.md`): no importa `fastify`, ni el
+runtime de Drizzle, ni `env`, ni ningún `db-*`. La dependencia apunta hacia
+adentro: la capa de persistencia (`server/db-logistics.ts`) importa el helper de
+`domain`, nunca al revés.
+
+## Origen
+
+La función existía **de forma implícita** como función privada pura dentro de la
+capa de persistencia `server/db-logistics.ts` (antes en las líneas 851-865),
+invocada por `generateHeuristicRoutePlan`. Era lógica de dominio pura viviendo en
+el archivo de persistencia; ARCH-5 la reubica en su capa correcta.
+
+## Archivos modificados
+
+| Archivo | Cambio |
+| --- | --- |
+| `server/features/logistics/domain/route-plan-field-visits.ts` | **Nuevo.** Helper puro `normalizeGenerateHeuristicFieldVisitIds`. |
+| `server/db-logistics.ts` | Se elimina la definición local de la función y se añade `import { normalizeGenerateHeuristicFieldVisitIds } from "./features/logistics/domain/route-plan-field-visits.ts";`. El call-site queda idéntico. |
+| `test/logistics-heuristic-field-visit-ids.test.ts` | **Nuevo.** Tests unitarios del helper de dominio. |
+
+## Comportamiento preservado
+
+- El nombre de la función y el call-site en `generateHeuristicRoutePlan` no
+  cambian: `normalizeGenerateHeuristicFieldVisitIds(input.fieldVisitIds)`.
+- La implementación se movió **verbatim** (misma firma, misma lógica de filtrado y
+  deduplicación, mismo orden de resultados).
+- No cambian endpoints, payloads, status codes, permisos, queries SQL, schema ni
+  contratos.
+- El guardrail `test/logistics-db.test.ts` (que exige que el source de
+  `db-logistics.ts` contenga el identificador `normalizeGenerateHeuristicFieldVisitIds`)
+  sigue satisfecho: el identificador permanece en el `import` y en el call-site.
+- El guardrail de scope dashboard (`dashboardScopeGuardApplies`) no aplica: el
+  diff no toca ningún archivo de scope dashboard.
+
+## Tests
+
+`test/logistics-heuristic-field-visit-ids.test.ts` (5 casos):
+
+1. Mantiene enteros positivos únicos en orden de primera aparición.
+2. Elimina duplicados preservando la primera ocurrencia.
+3. Descarta ids no positivos y no enteros (`0`, negativos, decimales, `NaN`).
+4. Devuelve lista vacía para entrada vacía.
+5. No muta el array de entrada.
+
+## Comandos ejecutados
+
+```powershell
+git status --short --untracked-files=all
+git branch --show-current
+pnpm test
+pnpm build
+git diff --check
+```
+
+## Resultado `pnpm test`
+
+`tests 2970 · pass 2970 · fail 0` (base previa: 2965; +5 tests nuevos del helper).
+
+## Resultado `pnpm build`
+
+OK — `esbuild server/index.ts … dist/index.js 838.0kb`, `Done`. Sin errores.
+
+## `git diff --check`
+
+Exit 0 — sin errores de whitespace.
+
+## Riesgos residuales
+
+- Bajos. El cambio es una reubicación verbatim de una función pura privada; sin
+  superficie de comportamiento observable afectada.
+- El nombre exportado conserva el prefijo `Generate` (herencia del sitio de
+  persistencia) para mantener call-site y guardrail idénticos; refinar el nombre
+  quedaría para una iteración futura fuera de scope.
+
+## Confirmaciones de scope
+
+- **No deps / lockfiles / CI:** no se tocó `package.json`, `pnpm-lock.yaml` ni CI.
+- **No DB / schema / migrations:** sin cambios en `drizzle/**` ni SQL.
+- **No API / runtime behavior:** endpoints, payloads, status codes, permisos y
+  queries intactos; comportamiento observable idéntico.
+- **No auth:** sin cambios en sesiones, roles ni fronteras.
+- **No git add/commit/push, no PR, no merge, no stashes, no `.claude/worktrees`.**
+- **No uso material del ZIP de skills:** el ZIP/carpeta de skills se usó sólo como
+  modo de trabajo/observación; no fue copiado, descomprimido, editado, ejecutado
+  ni agregado al repositorio.

--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -32,6 +32,7 @@ import {
   type RoutePlanningPoint,
   type RoutePlanningVisit,
 } from "./lib/logistics/route-planning.ts";
+import { normalizeGenerateHeuristicFieldVisitIds } from "./features/logistics/domain/route-plan-field-visits.ts";
 
 export const LOGISTICS_DEFAULT_LIMIT = 50;
 export const LOGISTICS_MAX_LIMIT = 100;
@@ -847,22 +848,6 @@ export async function transitionClinicScopedRoutePlanStatus(
   });
 }
 
-
-function normalizeGenerateHeuristicFieldVisitIds(ids: number[]): number[] {
-  const result: number[] = [];
-  const seen = new Set<number>();
-
-  for (const id of ids) {
-    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) {
-      continue;
-    }
-
-    seen.add(id);
-    result.push(id);
-  }
-
-  return result;
-}
 
 function toRoutePlanningPoint(
   location: VisitLocation | null | undefined,

--- a/server/features/logistics/domain/route-plan-field-visits.ts
+++ b/server/features/logistics/domain/route-plan-field-visits.ts
@@ -1,0 +1,36 @@
+// Logistics · domain (reglas puras)
+//
+// Regla de dominio de planificación de rutas: normalizar la lista de visitas de
+// campo con la que se genera un plan heurístico. Determinística, sin I/O, sin
+// framework y sin persistencia — sólo transforma la entrada en la salida.
+//
+// Esta lógica vivía de forma implícita dentro de la capa de persistencia
+// (`server/db-logistics.ts`). ARCH-5 la extrae al contexto `logistics/domain`
+// manteniendo el comportamiento observable idéntico: `generateHeuristicRoutePlan`
+// la sigue invocando con el mismo nombre, ahora vía import interno.
+
+/**
+ * Normaliza los ids de visitas de campo para la planificación heurística de
+ * rutas: descarta valores que no sean enteros positivos y elimina duplicados,
+ * preservando el orden de primera aparición.
+ *
+ * @param ids Lista cruda de ids de visitas de campo.
+ * @returns Lista saneada de ids únicos, en orden de primera aparición.
+ */
+export function normalizeGenerateHeuristicFieldVisitIds(
+  ids: number[],
+): number[] {
+  const result: number[] = [];
+  const seen = new Set<number>();
+
+  for (const id of ids) {
+    if (!Number.isInteger(id) || id <= 0 || seen.has(id)) {
+      continue;
+    }
+
+    seen.add(id);
+    result.push(id);
+  }
+
+  return result;
+}

--- a/test/logistics-heuristic-field-visit-ids.test.ts
+++ b/test/logistics-heuristic-field-visit-ids.test.ts
@@ -1,0 +1,38 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import { normalizeGenerateHeuristicFieldVisitIds } from "../server/features/logistics/domain/route-plan-field-visits.ts";
+
+test("normalizeGenerateHeuristicFieldVisitIds keeps unique positive integers in first-seen order", () => {
+  assert.deepEqual(
+    normalizeGenerateHeuristicFieldVisitIds([30, 10, 20]),
+    [30, 10, 20],
+  );
+});
+
+test("normalizeGenerateHeuristicFieldVisitIds removes duplicates preserving the first occurrence", () => {
+  assert.deepEqual(
+    normalizeGenerateHeuristicFieldVisitIds([10, 20, 10, 30, 20]),
+    [10, 20, 30],
+  );
+});
+
+test("normalizeGenerateHeuristicFieldVisitIds discards non-positive and non-integer ids", () => {
+  assert.deepEqual(
+    normalizeGenerateHeuristicFieldVisitIds([0, -1, 5, 2.5, Number.NaN, 7]),
+    [5, 7],
+  );
+});
+
+test("normalizeGenerateHeuristicFieldVisitIds returns an empty list for empty input", () => {
+  assert.deepEqual(normalizeGenerateHeuristicFieldVisitIds([]), []);
+});
+
+test("normalizeGenerateHeuristicFieldVisitIds does not mutate the input array", () => {
+  const input = [10, 10, -3, 20];
+  const snapshot = [...input];
+
+  normalizeGenerateHeuristicFieldVisitIds(input);
+
+  assert.deepEqual(input, snapshot);
+});


### PR DESCRIPTION
## Summary
- Extracts one pure Logistics domain helper into server/features/logistics/domain.
- Moves field visit ID normalization for heuristic route generation into the Logistics domain layer.
- Preserves runtime behavior, API, DB, schema, auth and observable behavior.
- Adds focused unit coverage and ARCH-5 implementation documentation.

## Validation
- pnpm test: 2970/2970 OK
- pnpm build: OK
- git diff --check: OK

## Guardrails
- No deps
- No lockfiles
- No CI
- No DB/schema/migrations
- No auth
- No API changes
- No runtime behavior changes
- No stashes
- No .claude/worktrees
- Skills ZIP not copied, decompressed, edited, executed or added to repo