### PR TITLE
test(architecture): support recursive suite census

### DIFF
--- a/docs/implementation/test-arch-12-enterprise-controller-bulk-batch-1.md
+++ b/docs/implementation/test-arch-12-enterprise-controller-bulk-batch-1.md
@@ -246,3 +246,14 @@ destino-único y tocan tests de security/architecture:
 Ver sección de resultados de comandos en el resumen de entrega. Como no cambió ningún test
 ni runtime, las validaciones confirman el **baseline verde intacto** y que el único cambio
 es este reporte untracked.
+
+## Resolución — TEST-ARCH-13
+
+La **Opción 1** de la recomendación fue ejecutada en
+[TEST-ARCH-13](test-arch-13-recursive-suite-census-and-source-path-guards.md): los censos
+`readdirSync("test")` de `audit-suite-completeness` y `security-boundary-suite-completeness`
+se volvieron **recursivos + canónicos**, y los `readSource`/`readFileSync` anclados a rutas
+de test-root en los guards de security se volvieron **subdirectory-aware** (resolver
+exact-first con fallback por basename único). **Sin mover tests.** Con eso, el **Grupo A
+(audit)** queda desbloqueado para su move real (renombrado a **TEST-ARCH-14** en el
+manifiesto §8 corregido).

--- a/docs/implementation/test-arch-13-recursive-suite-census-and-source-path-guards.md
+++ b/docs/implementation/test-arch-13-recursive-suite-census-and-source-path-guards.md
@@ -1,0 +1,180 @@
+# TEST-ARCH-13 — Recursive suite census and source path guards
+
+## Estado base
+
+- Entorno: Windows 11, PowerShell, PNPM (`pnpm@10.8.1`).
+- Herramienta: Claude · Modelo: Claude Opus 4.8 (`claude-opus-4-8`) · Effort: xhigh.
+- Rama esperada y creada: `test/architecture-recursive-suite-census` (desde `main`).
+- Base: `62e1302 docs(test): document blocked controller bulk migration (#1319)`
+  (TEST-ARCH-12 mergeado). Working tree inicial limpio.
+- Tipo de PR: **test guard architecture only** + reporte Markdown. **No se movieron tests.**
+
+## Objetivo
+
+Desbloquear las migraciones enterprise nested de tests **sin mover tests todavía**,
+corrigiendo los dos mecanismos que TEST-ARCH-12 probó como bloqueantes:
+
+1. Censos no recursivos basados en `readdirSync("test")` que solo ven archivos de la raíz.
+2. Guards de security con `readSource`/`readFileSync` anclados a rutas legacy de test-root.
+
+## Skills declaradas
+
+- **Principal:** VETNEB Production Web Optimization Engineer.
+- **Complementarias:** Staff Senior Full-Stack Engineer · Briefing/Planificación/Diseño/Desarrollo/Pruebas.
+- **Guardrail:** Security Production Invariants.
+
+## Archivos inspeccionados
+
+- `docs/implementation/test-suite-enterprise-migration-manifest.md` (batch manifest).
+- `docs/implementation/test-arch-12-enterprise-controller-bulk-batch-1.md`.
+- `test/README.md`; reportes TEST-ARCH-6..10 (patrón de move probado); audit/convención
+  citadas como fuente de verdad.
+- `test/audit-suite-completeness.test.ts`, `test/security-boundary-suite-completeness.test.ts`,
+  `test/security-session-cookie-boundaries.test.ts`,
+  `test/security-response-disclosure-boundaries.test.ts`,
+  `test/security-access-lifecycle-boundaries.test.ts`.
+- Barrido de todos los `readdirSync(` en `test/**` para confirmar que **solo** esos dos
+  archivos hacen censo no recursivo sobre la **raíz de test** (el resto apunta a
+  `server/`, `frontend/`, `migrations/`, dirs de fixtures, o ya son walkers recursivos con
+  `withFileTypes`).
+
+## Archivos modificados
+
+| Archivo | Cambio |
+|---|---|
+| `test/audit-suite-completeness.test.ts` | Censo → recursivo + canónico; `readSource`/`assertFileExists` subdirectory-aware; walker + resolver. |
+| `test/security-boundary-suite-completeness.test.ts` | Censo → recursivo + canónico; `readSource`/`assertFileExists` subdirectory-aware; walker + resolver. |
+| `test/security-session-cookie-boundaries.test.ts` | `readSource` subdirectory-aware; walker + resolver. |
+| `test/security-response-disclosure-boundaries.test.ts` | `readSource` subdirectory-aware; walker + resolver. |
+| `test/security-access-lifecycle-boundaries.test.ts` | `readSource` subdirectory-aware; walker + resolver. |
+| `docs/implementation/test-suite-enterprise-migration-manifest.md` | Corrección §3.1 y §8 (anclas subcontabilizadas; Grupo A renombrado a TEST-ARCH-14). |
+| `docs/implementation/test-arch-12-enterprise-controller-bulk-batch-1.md` | Nota de resolución apuntando a TEST-ARCH-13. |
+
+## Censos convertidos a recursivos
+
+Dos, ambos sobre la raíz `test/`:
+
+- **`audit-suite-completeness.test.ts`** — `test("audit suite includes every audit-named test file")`.
+  Antes: `readdirSync("test")` (no recursivo) filtrando basenames `audit*.test.ts` y
+  comparando **basenames** contra el registry. Ahora: `listTestFilesRecursive()` (walk
+  recursivo de `test/`, rutas relativas normalizadas a forward slash) filtrando
+  `basename(path).includes("audit")` y comparando **rutas canónicas completas** contra
+  `allSuiteTestPaths()`.
+- **`security-boundary-suite-completeness.test.ts`** — `test("security boundary suite includes
+  every security boundaries guardrail file")`. Antes: `readdirSync("test")` filtrando
+  `/^security-.*-boundaries\.test\.ts$/` sobre basename y comparando basenames. Ahora:
+  `listFilesRecursive("test")` filtrando el mismo regex sobre `basename(path)` y comparando
+  **rutas canónicas completas** contra `guardrail.path`.
+
+Comportamiento **hoy idéntico** (todos los archivos siguen en la raíz → el walk devuelve
+`test/<archivo>`, que coincide con el `path:` del registry). Es más **estricto** que antes:
+comparar rutas canónicas (en vez de basenames ambiguos) obliga a que un move futuro
+**actualice** el `path:` del registry a la ruta real del subdirectorio (requisito 4).
+
+## readSource / path anchors corregidos
+
+Se introdujo, en cada archivo modificado, un walker recursivo `listFilesRecursive(dir)` y un
+resolver `resolveExistingSourcePath(relativePath)`:
+
+- **Prefiere la ruta exacta** si existe (comportamiento byte-identical hoy).
+- Si no existe (archivo migrado a subdirectorio), busca por **basename único** bajo el
+  mismo directorio top-level y devuelve la ruta canónica.
+- Si hay **0 o >1 coincidencias**, devuelve `undefined` → el llamador (`readSource` /
+  `assertFileExists`) **falla** con aserción explícita (no hay match silencioso ni
+  degradación de cobertura).
+
+`readSource` y `assertFileExists` de los guards se reescribieron sobre ese resolver,
+**preservando su post-procesamiento** original (p. ej. el strip de BOM `﻿` y CRLF en
+`audit-suite-completeness` y `security-boundary-suite-completeness`). Los `readSource` que
+leen archivos de runtime (`server/**`, que no se mueven) siguen tomando la rama de ruta
+exacta.
+
+### Anclas de ruta-de-test desbloqueadas para el Grupo A (audit)
+
+- `security-session-cookie-boundaries` → `test/clinic-audit.fastify.test.ts` (readSource).
+- `security-response-disclosure-boundaries` → `test/particular-audit.fastify.test.ts` (readSource).
+- `security-access-lifecycle-boundaries` → `test/particular-audit.fastify.test.ts` (readSource).
+- `audit-suite-completeness` → censo + `readSource(path)` de los 3 audit fastify tests.
+
+Con esto, `admin-audit`, `clinic-audit` y `particular-audit` pueden moverse en un PR
+posterior (TEST-ARCH-14) sin `ENOENT` y sin reescribir lógica de censo.
+
+## Assertions preservadas
+
+- Ninguna aserción semántica cambió. Los censos siguen enforzando la **misma invariante**
+  ("todo test audit-named / security-boundaries está inventariado"), ahora sobre rutas
+  canónicas (más preciso, no más laxo).
+- Los `readSource` siguen leyendo el archivo real y verificando los **mismos markers**.
+- Los `assertFileExists` siguen **fallando** si el archivo no existe en ningún lado
+  (exacto ni por basename único).
+- No se eliminó ninguna entrada de registry ni se silenció ningún guard.
+
+## Cobertura preservada
+
+- 2983 tests → 2983 pass, 0 fail (idéntico al baseline pre-PR).
+- Verificación sintética adicional (Node, en scratchpad, sin tocar el repo) del resolver y
+  el censo recursivo sobre un árbol anidado: (A) ruta exacta preferida; (B) archivo migrado
+  a `test/integration/adapters/controllers/` resuelto sin ENOENT; (C) censo recursivo
+  devuelve rutas canónicas con forward slash a través de subdirectorios; (D) basename
+  duplicado ambiguo rechazado (no hay match silencioso). **ALL PASSED.**
+
+## Manifiesto corregido
+
+- §3.1: nota `[CORRECCIÓN — TEST-ARCH-12/13]` explicando que la tabla subcontabilizó las
+  anclas (censo `readdirSync` no recursivo + `readSource` en guards de security).
+- §8: la recomendación original asumía "1 solo registry"; se marca como falsa, se documenta
+  el desbloqueo por TEST-ARCH-13 y se renombra el move de Grupo A a **TEST-ARCH-14** con el
+  patrón corregido (actualizar `path:` a la ruta canónica del subdirectorio, no basename).
+
+## Confirmaciones de scope
+
+- **No se movieron tests.** Solo se editaron guards + docs.
+- **No se tocó** runtime (`server/**`, `frontend/src/**`), deps, `package.json`,
+  `pnpm-lock.yaml`, CI, DB, schema, migraciones, stashes ni `.claude/worktrees`.
+- No se cambiaron assertions semánticas, no se eliminó cobertura, no se borraron entradas
+  de registry, no se silenció ningún guard.
+- Fuente de las skills (ZIP) usada solo como observación: no copiada, no descomprimida, no
+  editada, no versionada, no ejecutada.
+
+## Resultados de validación
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | Limpio (sin whitespace errors). |
+| `git diff --stat` / `--name-only` | 5 tests-guard + 2 docs modificados; 1 doc nuevo (este). |
+| `pnpm test` | **2983 pass / 0 fail** (idéntico al baseline). |
+| `pnpm build` | OK (`dist/index.js 838.3kb`). |
+| `pnpm security:public-surface` | PASS; mantiene los findings `server-only` esperados en `frontend/src/proxy.ts`. |
+
+## Qué quedó desbloqueado y qué sigue prohibido
+
+**Desbloqueado (para PRs de move futuros, sin cambios adicionales de guard):**
+
+- **Grupo A (audit): `admin-audit`, `clinic-audit`, `particular-audit`** — censo audit
+  recursivo + los 3 guards de security que los `readSource`-anclaban ya son
+  subdirectory-aware. → **TEST-ARCH-14** recomendado.
+- Cualquier `security-*-boundaries.test.ts` que en el futuro se migre a `test/security/`:
+  el censo de `security-boundary-suite-completeness` ya es recursivo.
+
+**Sigue prohibido / aún NO desbloqueado en este PR:**
+
+- Grupos B (study-tracking) y D (reports/tokens): siguen `readSource`-anclados por guards de
+  security **no incluidos** en el scope de este PR
+  (`security-write-attribution-boundaries`, `security-resource-ownership-boundaries`,
+  `security-validation-cutoff-boundaries`, `security-rate-limit-isolation-boundaries`,
+  `security-audit-logging-phase-boundaries`, `public-professionals-source-boundaries`).
+  Requieren el mismo tratamiento subdirectory-aware en un PR análogo (TEST-ARCH-13-b) antes
+  de moverlos.
+- Mover tests (cualquier categoría) queda fuera de este PR.
+- Tocar runtime, deps, lockfile, CI, DB/schema/migrations.
+
+## Siguiente PR recomendado
+
+**TEST-ARCH-14 — controller bulk Grupo A (audit).** Mover los 3 audit `.fastify.test.ts` a
+`test/integration/adapters/controllers/`, ajustar imports de profundidad
+(`../server` → `../../../../server`) y actualizar los 3 `path:` en
+`audit-suite-completeness.test.ts` a la ruta canónica del subdirectorio (el censo recursivo
+lo exige). Validar con `pnpm validate:local` + `pnpm test` + `pnpm build`.
+
+Opcionalmente, **TEST-ARCH-13-b** puede replicar el tratamiento subdirectory-aware en los
+guards de security restantes para desbloquear los Grupos B y D antes de sus moves.

--- a/docs/implementation/test-suite-enterprise-migration-manifest.md
+++ b/docs/implementation/test-suite-enterprise-migration-manifest.md
@@ -158,6 +158,22 @@ para diseñar lotes que actualicen **un solo registry** por PR:
 Grupos B y C son medianos (1–2 registries). Grupo D (reports/tokens) es el más
 enredado (varios multi-anclados) → dejarlo para el final del bloque de controllers.
 
+> **[CORRECCIÓN — TEST-ARCH-12/13]** Esta tabla **subcontabilizó** las anclas. Solo miró
+> `*-suite-completeness`/`*-registry`. Dos clases de ancla adicionales fueron omitidas y
+> confirmadas por evidencia en TEST-ARCH-12:
+> 1. **Censo `readdirSync("test")` no recursivo** en `audit-suite-completeness.test.ts`
+>    (y en `security-boundary-suite-completeness.test.ts`): mover un archivo audit-named
+>    fuera de `test/` raíz rompe el `deepEqual` de basenames y **no** se repara actualizando
+>    el `path:` del registry.
+> 2. **`readSource`/`readFileSync` del archivo de test** dentro de guards de security
+>    (`security-session-cookie-boundaries`, `security-response-disclosure-boundaries`,
+>    `security-access-lifecycle-boundaries`, y varios más): lanzan `ENOENT` al mover.
+>
+> Consecuencia: **ninguno** de los 19 controllers restantes era un move limpio "de 1 solo
+> registry". **TEST-ARCH-13** volvió recursivos ambos censos y subdirectory-aware los
+> `readSource` de esos guards (sin mover tests). El **Grupo A (audit)** queda desbloqueado
+> para su move real (ver §8 corregido).
+
 ### 3.2. Detalle por archivo — grupo `unit/domain` **libre** (sin anchors) **[OBSERVADO]**
 
 Candidatos puros de dominio que **no** están en ningún registry → move + ajuste de
@@ -269,21 +285,35 @@ mismo patrón + mismo eje):
 
 ## 8. Primer bulk PR recomendado **[PROPUESTO]**
 
-**TEST-ARCH-12 — controller bulk batch 6 (Grupo A: audit controllers).**
+> **[CORRECCIÓN — TEST-ARCH-12/13]** La recomendación original (abajo) asumía que el Grupo A
+> era un move de **1 solo registry** con solo 3 actualizaciones de `path:`. **Falso:** el
+> trío audit estaba doblemente anclado por el **censo `readdirSync` no recursivo** de
+> `audit-suite-completeness` (irreparable con `path:`) y por `readSource` en guards de
+> security. TEST-ARCH-12 documentó el bloqueo (0 moves); **TEST-ARCH-13** desbloqueó los
+> guards (censos recursivos + `readSource` subdirectory-aware). **Recomendación vigente
+> ahora:** **TEST-ARCH-14 — mover Grupo A (audit)** con el patrón corregido descrito abajo.
+
+**TEST-ARCH-14 (post-TEST-ARCH-13) — controller bulk Grupo A: audit controllers.**
 
 - **Categoría:** `integration/adapters/controllers`.
-- **Rama sugerida:** `test/enterprise-controller-batch-6-audit`.
-- **Archivos sugeridos (mover):**
+- **Rama sugerida:** `test/enterprise-controller-batch-audit`.
+- **Archivos (mover):**
   - `test/admin-audit.fastify.test.ts` → `test/integration/adapters/controllers/admin-audit.fastify.test.ts`
   - `test/clinic-audit.fastify.test.ts` → `test/integration/adapters/controllers/clinic-audit.fastify.test.ts`
   - `test/particular-audit.fastify.test.ts` → `test/integration/adapters/controllers/particular-audit.fastify.test.ts`
-- **Edición mínima obligatoria en el mismo PR:**
-  - ajustar el import relativo de profundidad (`../server` → `../../server`, patrón probado en batches 6–10);
-  - actualizar los 3 `path:` correspondientes en `test/audit-suite-completeness.test.ts` (único registry que los ancla).
+- **Edición mínima obligatoria en el mismo PR (patrón corregido):**
+  - ajustar el import relativo de profundidad (`../server` → `../../../../server`, patrón probado en batches 6–10);
+  - actualizar los 3 `path:` en `test/audit-suite-completeness.test.ts` a la ruta canónica
+    del subdirectorio (el **censo recursivo** ahora **exige** que el `path:` refleje la
+    ubicación real; el basename ya no basta);
+  - actualizar, si se desea trazabilidad, los hints legacy `readSource("test/clinic-audit…")`
+    / `readSource("test/particular-audit…")` en los guards de security a la nueva ruta
+    (opcional: el resolver subdirectory-aware de TEST-ARCH-13 los tolera aunque queden como
+    hint legacy).
 - **Tamaño de lote:** 3 (tope efectivo = tamaño del grupo de anchor común).
-- **Riesgo:** medio (1 registry, patrón `app.inject` ya probado, dominio homogéneo).
+- **Riesgo:** medio-bajo (guards ya recursivos; patrón `app.inject` probado; dominio homogéneo).
 - **Validaciones:** `pnpm validate:local` (`typecheck:test` + `test` + `build`),
-  `git diff --stat` para confirmar que solo se tocan 3 tests + 1 registry + el doc.
+  `git diff --stat` para confirmar el alcance.
 
 **Por qué este y no un "controller bulk" de 15:** §3.1 demuestra que los 19
 controllers restantes están anclados y que Grupo A es el único trío con **un solo

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -480,8 +480,54 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
   },
 ];
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+function listTestFilesRecursive(): string[] {
+  return listFilesRecursive("test").filter((path) => path.endsWith(".test.ts"));
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory.
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8")
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8")
     .replace(/^\uFEFF/, "")
     .replace(/\r\n/g, "\n");
 }
@@ -491,9 +537,8 @@ function assertContains(source: string, marker: string, context: string): void {
 }
 
 function assertFileExists(relativePath: string): void {
-  assert.equal(
-    existsSync(resolve(REPO_ROOT, relativePath)),
-    true,
+  assert.ok(
+    resolveExistingSourcePath(relativePath) !== undefined,
     `${relativePath} must exist`,
   );
 }
@@ -534,13 +579,11 @@ test("audit suite completeness registry keeps canonical order", () => {
 });
 
 test("audit suite includes every audit-named test file", () => {
-  const actualFiles = readdirSync(resolve(REPO_ROOT, "test"))
-    .filter((fileName) => fileName.includes("audit") && fileName.endsWith(".test.ts"))
+  const actualFiles = listTestFilesRecursive()
+    .filter((relativePath) => basename(relativePath).includes("audit"))
     .sort();
 
-  const expectedFiles = allSuiteTestPaths()
-    .map((filePath) => basename(filePath))
-    .sort();
+  const expectedFiles = allSuiteTestPaths().slice().sort();
 
   assert.deepEqual(actualFiles, expectedFiles);
 });

--- a/test/security-access-lifecycle-boundaries.test.ts
+++ b/test/security-access-lifecycle-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -28,8 +28,50 @@ const ACCESS_LIFECYCLE_BOUNDARIES = {
   },
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory.
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8");
 }
 
 function assertContains(source: string, marker: string, context: string) {

--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { existsSync, readdirSync, readFileSync } from "node:fs";
-import { basename, resolve } from "node:path";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -467,8 +467,50 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
   },
 ];
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory.
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8")
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8")
     .replace(/^\uFEFF/, "")
     .replace(/\r\n/g, "\n");
 }
@@ -482,9 +524,8 @@ function uniqueValues(values: readonly string[]): string[] {
 }
 
 function assertFileExists(relativePath: string): void {
-  assert.equal(
-    existsSync(resolve(REPO_ROOT, relativePath)),
-    true,
+  assert.ok(
+    resolveExistingSourcePath(relativePath) !== undefined,
     `${relativePath} must exist`,
   );
 }
@@ -545,13 +586,15 @@ test("security boundary suite completeness registry keeps canonical order", () =
 });
 
 test("security boundary suite includes every security boundaries guardrail file", () => {
-  const actualFiles = readdirSync(resolve(REPO_ROOT, "test"))
-    .filter((fileName) => /^security-.*-boundaries\.test\.ts$/.test(fileName))
+  const actualFiles = listFilesRecursive("test")
+    .filter((relativePath) =>
+      /^security-.*-boundaries\.test\.ts$/.test(basename(relativePath)),
+    )
     .sort();
 
-  const expectedFiles = SECURITY_BOUNDARY_SUITE.map((guardrail) =>
-    basename(guardrail.path),
-  ).sort();
+  const expectedFiles = SECURITY_BOUNDARY_SUITE.map((guardrail) => guardrail.path)
+    .slice()
+    .sort();
 
   assert.deepEqual(actualFiles, expectedFiles);
 });

--- a/test/security-response-disclosure-boundaries.test.ts
+++ b/test/security-response-disclosure-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -29,8 +29,50 @@ const RESPONSE_DISCLOSURE_BOUNDARIES = {
   },
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory.
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8");
 }
 
 function assertContains(source: string, marker: string, context: string) {

--- a/test/security-session-cookie-boundaries.test.ts
+++ b/test/security-session-cookie-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -57,8 +57,50 @@ const PARTICULAR_SESSION_FILES = [
   "server/routes/particular-study-tracking.fastify.ts",
 ] as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory.
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8");
 }
 
 function assertContains(source: string, marker: string, context: string) {


### PR DESCRIPTION
## Summary
- Updates suite completeness guards to support recursive enterprise test paths
- Makes security readSource/assertFileExists guards subdirectory-aware without weakening assertions
- Corrects migration manifest and TEST-ARCH-12 report based on blocker evidence

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface

## Scope
Test guard architecture and documentation only. No test files moved. No runtime, deps, lockfiles, CI, DB, schema, migrations, package manifests, or functional changes.