### PR TITLE
test(architecture): move reports controller tests

### DIFF
--- a/docs/implementation/test-arch-22-controller-reports-trio-unlock-move.md
+++ b/docs/implementation/test-arch-22-controller-reports-trio-unlock-move.md
@@ -1,0 +1,174 @@
+# TEST-ARCH-22 - Controller reports trio unlock move
+
+## Resumen ejecutivo
+
+TEST-ARCH-22 desbloqueo y movio fisicamente el trio reports controller que
+TEST-ARCH-16 habia clasificado como `BLOQUEADO_POR_ANCHOR`.
+
+El cambio fue mecanico y limitado:
+
+- move de 3 `*.fastify.test.ts` a `test/integration/adapters/controllers/`
+- ajuste de imports relativos `../server/**` -> `../../../../server/**`
+- actualizacion path-only del catalogo bloqueante
+- actualizacion path-only de anchors exactos en guards de reports, storage y critical route
+- sin cambios de runtime, producto, backend productivo, DB, schema, migraciones, CI, dependencias, `package.json` ni `pnpm-lock.yaml`
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Entorno | Windows, PowerShell, PNPM |
+| Rama esperada | `test/controller-reports-trio-unlock-move` |
+| Rama observada | `test/controller-reports-trio-unlock-move` |
+| HEAD observado | `66e2d7c test(architecture): move remaining safe controller tests (#1328)` |
+| Working tree inicial | Limpio (`git status --short --untracked-files=all` sin salida). |
+| `git diff --stat` inicial | Sin salida. |
+
+## Fuente de verdad usada
+
+Fuente obligatoria:
+
+- `docs/implementation/test-arch-16-controller-post-unlock-inventory.md`
+
+Lectura aplicada:
+
+- Los 3 archivos estaban bloqueados por `test/report-study-types-catalog.test.ts`.
+- El catalogo tenia paths hardcodeados y `assert.deepEqual`.
+- Los imports de los 3 tests eran relativos simples a `../server/**`.
+- El destino enterprise es `test/integration/adapters/controllers/`.
+
+## Scope incluido
+
+Se movieron unicamente:
+
+| Origen | Destino |
+|---|---|
+| `test/admin-reports.fastify.test.ts` | `test/integration/adapters/controllers/admin-reports.fastify.test.ts` |
+| `test/reports.fastify.test.ts` | `test/integration/adapters/controllers/reports.fastify.test.ts` |
+| `test/reports-status.fastify.test.ts` | `test/integration/adapters/controllers/reports-status.fastify.test.ts` |
+
+## Scope excluido
+
+No se movio ningun otro test.
+
+No se tocaron:
+
+- runtime
+- producto
+- backend productivo
+- DB
+- schema
+- migraciones
+- CI/workflows
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+- auth estructural
+- cookies
+- CORS
+- CSP
+- rate limits
+
+No se usaron stashes, `.claude/worktrees`, `rg`, `git add`, `git commit`, `git push`, PR ni merge.
+
+## Auditoria previa
+
+Comandos de base ejecutados desde Terminal 1:
+
+```powershell
+git status --short --untracked-files=all
+git branch --show-current
+git log -1 --oneline
+git diff --stat
+```
+
+Verificaciones:
+
+- La rama activa coincidia con la esperada.
+- La base estaba limpia.
+- El destino `test/integration/adapters/controllers/` existia.
+- Los 3 archivos legacy existian antes del move.
+- `docs/implementation/test-arch-16-controller-post-unlock-inventory.md` existia y confirmaba el bloqueo.
+- `package.json` exponia los scripts requeridos: `test`, `build` y `security:public-surface`.
+
+Se buscaron referencias legacy con PowerShell `Select-String`, sin `rg`.
+
+## Cambios realizados
+
+### Moves
+
+Se movieron los 3 controller tests al destino enterprise.
+
+### Imports
+
+En los 3 archivos movidos se ajustaron solo imports relativos:
+
+- `../server/lib/env.ts` -> `../../../../server/lib/env.ts`
+- `../server/routes/admin-reports.fastify.ts` -> `../../../../server/routes/admin-reports.fastify.ts`
+- `../server/routes/reports.fastify.ts` -> `../../../../server/routes/reports.fastify.ts`
+- `../server/routes/reports-status.fastify.ts` -> `../../../../server/routes/reports-status.fastify.ts`
+
+### Catalogo bloqueante
+
+Se actualizo `test/report-study-types-catalog.test.ts` para que el filtro y el
+`assert.deepEqual` esperen los nuevos paths.
+
+Durante la primera validacion, `pnpm test` fallo solo por el orden esperado del
+`assert.deepEqual` despues del cambio de profundidad. Se corrigio el orden para
+coincidir con el sort real de `listSourceFiles("test").filter(...).sort()`.
+
+### Anchors exactos
+
+Se actualizaron paths exactos en:
+
+- `test/reports-suite-completeness.test.ts`
+- `test/storage-suite-completeness.test.ts`
+- `test/security-critical-route-surface-registry.test.ts`
+
+No se editaron guards secundarios que ya resuelven por basename/path-aware y no
+fallaron en validacion.
+
+## Archivos modificados
+
+- `docs/implementation/test-arch-22-controller-reports-trio-unlock-move.md`
+- `test/integration/adapters/controllers/admin-reports.fastify.test.ts`
+- `test/integration/adapters/controllers/reports.fastify.test.ts`
+- `test/integration/adapters/controllers/reports-status.fastify.test.ts`
+- `test/report-study-types-catalog.test.ts`
+- `test/reports-suite-completeness.test.ts`
+- `test/storage-suite-completeness.test.ts`
+- `test/security-critical-route-surface-registry.test.ts`
+
+## Validaciones
+
+| Comando | Resultado |
+|---|---|
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | Primer intento fallo por orden esperado del catalogo; segundo intento OK: 2983 pass, 0 fail. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | OK: `dist\index.js 838.3kb`. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | PASS: no public devtools exposure findings; conserva findings `server-only` esperados en `frontend/src/proxy.ts` para `CLINIC_SESSION_COOKIE_NAME` y `ADMIN_SESSION_COOKIE_NAME`. |
+
+Validaciones finales de diff/status quedan registradas al cierre de la tarea:
+
+```powershell
+git diff --check
+git diff --stat
+git diff --name-only
+git status --short --untracked-files=all
+```
+
+## Resultado
+
+El trio reports controller quedo desbloqueado y movido al destino enterprise.
+El catalogo bloqueante ahora espera los nuevos paths y mantiene cobertura sobre
+los mismos archivos criticos.
+
+## Riesgo residual
+
+Riesgo bajo. El cambio no toca runtime ni assertions funcionales. El riesgo
+principal era el orden del catalogo por paths mas profundos; quedo cubierto por
+`pnpm test`.
+
+## Estado final
+
+Pendiente solo stage/commit/push/PR manual por Nico.

--- a/test/integration/adapters/controllers/admin-reports.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-reports.fastify.test.ts
@@ -9,10 +9,10 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const {
   adminReportsNativeRoutes,
-} = await import("../server/routes/admin-reports.fastify.ts");
+} = await import("../../../../server/routes/admin-reports.fastify.ts");
 
 function createReportFixture(overrides: Record<string, unknown> = {}) {
   return {

--- a/test/integration/adapters/controllers/reports-status.fastify.test.ts
+++ b/test/integration/adapters/controllers/reports-status.fastify.test.ts
@@ -9,9 +9,9 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { reportsStatusNativeRoutes } = await import(
-  "../server/routes/reports-status.fastify.ts"
+  "../../../../server/routes/reports-status.fastify.ts"
 );
 
 function createReportFixture(overrides: Record<string, unknown> = {}) {

--- a/test/integration/adapters/controllers/reports.fastify.test.ts
+++ b/test/integration/adapters/controllers/reports.fastify.test.ts
@@ -9,8 +9,8 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
-const { reportsNativeRoutes } = await import("../server/routes/reports.fastify.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
+const { reportsNativeRoutes } = await import("../../../../server/routes/reports.fastify.ts");
 
 function createReportFixture(overrides: Record<string, unknown> = {}) {
   return {

--- a/test/report-study-types-catalog.test.ts
+++ b/test/report-study-types-catalog.test.ts
@@ -139,20 +139,20 @@ test("DB exposes study types from catalog and not persisted free-text values", (
 test("critical report tests stop using free-text or abbreviated studyType", () => {
   const criticalTestFiles = listSourceFiles("test").filter((file) =>
     [
-      "test/admin-reports.fastify.test.ts",
-      "test/reports.fastify.test.ts",
+      "test/integration/adapters/controllers/admin-reports.fastify.test.ts",
+      "test/integration/adapters/controllers/reports.fastify.test.ts",
       "test/report-write-surface-ownership.test.ts",
-      "test/reports-status.fastify.test.ts",
+      "test/integration/adapters/controllers/reports-status.fastify.test.ts",
     ].includes(file),
   );
 
   assert.deepEqual(
     criticalTestFiles,
     [
-      "test/admin-reports.fastify.test.ts",
+      "test/integration/adapters/controllers/admin-reports.fastify.test.ts",
+      "test/integration/adapters/controllers/reports-status.fastify.test.ts",
+      "test/integration/adapters/controllers/reports.fastify.test.ts",
       "test/report-write-surface-ownership.test.ts",
-      "test/reports-status.fastify.test.ts",
-      "test/reports.fastify.test.ts",
     ],
   );
 

--- a/test/reports-suite-completeness.test.ts
+++ b/test/reports-suite-completeness.test.ts
@@ -34,7 +34,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
         ],
       },
       {
-        path: "test/admin-reports.fastify.test.ts",
+        path: "test/integration/adapters/controllers/admin-reports.fastify.test.ts",
         markers: [
           "adminReportsNativeRoutes crea POST /upload",
           "requiere clinicId valido antes de storage",
@@ -65,7 +65,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       "Clinic reports stay read-only with list, search, study types, history, preview and download routes only.",
     testFiles: [
       {
-        path: "test/reports.fastify.test.ts",
+        path: "test/integration/adapters/controllers/reports.fastify.test.ts",
         markers: [
           "reportsNativeRoutes no registra POST /upload",
           "reportsNativeRoutes expone GET / con lista",
@@ -99,7 +99,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       "Report status mutation keeps trusted origin, clinic session, management permission, transition validation and audit logging.",
     testFiles: [
       {
-        path: "test/reports-status.fastify.test.ts",
+        path: "test/integration/adapters/controllers/reports-status.fastify.test.ts",
         markers: [
           "reportsStatusNativeRoutes actualiza PATCH /:reportId/status",
           "bloquea PATCH /:reportId/status sin management permission",

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -329,7 +329,7 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         ],
       },
       {
-        path: "test/reports.fastify.test.ts",
+        path: "test/integration/adapters/controllers/reports.fastify.test.ts",
         markers: [
           "reportsNativeRoutes responde preflight OPTIONS para superficie clinic read-only sin autenticar",
           "reportsNativeRoutes no anuncia POST /upload en preflight clinic",

--- a/test/storage-suite-completeness.test.ts
+++ b/test/storage-suite-completeness.test.ts
@@ -165,7 +165,7 @@ const STORAGE_SUITE: readonly StorageSuiteEntry[] = [
       "Admin report upload and clinic public profile avatar routes keep storage helpers injectable and ordered around persistence.",
     testFiles: [
       {
-        path: "test/admin-reports.fastify.test.ts",
+        path: "test/integration/adapters/controllers/admin-reports.fastify.test.ts",
         markers: [
           "adminReportsNativeRoutes crea POST /upload",
           "requiere clinicId valido antes de storage",


### PR DESCRIPTION
## Summary
- unlock report-study-types catalog path anchors
- move the remaining reports Fastify controller trio
- update required reports/storage/security path anchors
- complete controller Fastify migration to test/integration/adapters/controllers

## Scope
- test physical organization only
- no runtime/product/DB/CI/deps/lockfile changes

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface