### PR TITLE
test(architecture): move pricing http api tests

### DIFF
--- a/docs/implementation/test-arch-25-pricing-http-api-batch.md
+++ b/docs/implementation/test-arch-25-pricing-http-api-batch.md
@@ -1,0 +1,100 @@
+# TEST-ARCH-25 - Pricing HTTP/API batch
+
+## Resumen ejecutivo
+
+TEST-ARCH-25 mueve manualmente el lote pricing HTTP/API identificado por TEST-ARCH-24.
+
+El lote es chico y homogeneo:
+
+- `test/admin-pricing-api.test.ts`
+- `test/public-pricing-api.test.ts`
+
+Ambos usan request injection / `app.inject()` y validan rutas backend expuestas. Se reubican bajo:
+
+- `test/integration/adapters/controllers/`
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base | `a523f70 docs(test): inventory non fastify http api tests (#1331)` |
+| Rama de trabajo | `test/pricing-http-api-batch` |
+| Working tree inicial | Limpio |
+| PRs abiertos | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## Fuente de verdad
+
+- `docs/implementation/test-arch-24-non-fastify-http-api-test-inventory.md`
+
+## Archivos movidos
+
+| Origen | Destino |
+|---|---|
+| `test/admin-pricing-api.test.ts` | `test/integration/adapters/controllers/admin-pricing-api.test.ts` |
+| `test/public-pricing-api.test.ts` | `test/integration/adapters/controllers/public-pricing-api.test.ts` |
+
+## Imports ajustados
+
+Se ajustaron imports relativos mecanicos por nueva profundidad en `admin-pricing-api.test.ts`:
+
+- `../server/lib/env.ts` -> `../../../../server/lib/env.ts`
+- `../server/lib/public-pricing-cache.ts` -> `../../../../server/lib/public-pricing-cache.ts`
+- `../server/db-pricing.ts` -> `../../../../server/db-pricing.ts`
+
+`public-pricing-api.test.ts` no tenia imports relativos detectados en la revision previa.
+
+## Anchors/path references
+
+Se revisaron referencias a paths antiguos en:
+
+- `test/`
+- `docs/`
+- `scripts/`
+
+Resultado:
+
+- no hay anchors activos en `test/**`
+- solo hay referencias historicas/documentales en inventarios previos y `docs/pr-history`
+- no se modificaron docs historicos
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Pendiente completar antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado a lote pricing y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | OK: 2983 pass / 0 fail. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | OK. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | PASS: no public devtools exposure findings. |
+
+## Recomendacion para TEST-ARCH-26
+
+Mover el lote logistics runtime si TEST-ARCH-25 queda verde:
+
+- `test/logistics-audit-runtime.test.ts`
+- `test/logistics-route-plans-cache-runtime.test.ts`
+- `test/logistics-route-plans-heuristic-runtime.test.ts`
+- `test/logistics-route-plans-metrics-runtime.test.ts`
+
+Mantener `test/fastify-app.test.ts` diferido.

--- a/test/integration/adapters/controllers/admin-pricing-api.test.ts
+++ b/test/integration/adapters/controllers/admin-pricing-api.test.ts
@@ -9,20 +9,20 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { adminPricingNativeRoutes } = await import(
-  "../server/routes/admin-pricing.fastify.ts"
+  "../../../../server/routes/admin-pricing.fastify.ts"
 );
 const {
   clearPublicPricingCache,
   getCachedPublicPricingSnapshot,
   setCachedPublicPricingSnapshot,
-} = await import("../server/lib/public-pricing-cache.ts");
+} = await import("../../../../server/lib/public-pricing-cache.ts");
 
 type AdminPricingNativeRoutesOptions = import(
-  "../server/routes/admin-pricing.fastify.ts"
+  "../../../../server/routes/admin-pricing.fastify.ts"
 ).AdminPricingNativeRoutesOptions;
-type PricingItem = import("../server/db-pricing.ts").PricingItem;
+type PricingItem = import("../../../../server/db-pricing.ts").PricingItem;
 
 function createPricingItem(overrides: Record<string, unknown> = {}): PricingItem {
   return {

--- a/test/integration/adapters/controllers/public-pricing-api.test.ts
+++ b/test/integration/adapters/controllers/public-pricing-api.test.ts
@@ -3,14 +3,14 @@ import test from "node:test";
 import Fastify from "fastify";
 
 const { publicPricingNativeRoutes } = await import(
-  "../server/routes/public-pricing.fastify.ts"
+  "../../../../server/routes/public-pricing.fastify.ts"
 );
 const { clearPublicPricingCache } = await import(
-  "../server/lib/public-pricing-cache.ts"
+  "../../../../server/lib/public-pricing-cache.ts"
 );
 
 type PublicPricingNativeRoutesOptions = import(
-  "../server/routes/public-pricing.fastify.ts"
+  "../../../../server/routes/public-pricing.fastify.ts"
 ).PublicPricingNativeRoutesOptions;
 
 function createPricingItem(overrides: Record<string, unknown> = {}) {


### PR DESCRIPTION
## Summary
- move pricing HTTP/API request-injection tests
- relocate admin-pricing-api and public-pricing-api under test/integration/adapters/controllers
- adjust mechanical relative imports
- document manual-only execution

## Scope
- test physical organization only
- no runtime/product/DB/CI/deps/lockfile changes
- no Codex or Claude used

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface