### PR TITLE
test(integration): move controller batch 4

### DIFF
--- a/docs/implementation/test-arch-9-enterprise-integration-controller-batch-4.md
+++ b/docs/implementation/test-arch-9-enterprise-integration-controller-batch-4.md
@@ -1,0 +1,160 @@
+# TEST-ARCH-9 - Enterprise integration controller batch 4
+
+## Estado base
+
+- Entorno: Windows, PowerShell, PNPM.
+- Herramienta: Codex.
+- Modelo usado: GPT-5 Codex.
+- Effort usado: high.
+- Rama esperada y observada: `test/enterprise-integration-controller-batch-4`.
+- HEAD observado: `554dc51 test(integration): move controller batch 3 (#1315)`.
+- Working tree inicial: limpio (`git status --short --untracked-files=all` sin salida).
+- Movimiento fisico minimo: 2 archivos de test.
+- Categoria enterprise asignada: `test/integration/adapters/controllers/`.
+
+## Documentos leidos
+
+- `C:\Users\Nico\.codex\attachments\8cb3e00d-659b-4916-9069-8a9fcdbb6af6\pasted-text-1.txt`
+- `docs/audit/test-suite-enterprise-architecture-audit.md`
+- `docs/implementation/test-suite-enterprise-organization-convention.md`
+- `test/README.md`
+- `docs/implementation/test-arch-3-enterprise-first-unit-domain-batch.md`
+- `docs/implementation/test-arch-4-enterprise-architecture-security-guards-batch.md`
+- `docs/implementation/test-arch-5-enterprise-security-invariants-batch.md`
+- `docs/implementation/test-arch-6-enterprise-integration-controller-batch.md`
+- `docs/implementation/test-arch-7-enterprise-integration-controller-batch-2.md`
+- `docs/implementation/test-arch-8-enterprise-integration-controller-batch-3.md`
+- `package.json`
+- `frontend/package.json`
+
+## Regla de lote aplicada
+
+- Categoria del PR: `integration/controllers`.
+- Regla operativa aplicada: mover 2 a 3 tests maximo.
+- Decision: mover 2 archivos para mantener el lote minimo y no ampliar superficie aunque existen mas candidatos potenciales.
+- No se mezclaron categorias enterprise.
+- Destino usado: `test/integration/adapters/controllers/`.
+
+## Scope incluido
+
+- Cuarto movimiento fisico minimo de tests claramente clasificables como `integration/adapters/controllers`.
+- Movimiento de 2 archivos `*.fastify.test.ts`.
+- Ajustes minimos de imports relativos afectados por la nueva profundidad.
+- Creacion de esta nota de entrega requerida por protocolo VETNEB.
+
+## Scope excluido
+
+- No runtime.
+- No cambios funcionales de produccion.
+- No cambios de assertions.
+- No `package.json`.
+- No `pnpm-lock.yaml`.
+- No dependencias.
+- No CI/workflows.
+- No backend runtime.
+- No DB, schema ni migraciones.
+- No auth, roles, permisos, cookies, CSRF, CSP ni rate limits.
+- No stashes.
+- No `.claude/worktrees`.
+- No helpers, factories, mocks ni abstracciones nuevas.
+- No tests que requieran DB real, Supabase real, red externa o env productivo.
+- No e2e/UI tests.
+- No repository/persistence tests.
+- No security/architecture/unit/domain tests en este PR.
+
+## Auditoria previa
+
+Confirmaciones:
+
+- El glob `test/**/*.test.ts` descubre tests en subcarpetas sin tocar scripts.
+- `test/tsconfig.json` admite codigo anidado bajo `test/`.
+- `test/integration/adapters/controllers/` ya existia por TEST-ARCH-6, TEST-ARCH-7 y TEST-ARCH-8.
+- Se detectaron 29 archivos `*.fastify.test.ts` bajo `test/`, incluyendo 6 ya migrados en lotes anteriores.
+- Los candidatos elegidos usan `Fastify`, `app.inject`, rutas `*.fastify.ts`, stubs locales y datos sinteticos.
+- Los candidatos elegidos no requieren DB real, Supabase real, red externa ni credenciales reales.
+- `Select-String` no encontro anchors en `test/**` ni `package.json` para `admin-users-roles.fastify.test.ts` ni `admin-clinics.fastify.test.ts`.
+- Las referencias detectadas en `docs/**` son historicas, matrices documentales o reportes previos y quedaron fuera de scope para evitar churn documental no requerido.
+- `package.json` y `frontend/package.json` confirman scripts nativos reales para las validaciones ejecutadas.
+- No se uso `rg`, Python ni comandos `gh`.
+
+## Candidatos inspeccionados
+
+| Candidato | Categoria evaluada | Decision | Razon |
+| --- | --- | --- | --- |
+| `test/admin-users-roles.fastify.test.ts` | Integration / controller | Elegido | Valida contrato HTTP de `adminUsersRolesNativeRoutes` con `Fastify` y `app.inject`, GET/PATCH/OPTIONS, status codes, CORS, auth admin, roles, credenciales sanitizadas y auditoria con stubs locales. No tenia anchors en `test/**` ni `package.json`. |
+| `test/admin-clinics.fastify.test.ts` | Integration / controller | Elegido | Valida contrato HTTP de `adminClinicsNativeRoutes` con `Fastify` y `app.inject`, GET/POST/PATCH/DELETE/OPTIONS, status codes, CORS, auth admin, payloads sanitizados y auditoria con stubs locales. No tenia anchors en `test/**` ni `package.json`. |
+| `test/admin-audit.fastify.test.ts` | Integration / controller | No elegido | Candidato controller, pero tiene anchor en `test/audit-suite-completeness.test.ts` y referencias de matriz de seguridad/auditoria; moverlo exigia coordinar registries. |
+| `test/particular-audit.fastify.test.ts` | Integration / controller | No elegido | Candidato controller, pero tiene anchors en `test/audit-suite-completeness.test.ts` y guards de seguridad/disclosure; moverlo ampliaba el scope. |
+| `test/clinic-audit.fastify.test.ts` | Integration / controller | No elegido | Candidato controller, pero tiene anchors en audit/security guards y matrices; moverlo exigia actualizar demasiadas referencias. |
+| `test/auth-authorization-integration.fastify.test.ts` | Integration / controller / cross-route integration | No elegido | Valida integracion entre auth y reports y no es tan mecanico como un controlador aislado. Se mantuvo fuera para conservar lote minimo. |
+| `test/reports-status.fastify.test.ts` | Integration / controller | No elegido | Candidato claro, pero tiene anchors en registries/guards de reports y seguridad; moverlo exigia actualizar demasiadas referencias. |
+| `test/public-report-access.fastify.test.ts` | Integration / controller | No elegido | Candidato claro, pero tiene anchors en reports, storage y security guards; moverlo ampliaba el scope. |
+| `test/clinic-public-profile.fastify.test.ts` | Integration / controller | No elegido | Candidato viable, pero tiene anchor en storage suite y mayor superficie por avatar/multipart. |
+| `test/admin-auth.fastify.test.ts` | Integration / controller | No elegido | Candidato controller, pero tiene anchors en security registries y mayor criticidad auth. |
+
+## Candidatos elegidos
+
+| Archivo destino | Categoria asignada | Por que califica |
+| --- | --- | --- |
+| `test/integration/adapters/controllers/admin-users-roles.fastify.test.ts` | `integration/adapters/controllers` | Construye app Fastify controlada, registra una ruta Fastify con stubs y valida request/response, status codes, headers CORS, mutaciones y sanitizacion mediante `app.inject`. |
+| `test/integration/adapters/controllers/admin-clinics.fastify.test.ts` | `integration/adapters/controllers` | Construye app Fastify controlada, registra una ruta Fastify con stubs y valida request/response, status codes, headers CORS, mutaciones CRUD y sanitizacion mediante `app.inject`. |
+
+## Archivos movidos
+
+| Origen | Destino |
+| --- | --- |
+| `test/admin-users-roles.fastify.test.ts` | `test/integration/adapters/controllers/admin-users-roles.fastify.test.ts` |
+| `test/admin-clinics.fastify.test.ts` | `test/integration/adapters/controllers/admin-clinics.fastify.test.ts` |
+
+## Imports ajustados
+
+| Archivo | Cambio |
+| --- | --- |
+| `test/integration/adapters/controllers/admin-users-roles.fastify.test.ts` | `../server/lib/env.ts` -> `../../../../server/lib/env.ts` |
+| `test/integration/adapters/controllers/admin-users-roles.fastify.test.ts` | `../server/routes/admin-users-roles.fastify.ts` -> `../../../../server/routes/admin-users-roles.fastify.ts` |
+| `test/integration/adapters/controllers/admin-users-roles.fastify.test.ts` | `../server/db-admin-users-roles.ts` -> `../../../../server/db-admin-users-roles.ts` |
+| `test/integration/adapters/controllers/admin-users-roles.fastify.test.ts` | `../server/db-admin-clinics.ts` -> `../../../../server/db-admin-clinics.ts` |
+| `test/integration/adapters/controllers/admin-clinics.fastify.test.ts` | `../server/lib/env.ts` -> `../../../../server/lib/env.ts` |
+| `test/integration/adapters/controllers/admin-clinics.fastify.test.ts` | `../server/routes/admin-clinics.fastify.ts` -> `../../../../server/routes/admin-clinics.fastify.ts` |
+| `test/integration/adapters/controllers/admin-clinics.fastify.test.ts` | `../server/db-admin-clinics.ts` -> `../../../../server/db-admin-clinics.ts` |
+
+## Validaciones ejecutadas
+
+| Comando | Resultado |
+| --- | --- |
+| `git diff --check` | Paso sin salida antes del reporte. Revalidado al final del lote. |
+| `git diff --stat` | Paso. Al no usar `git add`, muestra bajas tracked de los 2 archivos movidos; los destinos nuevos se ven en `git status`. |
+| `git diff --name-only` | Paso. Al no usar `git add`, muestra las 2 bajas tracked esperadas antes del reporte. |
+| `pnpm test` | Primer intento con shim Codex aborto antes del runner por `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`; reejecutado con PNPM 10.8.1 de Corepack (`C:\Program Files\nodejs\pnpm.cmd`) y paso: 2983 tests, 2983 pass, 0 fail. |
+| `pnpm typecheck:test` | Paso con PNPM 10.8.1 de Corepack. |
+| `pnpm build` | Paso con PNPM 10.8.1 de Corepack: `dist/index.js 838.3kb`, `Done in 18ms`. |
+| `pnpm security:public-surface` | Paso: `PASS security/public-surface`; sin public devtools exposure findings; mantuvo findings `server-only` esperados para identificadores de cookies en `frontend/src/proxy.ts`. |
+| `pnpm --dir frontend lint` | Paso. |
+| `pnpm --dir frontend typecheck` | Paso. |
+| `pnpm --dir frontend build` | Paso. |
+
+## Confirmacion de scope
+
+- No se toco runtime (`server/**`, `frontend/src/**`).
+- No se tocaron deps, lockfile, package manifests, CI, DB, schema, migrations, stashes ni `.claude/worktrees`.
+- No se cambiaron assertions ni logica de tests.
+- No se crearon helpers, mocks, factories ni abstracciones nuevas.
+- El cambio es mecanico: mover 2 tests a `test/integration/adapters/controllers/`, ajustar paths relativos y documentar el lote.
+
+## Riesgo residual
+
+- Bajo. Los dos tests elegidos no tenian anchors en `test/**` ni `package.json`.
+- El riesgo principal es import relativo incorrecto por nueva profundidad; queda cubierto por `pnpm test`.
+- Las referencias en `docs/**` quedan historicas o documentales y no afectan el runner.
+
+## Estado final
+
+Working tree con cambios esperados:
+
+- `D test/admin-clinics.fastify.test.ts`
+- `D test/admin-users-roles.fastify.test.ts`
+- `?? docs/implementation/test-arch-9-enterprise-integration-controller-batch-4.md`
+- `?? test/integration/adapters/controllers/admin-clinics.fastify.test.ts`
+- `?? test/integration/adapters/controllers/admin-users-roles.fastify.test.ts`
+
+Nico conserva stage, commit, push, PR, checks y merge manuales.

--- a/test/integration/adapters/controllers/admin-clinics.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-clinics.fastify.test.ts
@@ -10,19 +10,19 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 process.env.CORS_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { adminClinicsNativeRoutes } = await import(
-  "../server/routes/admin-clinics.fastify.ts"
+  "../../../../server/routes/admin-clinics.fastify.ts"
 );
 
 type AdminClinicsNativeRoutesOptions = import(
-  "../server/routes/admin-clinics.fastify.ts"
+  "../../../../server/routes/admin-clinics.fastify.ts"
 ).AdminClinicsNativeRoutesOptions;
 type AdminClinicCreateResult = import(
-  "../server/db-admin-clinics.ts"
+  "../../../../server/db-admin-clinics.ts"
 ).AdminClinicCreateResult;
 type AdminClinicSummary = import(
-  "../server/db-admin-clinics.ts"
+  "../../../../server/db-admin-clinics.ts"
 ).AdminClinicSummary;
 
 const demoClinic: AdminClinicSummary = {

--- a/test/integration/adapters/controllers/admin-users-roles.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-users-roles.fastify.test.ts
@@ -11,28 +11,28 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 process.env.CORS_ORIGIN ??=
   "https://portal-vetneb-frontend-staging.onrender.com";
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { adminUsersRolesNativeRoutes } = await import(
-  "../server/routes/admin-users-roles.fastify.ts"
+  "../../../../server/routes/admin-users-roles.fastify.ts"
 );
 
 type AdminUsersRolesNativeRoutesOptions = import(
-  "../server/routes/admin-users-roles.fastify.ts"
+  "../../../../server/routes/admin-users-roles.fastify.ts"
 ).AdminUsersRolesNativeRoutesOptions;
 type AdminUsersRolesQuery = import(
-  "../server/db-admin-users-roles.ts"
+  "../../../../server/db-admin-users-roles.ts"
 ).AdminUsersRolesQuery;
 type AdminUsersRolesSnapshot = import(
-  "../server/db-admin-users-roles.ts"
+  "../../../../server/db-admin-users-roles.ts"
 ).AdminUsersRolesSnapshot;
 type AdminRoleUserSummary = import(
-  "../server/db-admin-users-roles.ts"
+  "../../../../server/db-admin-users-roles.ts"
 ).AdminRoleUserSummary;
 type AdminClinicUserRoleChangeResult = import(
-  "../server/db-admin-users-roles.ts"
+  "../../../../server/db-admin-users-roles.ts"
 ).AdminClinicUserRoleChangeResult;
 type AdminClinicUserCredentialsUpdateResult = import(
-  "../server/db-admin-clinics.ts"
+  "../../../../server/db-admin-clinics.ts"
 ).AdminClinicUserCredentialsUpdateResult;
 const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 


### PR DESCRIPTION
## Summary
- Moves the fourth controller integration batch into test/integration/adapters/controllers/
- Keeps the change mechanical and test-only
- Adds the required TEST-ARCH-9 implementation report

## Validation
- pnpm test
- pnpm build

## Scope
Test-only plus implementation report. No runtime, deps, lockfiles, CI, DB, schema, migrations, package manifests, or functional rewrites.