### PR TITLE
test(architecture): move auth core controller tests

### DIFF
--- a/docs/implementation/test-arch-18-controller-auth-core-batch.md
+++ b/docs/implementation/test-arch-18-controller-auth-core-batch.md
@@ -1,0 +1,176 @@
+# TEST-ARCH-18 - Controller auth core batch
+
+## Resumen ejecutivo
+
+TEST-ARCH-18 movio fisicamente un lote minimo de controller tests auth core
+clasificados como `MOVIBLE_SEGURO` por TEST-ARCH-16.
+
+El cambio fue mecanico y limitado a 2 tests `*.fastify.test.ts`, sus imports
+relativos minimos y los anchors/path references necesarios para que los guards
+sigan resolviendo los archivos reales.
+
+No se toco runtime, producto, backend productivo, DB, schema, migraciones, CI,
+dependencias, `package.json` ni `pnpm-lock.yaml`.
+
+## Base verificada
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Entorno | Windows, PowerShell, PNPM |
+| Rama esperada | `test/controller-auth-core-batch` |
+| Rama observada | `test/controller-auth-core-batch` |
+| HEAD observado | `7100b08 test(architecture): move study tracking controller tests (#1324)` |
+| Working tree inicial | Limpio (`git status --short --untracked-files=all` sin salida). |
+| PRs abiertos | Ninguno (`gh pr list --state open --limit 50` sin salida). |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, observado con `git branch -r --no-merged origin/main`; no se toco. |
+
+## Fuente de verdad usada
+
+Fuente obligatoria:
+
+- `docs/implementation/test-arch-16-controller-post-unlock-inventory.md`
+
+Documentos normativos leidos:
+
+- `docs/implementation/test-arch-17-controller-study-tracking-batch.md`
+- `test/README.md`
+- `docs/implementation/test-suite-enterprise-organization-convention.md`
+- `docs/audit/test-suite-enterprise-architecture-audit.md`
+
+TEST-ARCH-16 marco como `MOVIBLE_SEGURO` este lote:
+
+- `test/admin-auth.fastify.test.ts`
+- `test/auth.fastify.test.ts`
+
+## Archivos movidos
+
+| Origen | Destino |
+|---|---|
+| `test/admin-auth.fastify.test.ts` | `test/integration/adapters/controllers/admin-auth.fastify.test.ts` |
+| `test/auth.fastify.test.ts` | `test/integration/adapters/controllers/auth.fastify.test.ts` |
+
+## Imports ajustados
+
+Se ajustaron solo imports relativos desde `../server/**` a
+`../../../../server/**` en los 2 archivos movidos.
+
+| Archivo | Imports ajustados |
+|---|---|
+| `test/integration/adapters/controllers/admin-auth.fastify.test.ts` | `../../../../server/lib/env.ts`; `../../../../server/lib/audit.ts`; `../../../../server/lib/login-rate-limit.ts`; `../../../../server/routes/admin-auth.fastify.ts` |
+| `test/integration/adapters/controllers/auth.fastify.test.ts` | `../../../../server/lib/env.ts`; `../../../../server/lib/audit.ts`; `../../../../server/lib/login-rate-limit.ts`; `../../../../server/lib/rate-limit-store.ts`; `../../../../server/lib/permissions.ts`; `../../../../server/routes/auth.fastify.ts`; `../../../../server/lib/auth-security.ts` |
+
+No se cambiaron assertions funcionales ni logica de tests.
+
+## Anchors/path references actualizados
+
+Se actualizaron los anchors exactos necesarios:
+
+| Archivo | Paths actualizados |
+|---|---|
+| `test/security-critical-route-surface-registry.test.ts` | `test/auth.fastify.test.ts` -> `test/integration/adapters/controllers/auth.fastify.test.ts`; `test/admin-auth.fastify.test.ts` -> `test/integration/adapters/controllers/admin-auth.fastify.test.ts` |
+| `test/security-boundary-suite-completeness.test.ts` | `test/auth.fastify.test.ts` -> `test/integration/adapters/controllers/auth.fastify.test.ts`; `test/admin-auth.fastify.test.ts` -> `test/integration/adapters/controllers/admin-auth.fastify.test.ts` |
+
+Referencias legacy detectadas y no editadas por no ser anchors exactos
+necesarios para este move:
+
+- `test/security-session-cookie-boundaries.test.ts`
+- Documentacion historica bajo `docs/**`
+
+`security-session-cookie-boundaries` usa fallback recursivo por basename y
+TEST-ARCH-16 lo clasifico como subdirectory-aware.
+
+## Archivos explicitamente excluidos
+
+No se movio `particular-auth.fastify.test.ts`.
+
+No se movieron tokens:
+
+- `test/admin-particular-tokens.fastify.test.ts`
+- `test/admin-report-access-tokens.fastify.test.ts`
+- `test/particular-tokens.fastify.test.ts`
+- `test/report-access-tokens.fastify.test.ts`
+
+No se movieron public/storage:
+
+- `test/clinic-public-profile.fastify.test.ts`
+- `test/public-professionals.fastify.test.ts`
+- `test/public-report-access.fastify.test.ts`
+
+No se movio report-access fuera de los tokens explicitamente excluidos.
+
+No se movieron archivos `BLOQUEADO_POR_ANCHOR`:
+
+- `test/admin-reports.fastify.test.ts`
+- `test/reports.fastify.test.ts`
+- `test/reports-status.fastify.test.ts`
+
+No se movieron tests no `*.fastify.test.ts`.
+
+## Validaciones ejecutadas
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. Muestra deletes legacy y cambios en 2 guards; los archivos nuevos quedan untracked hasta stage manual. |
+| `git diff --name-only` | OK. Lista los 2 origenes legacy removidos y 2 guards modificados; los archivos nuevos quedan untracked hasta stage manual. |
+| `git status --short --untracked-files=all` | OK. Muestra 2 deletes, 2 guards modificados, 2 destinos nuevos y este reporte nuevo. |
+| `pnpm test` | Fallo antes del runner por shim no interactivo: `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | OK: 2983 pass, 0 fail. |
+| `pnpm build` | Fallo antes del build por shim no interactivo: `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | OK: `dist\index.js 838.3kb`. |
+| `pnpm security:public-surface` | Fallo antes del script por shim no interactivo: `ERR_PNPM_ABORTED_REMOVE_MODULES_DIR_NO_TTY`. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | PASS: no public devtools exposure findings; conserva findings `server-only` esperados en `frontend/src/proxy.ts` para `CLINIC_SESSION_COOKIE_NAME` y `ADMIN_SESSION_COOKIE_NAME`. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' --dir frontend lint` | OK. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' --dir frontend typecheck` | Fallo inicial por artefacto `.next/types/validator.ts`: no encontraba `./routes.js`. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' --dir frontend build` | OK: Next.js 16.2.7 compilo y genero 25 paginas estaticas. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' --dir frontend typecheck` | OK en reintento posterior al build. |
+
+## Riesgo residual
+
+Riesgo bajo. El runner descubre subdirectorios con `test/**/*.test.ts`, y los
+imports relativos fueron ajustados a la profundidad nueva.
+
+Quedan referencias legacy documentales o subdirectory-aware fuera del scope de
+este lote. No deberian bloquear `pnpm test` y no se editaron para evitar churn no
+necesario.
+
+## Recomendacion para TEST-ARCH-19
+
+Mantener lotes pequenos por dominio. Candidato recomendado: seleccionar otro
+grupo `MOVIBLE_SEGURO` distinto de particular-auth, tokens, public/storage,
+report-access y el subtrio reports bloqueado, o hacer primero una auditoria
+minima si el proximo lote requiere tocar anchors adicionales.
+
+No mover todavia:
+
+- `test/admin-reports.fastify.test.ts`
+- `test/reports.fastify.test.ts`
+- `test/reports-status.fastify.test.ts`
+
+Antes de mover reports, corregir o hacer path-aware
+`test/report-study-types-catalog.test.ts`.
+
+## Confirmacion de scope
+
+Scope incluido:
+
+- Move fisico de los 2 controller tests auth core autorizados.
+- Ajuste mecanico de imports relativos en los 2 archivos movidos.
+- Actualizacion de anchors/path references autorizados.
+- Reporte Markdown obligatorio en `docs/implementation/`.
+
+Scope excluido y respetado:
+
+- No runtime.
+- No producto.
+- No backend productivo.
+- No DB/schema/migrations.
+- No CI/workflows.
+- No dependencias.
+- No `package.json`.
+- No `pnpm-lock.yaml`.
+- No stashes.
+- No `.claude/worktrees`.
+- No `rg`.
+- No `git add`, `git commit`, `git push`, `gh pr create` ni `gh pr merge`.

--- a/test/integration/adapters/controllers/admin-auth.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-auth.fastify.test.ts
@@ -9,16 +9,16 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
-const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
+const { AUDIT_EVENTS } = await import("../../../../server/lib/audit.ts");
 const {
   LOGIN_RATE_LIMIT_CODE,
   LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
-} = await import("../server/lib/login-rate-limit.ts");
+} = await import("../../../../server/lib/login-rate-limit.ts");
 const {
   adminAuthNativeRoutes,
-} = await import("../server/routes/admin-auth.fastify.ts");
+} = await import("../../../../server/routes/admin-auth.fastify.ts");
 
 async function createTestApp(overrides: Record<string, unknown> = {}) {
   const app = Fastify();

--- a/test/integration/adapters/controllers/auth.fastify.test.ts
+++ b/test/integration/adapters/controllers/auth.fastify.test.ts
@@ -9,24 +9,24 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
-const { AUDIT_EVENTS } = await import("../server/lib/audit.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
+const { AUDIT_EVENTS } = await import("../../../../server/lib/audit.ts");
 const {
   buildLoginRateLimitKey,
   LOGIN_RATE_LIMIT_CODE,
   LOGIN_RATE_LIMIT_EXPOSED_HEADERS,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
-} = await import("../server/lib/login-rate-limit.ts");
+} = await import("../../../../server/lib/login-rate-limit.ts");
 const {
   createPersistentRateLimitStore,
   hashRateLimitKey,
-} = await import("../server/lib/rate-limit-store.ts");
+} = await import("../../../../server/lib/rate-limit-store.ts");
 const {
   getClinicPermissions,
-} = await import("../server/lib/permissions.ts");
+} = await import("../../../../server/lib/permissions.ts");
 const {
   clinicAuthNativeRoutes,
-} = await import("../server/routes/auth.fastify.ts");
+} = await import("../../../../server/routes/auth.fastify.ts");
 
 async function createTestApp(overrides: Record<string, unknown> = {}) {
   const app = Fastify();
@@ -1824,7 +1824,7 @@ test(
   "clinicAuthNativeRoutes clínica registrada con hash argon2 puede iniciar sesión",
   async () => {
     const { hashPassword, verifyPassword } = await import(
-      "../server/lib/auth-security.ts"
+      "../../../../server/lib/auth-security.ts"
     );
 
     const storedHash = await hashPassword("clave-inicial-segura");
@@ -1899,7 +1899,7 @@ test(
   "clinicAuthNativeRoutes password incorrecto rechaza clínica registrada",
   async () => {
     const { hashPassword, verifyPassword } = await import(
-      "../server/lib/auth-security.ts"
+      "../../../../server/lib/auth-security.ts"
     );
 
     const storedHash = await hashPassword("clave-correcta-123");

--- a/test/security-boundary-suite-completeness.test.ts
+++ b/test/security-boundary-suite-completeness.test.ts
@@ -626,11 +626,11 @@ test("security boundary guardrails remain connected to runtime anchors", () => {
 test("security boundary suite keeps required downstream runtime tests explicit", () => {
   const requiredRuntimeTests = [
     {
-      path: "test/auth.fastify.test.ts",
+      path: "test/integration/adapters/controllers/auth.fastify.test.ts",
       marker: "clinicAuthNativeRoutes bloquea login con origin no permitido",
     },
     {
-      path: "test/admin-auth.fastify.test.ts",
+      path: "test/integration/adapters/controllers/admin-auth.fastify.test.ts",
       marker: "adminAuthNativeRoutes aplica rate limit de login sobre intentos fallidos",
     },
     {

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -286,14 +286,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
     ],
     guardrailTests: [
       {
-        path: "test/auth.fastify.test.ts",
+        path: "test/integration/adapters/controllers/auth.fastify.test.ts",
         markers: [
           "clinicAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar",
           "clinicAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido",
         ],
       },
       {
-        path: "test/admin-auth.fastify.test.ts",
+        path: "test/integration/adapters/controllers/admin-auth.fastify.test.ts",
         markers: [
           "adminAuthNativeRoutes responde preflight OPTIONS permitido sin autenticar",
           "adminAuthNativeRoutes bloquea preflight OPTIONS con origin no permitido",


### PR DESCRIPTION
## Summary
- move TEST-ARCH-16 confirmed auth core controller batch
- relocate admin-auth and auth Fastify controller tests to test/integration/adapters/controllers
- adjust mechanical server import depth and required path anchors
- document selected/excluded candidates for next batch

## Scope
- test physical organization only
- no runtime/product/DB/CI/deps/lockfile changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface