### PR TITLE
test(architecture): move logistics runtime http api tests

### DIFF
--- a/docs/implementation/test-arch-26-logistics-runtime-http-api-batch.md
+++ b/docs/implementation/test-arch-26-logistics-runtime-http-api-batch.md
@@ -1,0 +1,102 @@
+# TEST-ARCH-26 - Logistics runtime HTTP/API batch
+
+## Resumen ejecutivo
+
+TEST-ARCH-26 mueve manualmente el lote logistics runtime HTTP/API identificado por TEST-ARCH-24.
+
+El lote es homogeneo:
+
+- `test/logistics-audit-runtime.test.ts`
+- `test/logistics-route-plans-cache-runtime.test.ts`
+- `test/logistics-route-plans-heuristic-runtime.test.ts`
+- `test/logistics-route-plans-metrics-runtime.test.ts`
+
+Los archivos usan request injection / `app.inject()` y validan rutas runtime de logistics. Se reubican bajo:
+
+- `test/integration/adapters/controllers/`
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base | `47328f7 test(architecture): move pricing http api tests (#1332)` |
+| Rama de trabajo | `test/logistics-runtime-http-api-batch` |
+| Working tree inicial | Limpio |
+| PRs abiertos | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## Fuente de verdad
+
+- `docs/implementation/test-arch-24-non-fastify-http-api-test-inventory.md`
+
+## Archivos movidos
+
+| Origen | Destino |
+|---|---|
+| `test/logistics-audit-runtime.test.ts` | `test/integration/adapters/controllers/logistics-audit-runtime.test.ts` |
+| `test/logistics-route-plans-cache-runtime.test.ts` | `test/integration/adapters/controllers/logistics-route-plans-cache-runtime.test.ts` |
+| `test/logistics-route-plans-heuristic-runtime.test.ts` | `test/integration/adapters/controllers/logistics-route-plans-heuristic-runtime.test.ts` |
+| `test/logistics-route-plans-metrics-runtime.test.ts` | `test/integration/adapters/controllers/logistics-route-plans-metrics-runtime.test.ts` |
+
+## Imports ajustados
+
+Se ajustaron imports relativos mecanicos por nueva profundidad:
+
+- `../server/db-logistics.ts` -> `../../../../server/db-logistics.ts`
+- `../server/lib/env.ts` -> `../../../../server/lib/env.ts`
+- `../server/lib/audit.ts` -> `../../../../server/lib/audit.ts`
+- `../server/lib/logistics-route-plans-cache.ts` -> `../../../../server/lib/logistics-route-plans-cache.ts`
+
+## Anchors/path references
+
+Se revisaron referencias a paths antiguos en:
+
+- `test/`
+- `docs/`
+- `scripts/`
+
+Anchor activo actualizado:
+
+- `test/audit-suite-completeness.test.ts`
+  - `test/logistics-audit-runtime.test.ts`
+  - `test/integration/adapters/controllers/logistics-audit-runtime.test.ts`
+
+Referencias historicas en documentacion previa no requieren cambio.
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Pendiente completar antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado a lote logistics y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | OK: 2983 pass / 0 fail. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | OK. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | PASS: no public devtools exposure findings. |
+
+## Recomendacion para TEST-ARCH-27
+
+Mover un lote API contract/error/observability, dejando diferido:
+
+- `test/fastify-app.test.ts`
+- rate-limit group
+- public-professionals invariant group

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -388,7 +388,7 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         ],
       },
       {
-        path: "test/logistics-audit-runtime.test.ts",
+        path: "test/integration/adapters/controllers/logistics-audit-runtime.test.ts",
         markers: [
           "logistics route plan lifecycle runtime writes audit metadata",
           "logistics route events runtime writes audit metadata",

--- a/test/integration/adapters/controllers/logistics-audit-runtime.test.ts
+++ b/test/integration/adapters/controllers/logistics-audit-runtime.test.ts
@@ -9,7 +9,7 @@ import type {
   RoutePlan,
   RoutePlanLifecycleAction,
   RouteStop,
-} from "../server/db-logistics.ts";
+} from "../../../../server/db-logistics.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -18,14 +18,14 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { logisticsRoutePlansNativeRoutes } = await import(
-  "../server/routes/logistics-route-plans.fastify.ts"
+  "../../../../server/routes/logistics-route-plans.fastify.ts"
 );
 const { logisticsRouteEventsNativeRoutes } = await import(
-  "../server/routes/logistics-route-events.fastify.ts"
+  "../../../../server/routes/logistics-route-events.fastify.ts"
 );
-const { createWriteAuditLog } = await import("../server/lib/audit.ts");
+const { createWriteAuditLog } = await import("../../../../server/lib/audit.ts");
 
 const VALID_ORIGIN = "http://localhost:3000";
 const SESSION_TOKEN = "clinic-session-token";

--- a/test/integration/adapters/controllers/logistics-route-plans-cache-runtime.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-plans-cache-runtime.test.ts
@@ -9,14 +9,14 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { logisticsRoutePlansNativeRoutes } = await import(
-  "../server/routes/logistics-route-plans.fastify.ts"
+  "../../../../server/routes/logistics-route-plans.fastify.ts"
 );
 const {
   clearRoutePlanMetricsCache,
   clearRoutePlansCache,
-} = await import("../server/lib/logistics-route-plans-cache.ts");
+} = await import("../../../../server/lib/logistics-route-plans-cache.ts");
 
 const VALID_ORIGIN = "http://localhost:3000";
 const SESSION_TOKEN = "clinic-session-token";

--- a/test/integration/adapters/controllers/logistics-route-plans-heuristic-runtime.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-plans-heuristic-runtime.test.ts
@@ -8,7 +8,7 @@ import type {
   GenerateHeuristicRoutePlanResult,
   RoutePlan,
   RouteStop,
-} from "../server/db-logistics.ts";
+} from "../../../../server/db-logistics.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -17,9 +17,9 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { logisticsRoutePlansNativeRoutes } = await import(
-  "../server/routes/logistics-route-plans.fastify.ts"
+  "../../../../server/routes/logistics-route-plans.fastify.ts"
 );
 
 const VALID_ORIGIN = "http://localhost:3000";

--- a/test/integration/adapters/controllers/logistics-route-plans-metrics-runtime.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-plans-metrics-runtime.test.ts
@@ -8,7 +8,7 @@ import type {
   GenerateHeuristicRoutePlanResult,
   RoutePlan,
   RouteStop,
-} from "../server/db-logistics.ts";
+} from "../../../../server/db-logistics.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -17,9 +17,9 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../../server/lib/env.ts");
 const { logisticsRoutePlansNativeRoutes } = await import(
-  "../server/routes/logistics-route-plans.fastify.ts"
+  "../../../../server/routes/logistics-route-plans.fastify.ts"
 );
 
 const VALID_ORIGIN = "http://localhost:3000";


### PR DESCRIPTION
## Summary
- move logistics runtime HTTP/API request-injection tests
- relocate logistics audit, route-plans cache, heuristic, and metrics tests
- adjust mechanical relative imports and active test anchors
- document manual-only execution

## Scope
- test physical organization only
- no runtime/product/DB/CI/deps/lockfile changes
- no Codex or Claude used

## Validation
- git diff --check
- pnpm test
- pnpm build
- pnpm security:public-surface