### PR TITLE
docs(test): close controller fastify migration

### DIFF
--- a/docs/implementation/test-arch-23-controller-fastify-migration-closeout.md
+++ b/docs/implementation/test-arch-23-controller-fastify-migration-closeout.md
@@ -1,0 +1,95 @@
+# TEST-ARCH-23 - Controller Fastify migration closeout
+
+## Resumen ejecutivo
+
+TEST-ARCH-23 cierra documentalmente la migracion controller-fastify del bloque TEST-ARCH.
+
+El objetivo fue ordenar fisicamente todos los tests `*.fastify.test.ts` bajo la estructura enterprise:
+
+- `test/integration/adapters/controllers/`
+
+El cierre se realiza despues de TEST-ARCH-22, que movio el trio reports restante y desbloqueo `test/report-study-types-catalog.test.ts`.
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base | `59cb588 test(architecture): move reports controller tests (#1329)` |
+| Working tree inicial | Limpio |
+| PRs abiertos | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## PRs incluidos en el cierre controller-fastify
+
+| PR | Descripcion |
+|---|---|
+| #1323 | Inventario post-unlock controller. |
+| #1324 | Move study-tracking controller tests. |
+| #1325 | Move auth core controller tests. |
+| #1326 | Move public/storage controller tests. |
+| #1327 | Move admin token controller tests. |
+| #1328 | Move remaining safe controller tests. |
+| #1329 | Unlock catalog and move reports controller tests. |
+
+## Resultado estructural
+
+Estado esperado al cierre:
+
+- No quedan controller `*.fastify.test.ts` legacy en `test/` raiz.
+- Los 29 controller Fastify detectados quedan bajo `test/integration/adapters/controllers/`.
+- Los guards y registries con anchors exactos fueron actualizados en los PRs de move correspondientes.
+- `report-study-types-catalog.test.ts` fue desbloqueado en TEST-ARCH-22 para aceptar los nuevos paths del trio reports.
+
+## Validaciones de cierre
+
+Pendiente completar antes del commit:
+
+| Comando | Resultado |
+|---|---|
+| Root `*.fastify.test.ts` check | OK: sin `*.fastify.test.ts` en `test/` raiz. |
+| Controller Fastify count | OK: 29 archivos `*.fastify.test.ts` en `test/integration/adapters/controllers/`. |
+| `git diff --check` | OK, sin salida. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | OK: 2983 pass / 0 fail. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | OK. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | PASS: no public devtools exposure findings. |
+
+## Scope confirmado
+
+El bloque controller-fastify no modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+El trabajo fue limitado a organizacion fisica de tests, imports relativos mecanicos, guards/anchors de test y documentacion de implementacion.
+
+## Riesgo residual
+
+Riesgo bajo para controller-fastify: el patron de movimiento fue validado por tests locales y CI en lotes sucesivos.
+
+Riesgo pendiente fuera de este closeout:
+
+- Existen tests HTTP/API request-injection no `*.fastify.test.ts` que no fueron parte de este cierre.
+- Esos tests requieren auditoria separada antes de cualquier reorganizacion global adicional.
+- No iniciar ese bloque hasta planificar un enfoque manual de bajo consumo.
+
+## Proximo paso recomendado
+
+No iniciar otro bloque grande inmediatamente.
+
+Recomendacion:
+
+1. Mergear este closeout docs-only.
+2. Mantener `main` limpio.
+3. Pausar reorganizacion global adicional.
+4. Definir despues un inventario manual de tests no-fastify, sin Codex ni Claude.
+
+## Confirmacion final
+
+TEST-ARCH controller-fastify queda cerrado documentalmente con main limpio esperado despues de mergear este PR.


### PR DESCRIPTION
## Summary
- close TEST-ARCH controller-fastify migration
- document completed moves through PR #1329
- confirm all Fastify controller tests now live under test/integration/adapters/controllers
- mark non-fastify HTTP/API tests as future separate inventory

## Scope
- docs-only
- no runtime/product/DB/CI/deps/lockfile changes

## Validation
- root fastify tests check
- controller fastify count
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface