### PR TITLE
test(integration): move controller batch 3

### DIFF
--- a/docs/implementation/test-arch-8-enterprise-integration-controller-batch-3.md
+++ b/docs/implementation/test-arch-8-enterprise-integration-controller-batch-3.md
@@ -1,0 +1,158 @@
+# TEST-ARCH-8 - Enterprise integration controller batch 3
+
+## Estado base
+
+- Entorno: Windows, PowerShell, PNPM.
+- Herramienta: Codex.
+- Modelo usado: GPT-5 Codex.
+- Effort usado: high.
+- Rama esperada y observada: `test/enterprise-integration-controller-batch-3`.
+- HEAD observado: `0d2ed0b test(integration): move controller batch 2 (#1314)`.
+- Working tree inicial: limpio (`git status --short --untracked-files=all` sin salida).
+- Movimiento fisico minimo: 2 archivos de test.
+- Categoria enterprise asignada: `test/integration/adapters/controllers/`.
+
+## Documentos leidos
+
+- `C:\Users\Nico\.codex\attachments\1fb142de-fd47-473b-bedb-4ab3ea2d9359\pasted-text-1.txt`
+- `docs/audit/test-suite-enterprise-architecture-audit.md`
+- `docs/implementation/test-suite-enterprise-organization-convention.md`
+- `test/README.md`
+- `docs/implementation/test-arch-3-enterprise-first-unit-domain-batch.md`
+- `docs/implementation/test-arch-4-enterprise-architecture-security-guards-batch.md`
+- `docs/implementation/test-arch-5-enterprise-security-invariants-batch.md`
+- `docs/implementation/test-arch-6-enterprise-integration-controller-batch.md`
+- `docs/implementation/test-arch-7-enterprise-integration-controller-batch-2.md`
+- `package.json`
+- `frontend/package.json`
+
+## Regla de lote aplicada
+
+- Categoria del PR: `integration/controllers`.
+- Regla operativa aplicada: mover 2 a 3 tests maximo.
+- Decision: mover 2 archivos para mantener el lote minimo y no ampliar superficie aunque habia mas candidatos potenciales.
+- No se mezclaron categorias enterprise.
+- Destino usado: `test/integration/adapters/controllers/`.
+
+## Scope incluido
+
+- Tercer movimiento fisico minimo de tests claramente clasificables como `integration/adapters/controllers`.
+- Movimiento de 2 archivos `*.fastify.test.ts`.
+- Ajustes minimos de imports relativos afectados por la nueva profundidad.
+- Creacion de esta nota de entrega requerida por protocolo VETNEB.
+
+## Scope excluido
+
+- No runtime.
+- No cambios funcionales de produccion.
+- No cambios de assertions.
+- No `package.json`.
+- No `pnpm-lock.yaml`.
+- No dependencias.
+- No CI/workflows.
+- No backend runtime.
+- No DB, schema ni migraciones.
+- No auth, roles, permisos, cookies, CSRF, CSP ni rate limits.
+- No stashes.
+- No `.claude/worktrees`.
+- No helpers, factories, mocks ni abstracciones nuevas.
+- No tests que requieran DB real, Supabase real, red externa o env productivo.
+- No e2e/UI tests.
+- No repository/persistence tests.
+- No security/architecture/unit/domain tests en este PR.
+
+## Auditoria previa
+
+Confirmaciones:
+
+- El glob `test/**/*.test.ts` descubre tests en subcarpetas sin tocar scripts.
+- `test/tsconfig.json` admite codigo anidado bajo `test/`.
+- `test/integration/adapters/controllers/` ya existia por TEST-ARCH-6 y TEST-ARCH-7.
+- Se detectaron 29 archivos `*.fastify.test.ts` bajo `test/`, incluyendo 4 ya migrados en lotes anteriores.
+- Los candidatos elegidos usan `Fastify`, `app.inject`, rutas `*.fastify.ts`, stubs locales y datos sinteticos.
+- Los candidatos elegidos no requieren DB real, Supabase real, red externa ni credenciales reales.
+- `Select-String` no encontro anchors en `test/**` para `admin-failed-login-alerts.fastify.test.ts` ni `admin-sessions.fastify.test.ts`.
+- Las referencias detectadas en `docs/**` son historicas, matrices documentales o reportes previos y quedaron fuera de scope para evitar churn documental no requerido.
+- `package.json` y `frontend/package.json` confirman scripts nativos reales para las validaciones ejecutadas.
+- No se uso `rg`, Python ni comandos `gh`.
+
+## Candidatos inspeccionados
+
+| Candidato | Categoria evaluada | Decision | Razon |
+| --- | --- | --- | --- |
+| `test/admin-failed-login-alerts.fastify.test.ts` | Integration / controller | Elegido | Valida contrato HTTP de `adminFailedLoginAlertsNativeRoutes` con `Fastify` y `app.inject`, GET/export.csv/OPTIONS, status codes, CORS, auth admin, sanitizacion de respuestas y stubs locales. No tenia anchors en `test/**`. |
+| `test/admin-sessions.fastify.test.ts` | Integration / controller | Elegido | Valida contrato HTTP de `adminSessionsNativeRoutes` con `Fastify` y `app.inject`, GET/revoke/OPTIONS, status codes, CORS, auth admin, auditoria y payload sanitizado con stubs locales. No tenia anchors en `test/**`. |
+| `test/admin-users-roles.fastify.test.ts` | Integration / controller | No elegido | Candidato viable y sin anchors en `test/**`, pero tiene mayor superficie de mutaciones/credenciales; se mantuvo el lote minimo en 2 archivos. |
+| `test/admin-clinics.fastify.test.ts` | Integration / controller | No elegido | Candidato viable, pero mas grande y con mas superficie de creacion/edicion/borrado de clinicas; no era necesario ampliar el lote. |
+| `test/reports-status.fastify.test.ts` | Integration / controller | No elegido | Candidato claro, pero tiene anchors en registries/guards de reports y seguridad; moverlo exigia actualizar demasiadas referencias. |
+| `test/public-report-access.fastify.test.ts` | Integration / controller | No elegido | Candidato claro, pero tiene anchors en reports, storage y security guards; moverlo ampliaba el scope. |
+| `test/clinic-public-profile.fastify.test.ts` | Integration / controller | No elegido | Candidato viable, pero tiene anchor en storage suite y mayor superficie por avatar/multipart. |
+| `test/auth-authorization-integration.fastify.test.ts` | Integration / controller / cross-route integration | No elegido | Valida integracion entre auth y reports; menos mecanico que un controlador aislado. |
+| `test/particular-audit.fastify.test.ts` | Integration / controller | No elegido | Candidato viable, pero tiene anchors en audit/security guards; moverlo exigia coordinar registries. |
+| `test/clinic-audit.fastify.test.ts` | Integration / controller | No elegido | Candidato viable, pero tiene anchors en audit/security guards; moverlo exigia coordinar registries. |
+
+## Candidatos elegidos
+
+| Archivo destino | Categoria asignada | Por que califica |
+| --- | --- | --- |
+| `test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts` | `integration/adapters/controllers` | Construye app Fastify controlada, registra una ruta Fastify con stubs y valida request/response, status codes, headers CORS, export CSV y sanitizacion mediante `app.inject`. |
+| `test/integration/adapters/controllers/admin-sessions.fastify.test.ts` | `integration/adapters/controllers` | Construye app Fastify controlada, registra una ruta Fastify con stubs y valida request/response, status codes, headers CORS, revocacion de sesiones y payloads sanitizados mediante `app.inject`. |
+
+## Archivos movidos
+
+| Origen | Destino |
+| --- | --- |
+| `test/admin-failed-login-alerts.fastify.test.ts` | `test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts` |
+| `test/admin-sessions.fastify.test.ts` | `test/integration/adapters/controllers/admin-sessions.fastify.test.ts` |
+
+## Imports ajustados
+
+| Archivo | Cambio |
+| --- | --- |
+| `test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts` | `../server/lib/env.ts` -> `../../../../server/lib/env.ts` |
+| `test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts` | `../server/routes/admin-failed-login-alerts.fastify.ts` -> `../../../../server/routes/admin-failed-login-alerts.fastify.ts` |
+| `test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts` | `../server/db-admin-failed-login-alerts.ts` -> `../../../../server/db-admin-failed-login-alerts.ts` |
+| `test/integration/adapters/controllers/admin-sessions.fastify.test.ts` | `../server/lib/env.ts` -> `../../../../server/lib/env.ts` |
+| `test/integration/adapters/controllers/admin-sessions.fastify.test.ts` | `../server/routes/admin-sessions.fastify.ts` -> `../../../../server/routes/admin-sessions.fastify.ts` |
+| `test/integration/adapters/controllers/admin-sessions.fastify.test.ts` | `../server/db-admin-sessions.ts` -> `../../../../server/db-admin-sessions.ts` |
+
+## Validaciones ejecutadas
+
+| Comando | Resultado |
+| --- | --- |
+| `git diff --check` | Paso sin salida antes del reporte. Revalidado al final del lote. |
+| `git diff --stat` | Paso. Al no usar `git add`, muestra bajas tracked de los 2 archivos movidos; los destinos nuevos se ven en `git status`. |
+| `git diff --name-only` | Paso. Al no usar `git add`, muestra las 2 bajas tracked esperadas antes del reporte. |
+| `pnpm typecheck:test` | Paso con PNPM 10.8.1 de Corepack. |
+| `pnpm test` | Paso con PNPM 10.8.1 de Corepack: 2983 tests, 2983 pass, 0 fail. |
+| `pnpm build` | Paso con PNPM 10.8.1 de Corepack: `dist/index.js 838.3kb`, `Done in 18ms`. |
+| `pnpm security:public-surface` | Paso: `PASS security/public-surface`; mantuvo findings `server-only` esperados para identificadores de cookies en `frontend/src/proxy.ts`. |
+| `pnpm --dir frontend lint` | Paso. |
+| `pnpm --dir frontend typecheck` | Paso. |
+| `pnpm --dir frontend build` | Paso. |
+
+## Confirmacion de scope
+
+- No se toco runtime (`server/**`, `frontend/src/**`).
+- No se tocaron deps, lockfile, package manifests, CI, DB, schema, migrations, stashes ni `.claude/worktrees`.
+- No se cambiaron assertions ni logica de tests.
+- No se crearon helpers, mocks, factories ni abstracciones nuevas.
+- El cambio es mecanico: mover 2 tests a `test/integration/adapters/controllers/`, ajustar paths relativos y documentar el lote.
+
+## Riesgo residual
+
+- Bajo. Los dos tests elegidos no tenian anchors en `test/**`.
+- El riesgo principal es import relativo incorrecto por nueva profundidad; queda cubierto por `pnpm typecheck:test` y `pnpm test`.
+- Las referencias en `docs/**` quedan historicas o documentales y no afectan el runner.
+
+## Estado final
+
+Working tree con cambios esperados:
+
+- `D test/admin-failed-login-alerts.fastify.test.ts`
+- `D test/admin-sessions.fastify.test.ts`
+- `?? docs/implementation/test-arch-8-enterprise-integration-controller-batch-3.md`
+- `?? test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts`
+- `?? test/integration/adapters/controllers/admin-sessions.fastify.test.ts`
+
+Nico conserva stage, commit, push, PR, checks y merge manuales.

--- a/test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-failed-login-alerts.fastify.test.ts
@@ -13,19 +13,19 @@ process.env.CORS_ORIGIN ??=
 
 const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { adminFailedLoginAlertsNativeRoutes } = await import(
-  "../server/routes/admin-failed-login-alerts.fastify.ts"
+  "../../../../server/routes/admin-failed-login-alerts.fastify.ts"
 );
 
 type AdminFailedLoginAlertsNativeRoutesOptions = import(
-  "../server/routes/admin-failed-login-alerts.fastify.ts"
+  "../../../../server/routes/admin-failed-login-alerts.fastify.ts"
 ).AdminFailedLoginAlertsNativeRoutesOptions;
 type AdminFailedLoginAlertsQuery = import(
-  "../server/db-admin-failed-login-alerts.ts"
+  "../../../../server/db-admin-failed-login-alerts.ts"
 ).AdminFailedLoginAlertsQuery;
 type AdminFailedLoginAlertsSnapshot = import(
-  "../server/db-admin-failed-login-alerts.ts"
+  "../../../../server/db-admin-failed-login-alerts.ts"
 ).AdminFailedLoginAlertsSnapshot;
 
 function buildDeps(

--- a/test/integration/adapters/controllers/admin-sessions.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-sessions.fastify.test.ts
@@ -11,25 +11,25 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 process.env.CORS_ORIGIN ??=
   "https://portal-vetneb-frontend-staging.onrender.com";
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { adminSessionsNativeRoutes } = await import(
-  "../server/routes/admin-sessions.fastify.ts"
+  "../../../../server/routes/admin-sessions.fastify.ts"
 );
 
 type AdminSessionsNativeRoutesOptions = import(
-  "../server/routes/admin-sessions.fastify.ts"
+  "../../../../server/routes/admin-sessions.fastify.ts"
 ).AdminSessionsNativeRoutesOptions;
 type AdminSessionsQuery = import(
-  "../server/db-admin-sessions.ts"
+  "../../../../server/db-admin-sessions.ts"
 ).AdminSessionsQuery;
 type AdminSessionsSnapshot = import(
-  "../server/db-admin-sessions.ts"
+  "../../../../server/db-admin-sessions.ts"
 ).AdminSessionsSnapshot;
 type AdminSessionSummary = import(
-  "../server/db-admin-sessions.ts"
+  "../../../../server/db-admin-sessions.ts"
 ).AdminSessionSummary;
 type AdminSessionRevocationResult = import(
-  "../server/db-admin-sessions.ts"
+  "../../../../server/db-admin-sessions.ts"
 ).AdminSessionRevocationResult;
 const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 


### PR DESCRIPTION
## Summary
- Moves the third controller integration batch into test/integration/adapters/controllers/
- Keeps the change mechanical and test-only
- Adds the required TEST-ARCH-8 implementation report

## Validation
- pnpm test
- pnpm build

## Scope
Test-only plus implementation report. No runtime, deps, lockfiles, CI, DB, schema, migrations, package manifests, or functional rewrites.