### PR TITLE
test(architecture): move public professionals invariants

### DIFF
--- a/docs/implementation/test-arch-28-public-professionals-invariants-batch.md
+++ b/docs/implementation/test-arch-28-public-professionals-invariants-batch.md
@@ -1,0 +1,102 @@
+# TEST-ARCH-28 - Public professionals invariants batch
+
+## Resumen ejecutivo
+
+TEST-ARCH-28 mueve manualmente el lote public-professionals invariants identificado por TEST-ARCH-24.
+
+El lote es homogeneo por superficie HTTP/API de profesionales publicos:
+
+- `test/public-professionals-logging-invariants.test.ts`
+- `test/public-professionals-response-headers-invariants.test.ts`
+- `test/public-professionals-route-surface-invariants.test.ts`
+
+Se reubican bajo:
+
+- `test/integration/adapters/controllers/`
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base esperado | `6dd227c test(architecture): move api contract observability tests (#1334)` |
+| Rama de trabajo | `test/public-professionals-invariants-batch` |
+| Working tree inicial | Limpio |
+| PRs abiertos esperados | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## Fuente de verdad
+
+- `docs/implementation/test-arch-24-non-fastify-http-api-test-inventory.md`
+- `docs/implementation/test-arch-27-api-contract-error-observability-batch.md`
+
+## Archivos movidos
+
+| Origen | Destino |
+|---|---|
+| `test/public-professionals-logging-invariants.test.ts` | `test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts` |
+| `test/public-professionals-response-headers-invariants.test.ts` | `test/integration/adapters/controllers/public-professionals-response-headers-invariants.test.ts` |
+| `test/public-professionals-route-surface-invariants.test.ts` | `test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts` |
+
+## Anchors actualizados
+
+Se actualizaron guards activos:
+
+- `test/public-professionals-fixture-adoption-invariants.test.ts`
+- `test/public-professionals-fixture-file-scope-invariants.test.ts`
+- `test/security-critical-route-surface-registry.test.ts`
+- `test/security-rate-limit-isolation-boundaries.test.ts`
+
+Cambios realizados:
+
+- paths antiguos del lote public-professionals -> paths nuevos bajo `test/integration/adapters/controllers/`
+- import esperado de fixture compartido:
+  - `from "./helpers/public-professionals-fixtures.ts"`
+  - `from "../../../helpers/public-professionals-fixtures.ts"`
+
+## Imports ajustados
+
+Se ajustaron imports relativos mecanicos por nueva profundidad:
+
+- `../server/routes/public-professionals.fastify.ts` -> `../../../../server/routes/public-professionals.fastify.ts`
+- `./helpers/public-professionals-fixtures.ts` -> `../../../helpers/public-professionals-fixtures.ts`
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Pendiente completar antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado al lote public-professionals invariants, guards activos y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' typecheck:test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | Pendiente |
+
+## Recomendacion para siguiente lote
+
+Mantener diferidos:
+
+- `test/client-version-gate-contract.test.ts`
+- `test/performance-load-smoke.test.ts`
+- `test/fastify-app.test.ts`
+- rate-limit group
+- security-sensitive groups hasta lote propio

--- a/test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts
+++ b/test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts
@@ -1,11 +1,11 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 import {
   buildPublicProfessionalFixtureRow,
   buildPublicProfessionalsRouteFixtureStubs,
   type PublicProfessionalsRouteFixtureStubs,
-} from "./helpers/public-professionals-fixtures.ts";
+} from "../../../helpers/public-professionals-fixtures.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -15,7 +15,7 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { publicProfessionalsNativeRoutes } = await import(
-  "../server/routes/public-professionals.fastify.ts"
+  "../../../../server/routes/public-professionals.fastify.ts"
 );
 
 async function buildLoggingApp(

--- a/test/integration/adapters/controllers/public-professionals-response-headers-invariants.test.ts
+++ b/test/integration/adapters/controllers/public-professionals-response-headers-invariants.test.ts
@@ -1,9 +1,9 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import Fastify from "fastify";
 import {
   buildPublicProfessionalsRouteFixtureStubs,
-} from "./helpers/public-professionals-fixtures.ts";
+} from "../../../helpers/public-professionals-fixtures.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -13,7 +13,7 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { publicProfessionalsNativeRoutes } = await import(
-  "../server/routes/public-professionals.fastify.ts"
+  "../../../../server/routes/public-professionals.fastify.ts"
 );
 
 const allowedOrigin = "http://localhost:3000";

--- a/test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts
+++ b/test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -6,7 +6,7 @@ import Fastify from "fastify";
 import {
   buildPublicProfessionalFixtureRow,
   buildPublicProfessionalsRouteFixtureStubs,
-} from "./helpers/public-professionals-fixtures.ts";
+} from "../../../helpers/public-professionals-fixtures.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -16,7 +16,7 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { publicProfessionalsNativeRoutes } = await import(
-  "../server/routes/public-professionals.fastify.ts"
+  "../../../../server/routes/public-professionals.fastify.ts"
 );
 
 function readSource(relativePath: string): string {

--- a/test/public-professionals-fixture-adoption-invariants.test.ts
+++ b/test/public-professionals-fixture-adoption-invariants.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -10,13 +10,16 @@ function readSource(relativePath: string): string {
   );
 }
 
+const MOVED_PUBLIC_PROFESSIONALS_FIXTURE_IMPORT =
+  "../../../helpers/public-professionals-fixtures.ts";
+
 test("route surface tests usan fixtures compartidos sin stubs locales de profesionales públicos", () => {
   const source = readSource(
-    "test/public-professionals-route-surface-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts",
   );
 
   assert.ok(
-    source.includes('from "./helpers/public-professionals-fixtures.ts"'),
+    source.includes(`from "${MOVED_PUBLIC_PROFESSIONALS_FIXTURE_IMPORT}"`),
     "route surface debe importar fixtures compartidos",
   );
 
@@ -46,16 +49,16 @@ test("route surface tests usan fixtures compartidos sin stubs locales de profesi
 
 test("tests recientes de profesionales públicos comparten el helper de fixtures", () => {
   const checkedFiles = [
-    "test/public-professionals-response-headers-invariants.test.ts",
-    "test/public-professionals-logging-invariants.test.ts",
-    "test/public-professionals-route-surface-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-response-headers-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts",
   ];
 
   for (const file of checkedFiles) {
     const source = readSource(file);
 
     assert.ok(
-      source.includes('from "./helpers/public-professionals-fixtures.ts"'),
+      source.includes(`from "${MOVED_PUBLIC_PROFESSIONALS_FIXTURE_IMPORT}"`),
       `${file} debe importar fixtures compartidos`,
     );
 

--- a/test/public-professionals-fixture-file-scope-invariants.test.ts
+++ b/test/public-professionals-fixture-file-scope-invariants.test.ts
@@ -57,12 +57,45 @@ function listSourceFiles(directory: string): string[] {
   return files.sort();
 }
 
-function isTopLevelPublicProfessionalsTest(file: string): boolean {
+function isAllowedPublicProfessionalsFixtureConsumerTest(file: string): boolean {
+  const isLegacyTopLevelPublicProfessionalsTest =
+    file.startsWith("test/public-professionals-") &&
+    file.endsWith(".test.ts") &&
+    !file.slice("test/".length).includes("/");
+
+  const isControllerPublicProfessionalsInvariant =
+    file.startsWith("test/integration/adapters/controllers/public-professionals-") &&
+    file.endsWith(".test.ts") &&
+    !file
+      .slice("test/integration/adapters/controllers/".length)
+      .includes("/");
+
   return (
+    isLegacyTopLevelPublicProfessionalsTest ||
+    isControllerPublicProfessionalsInvariant
+  );
+}
+
+function expectedPublicProfessionalsFixtureImport(file: string): string | null {
+  if (
     file.startsWith("test/public-professionals-") &&
     file.endsWith(".test.ts") &&
     !file.slice("test/".length).includes("/")
-  );
+  ) {
+    return "./helpers/public-professionals-fixtures.ts";
+  }
+
+  if (
+    file.startsWith("test/integration/adapters/controllers/public-professionals-") &&
+    file.endsWith(".test.ts") &&
+    !file
+      .slice("test/integration/adapters/controllers/".length)
+      .includes("/")
+  ) {
+    return "../../../helpers/public-professionals-fixtures.ts";
+  }
+
+  return null;
 }
 
 function referencesPublicProfessionalsFixtureHelper(source: string): boolean {
@@ -108,7 +141,7 @@ test("fixtures públicos de profesionales sólo se referencian desde helper can�
 
     if (
       referencesPublicProfessionalsFixtureHelper(source) &&
-      !isTopLevelPublicProfessionalsTest(file)
+      !isAllowedPublicProfessionalsFixtureConsumerTest(file)
     ) {
       offenders.push(file);
     }
@@ -117,7 +150,7 @@ test("fixtures públicos de profesionales sólo se referencian desde helper can�
   assert.deepEqual(
     offenders,
     [],
-    "fixtures públicos de profesionales deben quedar limitados a test/helpers y test/public-professionals-*.test.ts",
+    "fixtures públicos de profesionales deben quedar limitados a test/helpers, test/public-professionals-*.test.ts y test/integration/adapters/controllers/public-professionals-*.test.ts",
   );
 });
 
@@ -175,14 +208,15 @@ test("imports del helper de fixtures públicos usan path relativo canónico", ()
 
     const source = readSource(file);
     const imports = helperImports(source);
+    const expectedImportPath = expectedPublicProfessionalsFixtureImport(file);
 
     for (const importPath of imports) {
-      if (!isTopLevelPublicProfessionalsTest(file)) {
+      if (expectedImportPath === null) {
         offenders.push(`${file}: import fuera de scope`);
         continue;
       }
 
-      if (importPath !== "./helpers/public-professionals-fixtures.ts") {
+      if (importPath !== expectedImportPath) {
         offenders.push(`${file}: ${importPath}`);
       }
     }
@@ -191,7 +225,7 @@ test("imports del helper de fixtures públicos usan path relativo canónico", ()
   assert.deepEqual(
     offenders,
     [],
-    "los tests top-level deben importar fixtures públicos con ./helpers/public-professionals-fixtures.ts",
+    "los tests deben importar fixtures públicos con el path relativo canónico según su ubicación",
   );
 });
 

--- a/test/security-critical-route-surface-registry.test.ts
+++ b/test/security-critical-route-surface-registry.test.ts
@@ -492,14 +492,14 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
     ],
     guardrailTests: [
       {
-        path: "test/public-professionals-route-surface-invariants.test.ts",
+        path: "test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts",
         markers: [
           "router público de profesionales conserva solo endpoints GET search y detail",
           "superficie pública no acepta métodos mutantes en profesionales públicos",
         ],
       },
       {
-        path: "test/public-professionals-response-headers-invariants.test.ts",
+        path: "test/integration/adapters/controllers/public-professionals-response-headers-invariants.test.ts",
         markers: [
           "profesionales públicos responde JSON y sin cookies en search detail y errores públicos",
           "profesionales públicos expone CORS permitido solo en rutas reales con Origin permitido",
@@ -673,7 +673,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/security-validation-cutoff-boundaries.test.ts",
     "test/security-rate-limit-isolation-boundaries.test.ts",
     "test/supabase-storage-boundaries.test.ts",
-    "test/public-professionals-route-surface-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-route-surface-invariants.test.ts",
     "test/public-professionals-fixture-suite-completeness-invariants.test.ts",
     "test/backend-ci-workflow.test.ts",
     "test/package-scripts.test.ts",

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -580,7 +580,7 @@ test("rate-limited responses are logged with the shared RATE_LIMITED marker only
   );
 
   for (const file of [
-    "test/public-professionals-logging-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts",
     "test/request-logger.test.ts",
   ] as const) {
     const source = readSource(file);
@@ -591,7 +591,7 @@ test("rate-limited responses are logged with the shared RATE_LIMITED marker only
 test("runtime rate limit tests remain explicit for isolated public and mutation buckets", () => {
   const publicProfessionals = readSource("test/public-professionals.fastify.test.ts");
   const publicProfessionalsResponseHeaders = readSource(
-    "test/public-professionals-response-headers-invariants.test.ts",
+    "test/integration/adapters/controllers/public-professionals-response-headers-invariants.test.ts",
   );
   const publicReportAccess = readSource("test/public-report-access.fastify.test.ts");
   const reportAccessTokens = readSource("test/report-access-tokens.fastify.test.ts");


### PR DESCRIPTION
## Summary
- Move public-professionals invariant request-injection tests under test/integration/adapters/controllers.
- Adjust relative imports after the move.
- Update fixture/route/rate-limit guardrails that referenced old top-level paths.
- Add TEST-ARCH-28 implementation report.

## Scope
- Manual-only.
- No Codex.
- No Claude.
- No runtime/producto changes.
- No DB/schema/migrations.
- No CI/deps/package.json/pnpm-lock.yaml changes.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface