### PR TITLE
test(architecture): support source path guard fallbacks

### DIFF
--- a/docs/implementation/test-arch-15-source-path-guards-bd-unlock.md
+++ b/docs/implementation/test-arch-15-source-path-guards-bd-unlock.md
@@ -1,0 +1,190 @@
+# TEST-ARCH-15 — Source path guards B/D unlock
+
+## Estado base
+
+- Entorno: Windows 11, PowerShell, PNPM (`pnpm@10.8.1`).
+- Herramienta: Claude · Modelo usado: Claude Opus 4.8 (`claude-opus-4-8`) · Effort configurado: xhigh.
+- Rama esperada y observada: `test/architecture-source-path-guards-bd`.
+- Base esperada y observada: `fb2d081 test(integration): move audit controller group (#1321)`
+  (TEST-ARCH-14 mergeado). Working tree inicial limpio.
+- Tipo de PR: **test-guard architecture only** + reporte Markdown. **No se movieron tests.**
+
+## Objetivo
+
+Desbloquear las migraciones enterprise nested de los controllers restantes de los
+**Grupos B (study-tracking)** y **D (reports/tokens)** replicando en los guards de security
+fuera del scope de TEST-ARCH-13 el mismo tratamiento subdirectory-aware
+(exact-first + fallback por basename único + fallo explícito). **Este PR no mueve tests.**
+
+## Skills declaradas
+
+- **Principal:** VETNEB Production Web Optimization Engineer.
+- **Complementarias:** Staff Senior Full-Stack Engineer · Briefing/Planificación/Diseño/Desarrollo/Pruebas.
+- **Guardrail:** Security Production Invariants.
+
+## Documentos leídos
+
+- `docs/implementation/test-suite-enterprise-migration-manifest.md` (§3.1, §7, §8).
+- `docs/implementation/test-arch-12-enterprise-controller-bulk-batch-1.md` (bloqueo original).
+- `docs/implementation/test-arch-13-recursive-suite-census-and-source-path-guards.md`
+  (patrón de referencia: resolver exact-first + fallback por basename único).
+- `docs/implementation/test-arch-14-enterprise-controller-audit-group-a.md` (move real Grupo A).
+- `docs/implementation/test-suite-enterprise-organization-convention.md` (fuente de verdad).
+- `test/README.md`.
+
+## Guards inspeccionados
+
+Se barrió con `Select-String` (PowerShell) por `readSource`, `readFileSync`, `assertFileExists`
+y por cada basename de test de los controllers de los Grupos B/D. Referenciantes encontrados y
+su clasificación:
+
+| Archivo | Mecanismo de ancla a rutas de test | ¿Requiere fix aquí? |
+|---|---|---|
+| `security-write-attribution-boundaries.test.ts` | `readSource("test/…")` inline (8 tests B/D) | **SÍ — este PR** |
+| `security-resource-ownership-boundaries.test.ts` | `readSource("test/…")` inline (5 tests B/D) | **SÍ — este PR** |
+| `security-validation-cutoff-boundaries.test.ts` | `readSource("test/…")` inline (8 tests) | **SÍ — este PR** |
+| `security-rate-limit-isolation-boundaries.test.ts` | `readSource("test/…")` inline (9 tests) | **SÍ — este PR** |
+| `security-audit-logging-phase-boundaries.test.ts` | `readSource("test/…")` inline (3 tests) | **SÍ — este PR** |
+| `public-professionals-source-boundaries.test.ts` | `readSource("test/…")` inline (1 test) | **SÍ — este PR** |
+| `security-session-cookie-boundaries.test.ts` | `readSource` inline | ya subdirectory-aware (TEST-ARCH-13) |
+| `security-response-disclosure-boundaries.test.ts` | `readSource` inline | ya subdirectory-aware (TEST-ARCH-13) |
+| `security-access-lifecycle-boundaries.test.ts` | `readSource` inline | ya subdirectory-aware (TEST-ARCH-13) |
+| `audit-suite-completeness.test.ts` | censo recursivo + `readSource(path)` | ya recursivo (TEST-ARCH-13) |
+| `security-boundary-suite-completeness.test.ts` | censo recursivo + `readSource(path)` | ya recursivo (TEST-ARCH-13) |
+| `reports-suite-completeness.test.ts` | **registry** `path:` + `assertFileExists`/`readSource(path)` | no — invariante de move: actualizar `path:` en el mismo PR |
+| `study-tracking-suite-completeness.test.ts` | **registry** `path:` + `assertFileExists`/`readSource(path)` | no — invariante de move: actualizar `path:` |
+| `storage-suite-completeness.test.ts` | **registry** `path:` + `readSource(path)` | no — invariante de move: actualizar `path:` |
+| `security-critical-route-surface-registry.test.ts` | **registry** `path:` + `existsSync(path)` | no — invariante de move: actualizar `path:` |
+| `security-cross-tenant-idor-contract.test.ts` | path como **dato** (`requiredTestEvidence`), no lee FS | no — no produce ENOENT (precedente TEST-ARCH-14) |
+| `report-study-types-catalog.test.ts` | **censo por lista hardcodeada** (`.filter([...paths].includes)` + `assert.deepEqual` + `readSource(file)`) | **NO en este PR** — mecanismo distinto; ver "Grupos aún bloqueados" |
+
+## Guards modificados
+
+Los **6** guards nombrados en el objetivo, exclusivamente su helper `readSource`
+(y sus imports de `node:fs`/`node:path`):
+
+| Archivo | Cambio |
+|---|---|
+| `test/security-write-attribution-boundaries.test.ts` | `readSource` subdirectory-aware; añadidos `listFilesRecursive` + `resolveExistingSourcePath`. |
+| `test/security-resource-ownership-boundaries.test.ts` | idem. |
+| `test/security-validation-cutoff-boundaries.test.ts` | idem (se preserva el strip de BOM `﻿` + CRLF). |
+| `test/security-rate-limit-isolation-boundaries.test.ts` | idem (se preserva el strip de CRLF). |
+| `test/security-audit-logging-phase-boundaries.test.ts` | idem (se preserva el strip de CRLF). |
+| `test/public-professionals-source-boundaries.test.ts` | idem sobre base `process.cwd()` (`SOURCE_ROOT`), preserva strip de CRLF. |
+
+## Patrón exact-first / fallback único aplicado
+
+Idéntico al de TEST-ARCH-13 (byte-compatible con los guards ya migrados):
+
+- **Prefiere la ruta exacta** si existe → comportamiento byte-identical hoy (todos los
+  archivos siguen en su ubicación actual; runtime `server/**` siempre toma esta rama).
+- Si no existe (archivo migrado a subdirectorio), busca por **basename único** bajo el
+  mismo directorio top-level (`test/`) con un walker recursivo `withFileTypes` y devuelve la
+  ruta canónica (forward slash).
+- **0 coincidencias** → `undefined` → `assert.ok(resolved, …)` **falla** explícito (ENOENT
+  convertido en aserción legible).
+- **>1 coincidencia** (basename ambiguo) → `undefined` → **falla** explícito. Sin match
+  silencioso, sin degradación de cobertura.
+
+`readSource` conserva su post-procesamiento original por guard (strip de BOM/CRLF donde
+existía). Los `readSource` de runtime (`server/**`, que no se mueven) siguen tomando siempre
+la rama exact-first.
+
+### Verificación en vivo del resolver (contra el árbol real, sin mover nada)
+
+Comprobación sintética (Node, en scratchpad, sin tocar el repo) usando el árbol real, que ya
+contiene el Grupo A audit movido por TEST-ARCH-14:
+
+| Entrada | Resultado |
+|---|---|
+| `test/admin-audit.fastify.test.ts` (movido por TEST-ARCH-14) | `test/integration/adapters/controllers/admin-audit.fastify.test.ts` **[FALLBACK-UNIQUE]** |
+| `test/reports.fastify.test.ts` (aún en raíz) | `test/reports.fastify.test.ts` **[EXACT]** |
+| `server/routes/reports.fastify.ts` (runtime) | `server/routes/reports.fastify.ts` **[EXACT]** |
+| `test/does-not-exist.fastify.test.ts` | `undefined (matches=0)` **[FAIL explícito]** |
+
+Prueba que, una vez movidos, los tests de los controllers B/D resolverán en los 6 guards
+**sin ENOENT** por fallback de basename único.
+
+## Assertions preservadas
+
+- Ninguna aserción semántica cambió. Cada guard sigue leyendo el archivo real y verificando
+  **los mismos markers** (mismos `assertContains`/`assertContainsInOrder`/`assertMatches`).
+- Los self-checks ascii-only de cada guard siguen pasando: todo el código insertado es ASCII.
+- 0 assertions debilitadas, 0 guards silenciados.
+
+## Cobertura preservada
+
+- 2983 tests → **2983 pass / 0 fail** (idéntico al baseline TEST-ARCH-14).
+- El resolver falla explícito ante 0 o >1 coincidencias → no hay pérdida silenciosa de
+  cobertura si un move futuro deja un basename ambiguo.
+
+## Docs / manifiesto actualizados
+
+- Este reporte (`docs/implementation/test-arch-15-source-path-guards-bd-unlock.md`).
+- `docs/implementation/test-suite-enterprise-migration-manifest.md`: nota
+  `[CORRECCIÓN — TEST-ARCH-15]` en §3.1 y actualización de §7 documentando (a) el desbloqueo
+  de los 6 guards, (b) el **anchor adicional no anticipado** `report-study-types-catalog`
+  (censo por lista hardcodeada) que aún bloquea el sub-trío `reports`/`admin-reports`/
+  `reports-status` del Grupo D.
+
+## Grupos desbloqueados
+
+- **Grupo B (study-tracking): DESBLOQUEADO.** Sus anclas inline (`security-resource-ownership`,
+  `security-write-attribution` en este PR; `security-access-lifecycle` y
+  `security-response-disclosure` ya de TEST-ARCH-13) son subdirectory-aware. Sus registries
+  (`study-tracking-suite-completeness`, `security-critical-route-surface-registry`) se
+  resuelven con la actualización estándar de `path:` en el mismo PR de move.
+  `security-cross-tenant-idor-contract` guarda el path como dato (no lee FS). → move real
+  candidato para **TEST-ARCH-16**.
+- **Grupo D (reports/tokens): PARCIALMENTE DESBLOQUEADO.** Los 6 guards + los de TEST-ARCH-13
+  ya no dan ENOENT; los registries (`reports-suite-completeness`, `storage-suite-completeness`,
+  `security-critical-route-surface-registry`) se manejan con la actualización de `path:` en el
+  move. **Subconjunto desbloqueado:** `particular-auth`, `admin-particular-tokens`,
+  `admin-report-access-tokens`, `particular-tokens`, `report-access-tokens`,
+  `public-report-access`, `auth` (`.fastify`).
+
+## Grupos aún bloqueados
+
+- **Sub-trío `reports` del Grupo D — AÚN BLOQUEADO:** `reports.fastify`, `admin-reports.fastify`
+  y `reports-status.fastify` siguen anclados por
+  **`test/report-study-types-catalog.test.ts`** (test _"critical report tests stop using
+  free-text or abbreviated studyType"_). Ese guard **no** usa el patrón `readSource("test/…")`
+  inline sino un **censo por lista hardcodeada**: `listSourceFiles("test")` (ya recursivo)
+  filtrado por `.filter(file => [rutas test-root].includes(file))` y comparado con
+  `assert.deepEqual(criticalTestFiles, [rutas test-root])`. Mover cualquiera de esos 3 archivos
+  haría que el filtro los excluya (nueva ruta ≠ ruta hardcodeada) → `deepEqual` rojo + pérdida
+  de cobertura. **Fix pendiente (fuera del scope nombrado de este PR):** hacer ese censo
+  path-aware (comparar por basename canónico o actualizar las 3 rutas hardcodeadas en el PR de
+  move). Recomendado como **TEST-ARCH-15-b** antes de mover el sub-trío `reports`.
+- Grupo C (storage: `clinic-public-profile`, `public-professionals`) fuera de scope aquí.
+- `frontend-*` (R2) y residual `unknown` siguen fuera de move mecánico.
+
+## Confirmaciones de scope
+
+- **No se movieron tests.** Solo se editaron 6 guards + docs.
+- **No se tocó** runtime (`server/**`, `frontend/src/**`), deps, `package.json`,
+  `pnpm-lock.yaml`, CI, DB, schema, migraciones, stashes ni `.claude/worktrees`.
+- No se cambiaron assertions semánticas, no se eliminó cobertura, no se borraron entradas de
+  registry, no se silenció ningún guard.
+- No se usó Python, no se usó `rg`; todo por PowerShell; PNPM only.
+
+## Resultados de validación
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | Limpio (sin whitespace errors). |
+| `git diff --stat` / `--name-only` | 6 guards modificados + 2 docs (este reporte + manifiesto). |
+| `pnpm test` | **2983 pass / 0 fail** (idéntico al baseline). |
+| `pnpm build` | OK (`dist/index.js 838.3kb`). |
+| `pnpm security:public-surface` | PASS; mantiene solo los findings `server-only` esperados en `frontend/src/proxy.ts`. |
+
+## Siguiente PR recomendado
+
+- **TEST-ARCH-16 — controller bulk Grupo B (study-tracking).** Mover `particular-study-tracking`,
+  `admin-study-tracking`, `study-tracking` (`.fastify`) a
+  `test/integration/adapters/controllers/`, ajustar imports de profundidad y actualizar `path:`
+  en `study-tracking-suite-completeness` y `security-critical-route-surface-registry`. Validar
+  con `pnpm validate:local` + `pnpm test` + `pnpm build`.
+- **TEST-ARCH-15-b (prerrequisito del sub-trío `reports`):** hacer path-aware el censo por lista
+  hardcodeada de `report-study-types-catalog.test.ts` antes de mover
+  `reports`/`admin-reports`/`reports-status`.

--- a/docs/implementation/test-suite-enterprise-migration-manifest.md
+++ b/docs/implementation/test-suite-enterprise-migration-manifest.md
@@ -174,6 +174,23 @@ enredado (varios multi-anclados) → dejarlo para el final del bloque de control
 > `readSource` de esos guards (sin mover tests). El **Grupo A (audit)** queda desbloqueado
 > para su move real (ver §8 corregido).
 
+> **[CORRECCIÓN — TEST-ARCH-15]** Para los **Grupos B (study-tracking)** y **D (reports/tokens)**,
+> **TEST-ARCH-15** hizo subdirectory-aware los 6 guards de security restantes que anclaban por
+> `readSource("test/…")` inline (`security-write-attribution-boundaries`,
+> `security-resource-ownership-boundaries`, `security-validation-cutoff-boundaries`,
+> `security-rate-limit-isolation-boundaries`, `security-audit-logging-phase-boundaries`,
+> `public-professionals-source-boundaries`), sin mover tests. Con eso:
+> - **Grupo B: DESBLOQUEADO** (anclas inline resueltas; registries `study-tracking-suite-completeness`
+>   y `security-critical-route-surface-registry` se manejan con la actualización estándar de `path:`
+>   en el mismo PR de move).
+> - **Grupo D: PARCIALMENTE DESBLOQUEADO** — el subconjunto tokens/auth queda libre, pero el
+>   **sub-trío `reports`/`admin-reports`/`reports-status` sigue bloqueado** por un ancla no
+>   anticipada: **`report-study-types-catalog.test.ts`** usa un **censo por lista hardcodeada**
+>   (`listSourceFiles("test").filter([...rutas].includes)` + `assert.deepEqual`), que **no** se
+>   repara con el patrón `readSource` subdirectory-aware. Requiere un **TEST-ARCH-15-b** que haga
+>   path-aware ese censo (o actualizar las 3 rutas en el PR de move). Detalle en
+>   `docs/implementation/test-arch-15-source-path-guards-bd-unlock.md`.
+
 ### 3.2. Detalle por archivo — grupo `unit/domain` **libre** (sin anchors) **[OBSERVADO]**
 
 Candidatos puros de dominio que **no** están en ningún registry → move + ajuste de

--- a/test/public-professionals-source-boundaries.test.ts
+++ b/test/public-professionals-source-boundaries.test.ts
@@ -1,10 +1,55 @@
 ﻿import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
+
+const SOURCE_ROOT = process.cwd();
+
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(SOURCE_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(SOURCE_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13/15). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory. Zero or
+// multiple matches return undefined so the caller fails explicitly (no silent match).
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(SOURCE_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
 
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(SOURCE_ROOT, resolved), "utf8").replace(
     /\r\n/g,
     "\n",
   );

--- a/test/security-audit-logging-phase-boundaries.test.ts
+++ b/test/security-audit-logging-phase-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -33,8 +33,51 @@ const AUDIT_LOGGING_PHASE_BOUNDARIES = {
   ],
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13/15). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory. Zero or
+// multiple matches return undefined so the caller fails explicitly (no silent match).
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8").replace(
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8").replace(
     /\r\n/g,
     "\n",
   );

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -33,8 +33,51 @@ const RATE_LIMIT_ISOLATION_BOUNDARIES = {
   ],
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13/15). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory. Zero or
+// multiple matches return undefined so the caller fails explicitly (no silent match).
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8").replace(
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8").replace(
     /\r\n/g,
     "\n",
   );

--- a/test/security-resource-ownership-boundaries.test.ts
+++ b/test/security-resource-ownership-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -31,8 +31,51 @@ const RESOURCE_OWNERSHIP_BOUNDARIES = {
   },
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13/15). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory. Zero or
+// multiple matches return undefined so the caller fails explicitly (no silent match).
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8");
 }
 
 function assertContains(source: string, marker: string, context: string) {

--- a/test/security-validation-cutoff-boundaries.test.ts
+++ b/test/security-validation-cutoff-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -29,8 +29,51 @@ const VALIDATION_CUTOFF_BOUNDARIES = {
   ],
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13/15). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory. Zero or
+// multiple matches return undefined so the caller fails explicitly (no silent match).
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8")
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8")
     .replace(/^\uFEFF/, "")
     .replace(/\r\n/g, "\n");
 }

--- a/test/security-write-attribution-boundaries.test.ts
+++ b/test/security-write-attribution-boundaries.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
@@ -31,8 +31,51 @@ const WRITE_ATTRIBUTION_BOUNDARIES = {
   },
 } as const;
 
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Resolve a legacy test-root path to its current canonical location, tolerating tests
+// already migrated into enterprise subdirectories (TEST-ARCH-13/15). Prefers the exact
+// path; falls back to a unique basename match under the same top-level directory. Zero or
+// multiple matches return undefined so the caller fails explicitly (no silent match).
+function resolveExistingSourcePath(relativePath: string): string | undefined {
+  const normalized = relativePath.split(sep).join("/");
+  if (existsSync(resolve(REPO_ROOT, normalized))) {
+    return normalized;
+  }
+
+  const targetName = basename(normalized);
+  const topDir = normalized.split("/")[0];
+  const matches = listFilesRecursive(topDir).filter(
+    (candidate) => basename(candidate) === targetName,
+  );
+
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
 function readSource(relativePath: string): string {
-  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8");
+  const resolved = resolveExistingSourcePath(relativePath);
+  assert.ok(resolved, `source not found for ${relativePath}`);
+  return readFileSync(resolve(REPO_ROOT, resolved), "utf8");
 }
 
 function assertContains(source: string, marker: string, context: string) {


### PR DESCRIPTION
## Summary
- Updates remaining test source-path guards to support enterprise nested test paths
- Preserves explicit failure behavior for missing or ambiguous file matches
- Documents which controller groups are now unlocked for migration

## Validation
- pnpm test
- pnpm build
- pnpm security:public-surface

## Scope
Test guard architecture and documentation only. No test files moved. No runtime, deps, lockfiles, CI, DB, schema, migrations, package manifests, or functional changes.