### PR TITLE
refactor(logistics): extract pagination domain helper

### DIFF
--- a/docs/implementation/arch-7-logistics-second-domain-helper.md
+++ b/docs/implementation/arch-7-logistics-second-domain-helper.md
@@ -1,0 +1,158 @@
+# ARCH-7 · Extracción del 2º helper de dominio puro en Logistics
+
+## Objetivo
+
+Extraer **exactamente un** helper de dominio puro adicional del contexto
+Logistics hacia `server/features/logistics/domain`, con un PR chico y sin
+cambiar runtime, comportamiento observable, API, DB, schema ni contratos.
+Continúa el trabajo de ARCH-5 (primer helper) y respeta el guardrail de pureza
+de ARCH-6.
+
+## Helper extraído
+
+`normalizeLogisticsLimit(value, defaultLimit?, maxLimit?): number` y
+`normalizeLogisticsOffset(value): number`, junto con las constantes
+`LOGISTICS_DEFAULT_LIMIT = 50` y `LOGISTICS_MAX_LIMIT = 100` de las que
+dependen sus valores por defecto.
+
+Regla de dominio de **paginación de listados de Logistics**: acota `limit` a un
+entero positivo dentro de `[1, maxLimit]` (usando el default si el valor es
+inválido) y acota `offset` a un entero `>= 0` (usando `0` si el valor es
+inválido). Se usan en los 6 listados paginados de Logistics: visitas de campo,
+eventos de ruta (lectura clinic-scoped e incremental), instancias de SLA
+(lectura general) e instancias de SLA vencidas (overdue).
+
+Cumple los criterios de helper puro:
+
+- Determinístico (misma entrada → misma salida).
+- Sin I/O, sin DB, sin fetch, sin Fastify request/reply, sin cookies, sin env,
+  sin logging, sin side effects.
+- No usa `Date.now` ni ningún reloj; no muta la entrada.
+- Testeable input/output en aislamiento.
+- Cero dependencias externas (ni siquiera tipos de schema).
+
+## Ubicación nueva
+
+`server/features/logistics/domain/pagination.ts`
+
+Respeta la regla de dependencia de la capa `domain`
+(`server/features/logistics/domain/README.md`): no importa `fastify`, ni el
+runtime de Drizzle, ni `env`, ni ningún `db-*`. La dependencia apunta hacia
+adentro: la capa de persistencia (`server/db-logistics.ts`) importa el helper
+de `domain`, nunca al revés. Verificado por
+`test/logistics-domain-boundary-guard.test.ts` (sigue verde, sin modificar).
+
+## Origen
+
+Las funciones y constantes existían **de forma implícita** como código
+público puro dentro de la capa de persistencia `server/db-logistics.ts` (antes
+en las líneas 37-38 y 298-318), invocadas 6 veces por distintos listados. Era
+lógica de dominio pura (normalización de paginación) viviendo en el archivo de
+persistencia; ARCH-7 la reubica en su capa correcta, igual que ARCH-5 hizo con
+`normalizeGenerateHeuristicFieldVisitIds`.
+
+## Archivos modificados
+
+| Archivo | Cambio |
+| --- | --- |
+| `server/features/logistics/domain/pagination.ts` | **Nuevo.** Constantes `LOGISTICS_DEFAULT_LIMIT`/`LOGISTICS_MAX_LIMIT` y helpers puros `normalizeLogisticsLimit`/`normalizeLogisticsOffset`. |
+| `server/db-logistics.ts` | Se elimina la definición local de las 2 constantes y las 2 funciones; se añade `import { LOGISTICS_DEFAULT_LIMIT, LOGISTICS_MAX_LIMIT, normalizeLogisticsLimit, normalizeLogisticsOffset } from "./features/logistics/domain/pagination.ts";` y se re-exportan con `export { ... }` para conservar exactamente la misma superficie pública del módulo (nada externo importaba estos símbolos desde `db-logistics.ts`, pero se preserva por si acaso). Los 6 call-sites quedan idénticos. |
+| `test/logistics-db.test.ts` | Se ajusta el test `"logistics DB helpers define bounded pagination defaults"` (ahora `"...wire bounded pagination defaults from the domain layer"`): en vez de verificar el cuerpo de la función en el source de `db-logistics.ts`, verifica el import desde `./features/logistics/domain/pagination.ts` y la presencia de los 4 identificadores. Los demás tests que verifican `normalizeLogisticsLimit(params.limit)` / `normalizeLogisticsOffset(params.offset)` como call-site (líneas 53-54, 139, 187-188, 220-221) **no se tocaron**: siguen siendo ciertos porque el call-site no cambió. |
+| `test/logistics-pagination.test.ts` | **Nuevo.** Tests unitarios del helper de dominio (11 casos). |
+
+## Comportamiento preservado
+
+- Los nombres de las funciones/constantes y los 6 call-sites en
+  `server/db-logistics.ts` no cambian: `normalizeLogisticsLimit(params.limit)` /
+  `normalizeLogisticsOffset(params.offset)`.
+- La implementación se movió **verbatim** (misma firma, misma lógica de
+  clamping, mismos valores por defecto `50`/`100`).
+- `db-logistics.ts` sigue exportando `LOGISTICS_DEFAULT_LIMIT`,
+  `LOGISTICS_MAX_LIMIT`, `normalizeLogisticsLimit` y `normalizeLogisticsOffset`
+  (vía re-export), preservando su superficie pública.
+- No cambian endpoints, payloads, status codes, permisos, queries SQL, schema
+  ni contratos.
+- El guardrail `test/logistics-domain-boundary-guard.test.ts` sigue
+  satisfecho sin modificarlo: `pagination.ts` no importa nada prohibido (no
+  tiene ningún import).
+- El guardrail de scope dashboard (`dashboardScopeGuardApplies`) no aplica: el
+  diff no toca ningún archivo de scope dashboard.
+
+## Tests
+
+`test/logistics-pagination.test.ts` (11 casos):
+
+1. `LOGISTICS_DEFAULT_LIMIT` y `LOGISTICS_MAX_LIMIT` conservan sus valores
+   (50/100).
+2. `normalizeLogisticsLimit` cae al default con `undefined`, `null`, `0`,
+   negativos, decimales y `NaN`.
+3. `normalizeLogisticsLimit` acota valores por encima del máximo (incluyendo el
+   límite exacto).
+4. `normalizeLogisticsLimit` deja pasar valores válidos sin cambios.
+5. `normalizeLogisticsLimit` respeta overrides de `defaultLimit`/`maxLimit`.
+6. `normalizeLogisticsOffset` cae a `0` con `undefined`, `null`, negativos,
+   decimales y `NaN`.
+7. `normalizeLogisticsOffset` deja pasar enteros no negativos sin cambios.
+
+`test/logistics-db.test.ts` ajustado (1 test reescrito, sin agregar/quitar
+casos): ahora valida el import desde la capa `domain` en vez del cuerpo de la
+función.
+
+## Comandos ejecutados
+
+```powershell
+git branch --show-current
+git log -1 --oneline
+git status --short --untracked-files=all
+pnpm test
+pnpm build
+git diff --check
+```
+
+## Resultado `pnpm test`
+
+`tests 2980 · pass 2980 · fail 0` (base previa: 2970 tras ARCH-5/6; +11 tests
+nuevos del helper, -1 test reescrito sin cambiar el conteo neto de tests fuera
+del nuevo archivo).
+
+## Resultado `pnpm build`
+
+OK — `esbuild server/index.ts … dist/index.js 838.1kb`, `Done`. Sin errores.
+
+## `git diff --check`
+
+Exit 0 — sin errores de whitespace.
+
+## `git status --short --untracked-files=all`
+
+```
+ M server/db-logistics.ts
+ M test/logistics-db.test.ts
+?? server/features/logistics/domain/pagination.ts
+?? test/logistics-pagination.test.ts
+```
+
+(más este documento, `docs/implementation/arch-7-logistics-second-domain-helper.md`)
+
+## Riesgos residuales
+
+- Bajos. El cambio es una reubicación verbatim de código público puro que ya
+  vivía sin dependencias fuera de la capa de persistencia; sin superficie de
+  comportamiento observable afectada.
+- Existe una duplicación conceptual pre-existente con
+  `server/lib/list-pagination.ts` (`normalizeListPagination`, usado por otros
+  contextos con distintos defaults y semántica de clamping). ARCH-7 no
+  consolida ambas implementaciones: eso sería un refactor de comportamiento
+  compartido fuera de scope ("solo 1 helper", "no refactor masivo").
+
+## Confirmaciones de scope
+
+- **No deps / lockfiles / CI:** no se tocó `package.json`, `pnpm-lock.yaml` ni CI.
+- **No DB / schema / migrations:** sin cambios en `drizzle/**` ni SQL.
+- **No API / runtime behavior:** endpoints, payloads, status codes, permisos y
+  queries intactos; comportamiento observable idéntico.
+- **No auth:** sin cambios en sesiones, roles ni fronteras.
+- **No git add/commit/push, no PR, no merge, no stashes, no `.claude/worktrees`.**
+- **No uso material del ZIP de skills:** el ZIP/carpeta de skills se usó sólo
+  como modo de trabajo/observación; no fue copiado, descomprimido, editado,
+  ejecutado ni agregado al repositorio.

--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -33,9 +33,19 @@ import {
   type RoutePlanningVisit,
 } from "./lib/logistics/route-planning.ts";
 import { normalizeGenerateHeuristicFieldVisitIds } from "./features/logistics/domain/route-plan-field-visits.ts";
+import {
+  LOGISTICS_DEFAULT_LIMIT,
+  LOGISTICS_MAX_LIMIT,
+  normalizeLogisticsLimit,
+  normalizeLogisticsOffset,
+} from "./features/logistics/domain/pagination.ts";
 
-export const LOGISTICS_DEFAULT_LIMIT = 50;
-export const LOGISTICS_MAX_LIMIT = 100;
+export {
+  LOGISTICS_DEFAULT_LIMIT,
+  LOGISTICS_MAX_LIMIT,
+  normalizeLogisticsLimit,
+  normalizeLogisticsOffset,
+};
 
 export type FieldVisit = typeof fieldVisits.$inferSelect;
 export type NewFieldVisit = typeof fieldVisits.$inferInsert;
@@ -294,28 +304,6 @@ export type RoutePlanLifecycleTransitionResult =
       reason: "not_found" | "invalid_transition";
       currentStatus?: RoutePlanStatus;
     };
-
-export function normalizeLogisticsLimit(
-  value: number | null | undefined,
-  defaultLimit = LOGISTICS_DEFAULT_LIMIT,
-  maxLimit = LOGISTICS_MAX_LIMIT,
-): number {
-  if (!Number.isInteger(value) || value == null || value <= 0) {
-    return defaultLimit;
-  }
-
-  return Math.min(value, maxLimit);
-}
-
-export function normalizeLogisticsOffset(
-  value: number | null | undefined,
-): number {
-  if (!Number.isInteger(value) || value == null || value < 0) {
-    return 0;
-  }
-
-  return value;
-}
 
 export async function createFieldVisit(
   input: CreateFieldVisitInput,

--- a/server/features/logistics/domain/pagination.ts
+++ b/server/features/logistics/domain/pagination.ts
@@ -1,0 +1,52 @@
+// Logistics · domain (reglas puras)
+//
+// Regla de dominio de paginación: acotar los parámetros `limit`/`offset` con los
+// que se listan recursos de Logistics (visitas de campo, eventos de ruta,
+// instancias de SLA). Determinística, sin I/O, sin framework y sin persistencia
+// — sólo transforma la entrada en la salida.
+//
+// Esta lógica vivía de forma implícita dentro de la capa de persistencia
+// (`server/db-logistics.ts`). ARCH-7 la extrae al contexto `logistics/domain`
+// manteniendo el comportamiento observable idéntico: `db-logistics.ts` la sigue
+// invocando con el mismo nombre, ahora vía import interno.
+
+export const LOGISTICS_DEFAULT_LIMIT = 50;
+export const LOGISTICS_MAX_LIMIT = 100;
+
+/**
+ * Normaliza el `limit` de un listado de Logistics: si no es un entero positivo
+ * usa el valor por defecto, y en cualquier caso lo acota al máximo permitido.
+ *
+ * @param value Límite crudo solicitado.
+ * @param defaultLimit Límite por defecto cuando `value` no es válido.
+ * @param maxLimit Límite máximo permitido.
+ * @returns Límite saneado, entre 1 y `maxLimit`.
+ */
+export function normalizeLogisticsLimit(
+  value: number | null | undefined,
+  defaultLimit = LOGISTICS_DEFAULT_LIMIT,
+  maxLimit = LOGISTICS_MAX_LIMIT,
+): number {
+  if (!Number.isInteger(value) || value == null || value <= 0) {
+    return defaultLimit;
+  }
+
+  return Math.min(value, maxLimit);
+}
+
+/**
+ * Normaliza el `offset` de un listado de Logistics: descarta valores que no
+ * sean enteros no negativos y los reemplaza por `0`.
+ *
+ * @param value Offset crudo solicitado.
+ * @returns Offset saneado, siempre `>= 0`.
+ */
+export function normalizeLogisticsOffset(
+  value: number | null | undefined,
+): number {
+  if (!Number.isInteger(value) || value == null || value < 0) {
+    return 0;
+  }
+
+  return value;
+}

--- a/test/logistics-db.test.ts
+++ b/test/logistics-db.test.ts
@@ -8,13 +8,15 @@ const dbLogisticsSource = readFileSync(
   "utf8",
 );
 
-test("logistics DB helpers define bounded pagination defaults", () => {
-  assert.match(dbLogisticsSource, /export const LOGISTICS_DEFAULT_LIMIT = 50/);
-  assert.match(dbLogisticsSource, /export const LOGISTICS_MAX_LIMIT = 100/);
-  assert.match(dbLogisticsSource, /export function normalizeLogisticsLimit/);
-  assert.match(dbLogisticsSource, /export function normalizeLogisticsOffset/);
-  assert.match(dbLogisticsSource, /Math\.min\(value, maxLimit\)/);
-  assert.match(dbLogisticsSource, /return 0/);
+test("logistics DB helpers wire bounded pagination defaults from the domain layer", () => {
+  assert.match(
+    dbLogisticsSource,
+    /from ["']\.\/features\/logistics\/domain\/pagination\.ts["']/,
+  );
+  assert.match(dbLogisticsSource, /LOGISTICS_DEFAULT_LIMIT/);
+  assert.match(dbLogisticsSource, /LOGISTICS_MAX_LIMIT/);
+  assert.match(dbLogisticsSource, /normalizeLogisticsLimit/);
+  assert.match(dbLogisticsSource, /normalizeLogisticsOffset/);
 });
 
 test("logistics DB helpers expose tenant-scoped field visit operations", () => {

--- a/test/logistics-pagination.test.ts
+++ b/test/logistics-pagination.test.ts
@@ -1,0 +1,51 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  LOGISTICS_DEFAULT_LIMIT,
+  LOGISTICS_MAX_LIMIT,
+  normalizeLogisticsLimit,
+  normalizeLogisticsOffset,
+} from "../server/features/logistics/domain/pagination.ts";
+
+test("LOGISTICS_DEFAULT_LIMIT and LOGISTICS_MAX_LIMIT keep their bounded values", () => {
+  assert.equal(LOGISTICS_DEFAULT_LIMIT, 50);
+  assert.equal(LOGISTICS_MAX_LIMIT, 100);
+});
+
+test("normalizeLogisticsLimit falls back to the default for non-positive or non-integer values", () => {
+  assert.equal(normalizeLogisticsLimit(undefined), LOGISTICS_DEFAULT_LIMIT);
+  assert.equal(normalizeLogisticsLimit(null), LOGISTICS_DEFAULT_LIMIT);
+  assert.equal(normalizeLogisticsLimit(0), LOGISTICS_DEFAULT_LIMIT);
+  assert.equal(normalizeLogisticsLimit(-5), LOGISTICS_DEFAULT_LIMIT);
+  assert.equal(normalizeLogisticsLimit(2.5), LOGISTICS_DEFAULT_LIMIT);
+  assert.equal(normalizeLogisticsLimit(Number.NaN), LOGISTICS_DEFAULT_LIMIT);
+});
+
+test("normalizeLogisticsLimit clamps values above the max limit", () => {
+  assert.equal(normalizeLogisticsLimit(999), LOGISTICS_MAX_LIMIT);
+  assert.equal(normalizeLogisticsLimit(LOGISTICS_MAX_LIMIT), LOGISTICS_MAX_LIMIT);
+});
+
+test("normalizeLogisticsLimit passes through valid values unchanged", () => {
+  assert.equal(normalizeLogisticsLimit(1), 1);
+  assert.equal(normalizeLogisticsLimit(25), 25);
+});
+
+test("normalizeLogisticsLimit honors custom default and max overrides", () => {
+  assert.equal(normalizeLogisticsLimit(undefined, 10, 20), 10);
+  assert.equal(normalizeLogisticsLimit(999, 10, 20), 20);
+});
+
+test("normalizeLogisticsOffset falls back to 0 for non-integer or negative values", () => {
+  assert.equal(normalizeLogisticsOffset(undefined), 0);
+  assert.equal(normalizeLogisticsOffset(null), 0);
+  assert.equal(normalizeLogisticsOffset(-1), 0);
+  assert.equal(normalizeLogisticsOffset(2.5), 0);
+  assert.equal(normalizeLogisticsOffset(Number.NaN), 0);
+});
+
+test("normalizeLogisticsOffset passes through non-negative integers unchanged", () => {
+  assert.equal(normalizeLogisticsOffset(0), 0);
+  assert.equal(normalizeLogisticsOffset(100_000), 100_000);
+});


### PR DESCRIPTION
## Summary
- Extracts Logistics pagination normalization into server/features/logistics/domain.
- Preserves DB logistics public surface by re-exporting the helpers.
- Adds focused unit coverage for pagination normalization.
- Documents ARCH-7 implementation.

## Validation
- pnpm test: 2980/2980 OK
- pnpm build: OK
- git diff --check: OK

## Guardrails
- No deps
- No lockfiles
- No CI
- No DB/schema/migrations
- No auth
- No API changes
- No runtime behavior changes
- Logistics domain boundary guard remains green
- No stashes
- No .claude/worktrees
- Skills ZIP not copied, decompressed, edited, executed or added to repo