### PR TITLE
test(architecture): move login rate limit api tests

### DIFF
--- a/docs/implementation/test-arch-29-login-rate-limit-http-api-batch.md
+++ b/docs/implementation/test-arch-29-login-rate-limit-http-api-batch.md
@@ -1,0 +1,92 @@
+# TEST-ARCH-29 - Login rate-limit HTTP/API batch
+
+## Resumen ejecutivo
+
+TEST-ARCH-29 mueve manualmente el lote login rate-limit HTTP/API identificado por TEST-ARCH-24.
+
+El lote es homogeneo por superficie de autenticacion y rate limit con `app.inject()`:
+
+- `test/login-rate-limit-operability.test.ts`
+- `test/login-rate-limit-reset-on-success.test.ts`
+
+Se reubican bajo:
+
+- `test/integration/adapters/controllers/`
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base esperado | `9abb7b1 docs(test): close test arch 28 validation report (#1336)` |
+| Rama de trabajo | `test/login-rate-limit-http-api-batch` |
+| Working tree inicial | Limpio |
+| PRs abiertos esperados | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## Fuente de verdad
+
+- `docs/implementation/test-arch-24-non-fastify-http-api-test-inventory.md`
+- `docs/implementation/test-arch-28-public-professionals-invariants-batch.md`
+
+## Archivos movidos
+
+| Origen | Destino |
+|---|---|
+| `test/login-rate-limit-operability.test.ts` | `test/integration/adapters/controllers/login-rate-limit-operability.test.ts` |
+| `test/login-rate-limit-reset-on-success.test.ts` | `test/integration/adapters/controllers/login-rate-limit-reset-on-success.test.ts` |
+
+## Imports ajustados
+
+Se ajustaron imports relativos mecanicos por nueva profundidad:
+
+- `../server/lib/rate-limit-store.ts` -> `../../../../server/lib/rate-limit-store.ts`
+- `../server/lib/login-rate-limit.ts` -> `../../../../server/lib/login-rate-limit.ts`
+- `../server/routes/auth.fastify.ts` -> `../../../../server/routes/auth.fastify.ts`
+- `../server/routes/admin-auth.fastify.ts` -> `../../../../server/routes/admin-auth.fastify.ts`
+- `../server/routes/particular-auth.fastify.ts` -> `../../../../server/routes/particular-auth.fastify.ts`
+
+## Anchors activos
+
+No se esperan anchors activos en `test/**` o `scripts/**` para los paths antiguos del lote.
+Las referencias documentales historicas se mantienen.
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Completadas antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado al lote login rate-limit HTTP/API y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' typecheck:test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | Pendiente |
+
+## Recomendacion para siguiente lote
+
+Mantener diferidos:
+
+- `test/client-version-gate-contract.test.ts`
+- `test/performance-load-smoke.test.ts`
+- `test/fastify-app.test.ts`
+- `test/contact-route.test.ts`
+- security-sensitive groups con anchors activos hasta lote propio

--- a/test/integration/adapters/controllers/login-rate-limit-operability.test.ts
+++ b/test/integration/adapters/controllers/login-rate-limit-operability.test.ts
@@ -4,7 +4,7 @@ import Fastify from "fastify";
 import type {
   RateLimitEntry,
   RateLimitStore,
-} from "../server/lib/rate-limit-store.ts";
+} from "../../../../server/lib/rate-limit-store.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -18,16 +18,16 @@ const {
   buildMissingCredentialsLoginRateLimitKey,
   LOGIN_RATE_LIMIT_CODE,
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
-} = await import("../server/lib/login-rate-limit.ts");
+} = await import("../../../../server/lib/login-rate-limit.ts");
 const {
   clinicAuthNativeRoutes,
-} = await import("../server/routes/auth.fastify.ts");
+} = await import("../../../../server/routes/auth.fastify.ts");
 const {
   adminAuthNativeRoutes,
-} = await import("../server/routes/admin-auth.fastify.ts");
+} = await import("../../../../server/routes/admin-auth.fastify.ts");
 const {
   particularAuthNativeRoutes,
-} = await import("../server/routes/particular-auth.fastify.ts");
+} = await import("../../../../server/routes/particular-auth.fastify.ts");
 const REQUIRED_429_HEADERS = [
   "retry-after",
   "ratelimit-policy",

--- a/test/integration/adapters/controllers/login-rate-limit-reset-on-success.test.ts
+++ b/test/integration/adapters/controllers/login-rate-limit-reset-on-success.test.ts
@@ -19,19 +19,19 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const {
   LOGIN_RATE_LIMIT_ERROR_MESSAGE,
-} = await import("../server/lib/login-rate-limit.ts");
+} = await import("../../../../server/lib/login-rate-limit.ts");
 const {
   createMemoryRateLimitStore,
-} = await import("../server/lib/rate-limit-store.ts");
+} = await import("../../../../server/lib/rate-limit-store.ts");
 const {
   clinicAuthNativeRoutes,
-} = await import("../server/routes/auth.fastify.ts");
+} = await import("../../../../server/routes/auth.fastify.ts");
 const {
   adminAuthNativeRoutes,
-} = await import("../server/routes/admin-auth.fastify.ts");
+} = await import("../../../../server/routes/admin-auth.fastify.ts");
 const {
   particularAuthNativeRoutes,
-} = await import("../server/routes/particular-auth.fastify.ts");
+} = await import("../../../../server/routes/particular-auth.fastify.ts");
 
 const WINDOW_MS = 60_000;
 const MAX_ATTEMPTS = 3;
@@ -569,7 +569,7 @@ test("particular login exitoso resetea el rate limit", async () => {
 // ─── Store delete method ─────────────────────────────────────────────────────
 
 test("createMemoryRateLimitStore.delete elimina la entrada correctamente", async () => {
-  const { createMemoryRateLimitStore: mk, getOrCreateRateLimitEntry, incrementRateLimitEntry } = await import("../server/lib/rate-limit-store.ts");
+  const { createMemoryRateLimitStore: mk, getOrCreateRateLimitEntry, incrementRateLimitEntry } = await import("../../../../server/lib/rate-limit-store.ts");
 
   const store = mk();
   const now = Date.now();
@@ -595,7 +595,7 @@ test("createMemoryRateLimitStore.delete elimina la entrada correctamente", async
 });
 
 test("createMemoryRateLimitStore.delete de key inexistente no lanza error", async () => {
-  const { createMemoryRateLimitStore: mk } = await import("../server/lib/rate-limit-store.ts");
+  const { createMemoryRateLimitStore: mk } = await import("../../../../server/lib/rate-limit-store.ts");
   const store = mk();
 
   assert.doesNotReject(async () => {


### PR DESCRIPTION
## Summary
- Move login rate-limit HTTP/API request-injection tests under test/integration/adapters/controllers.
- Adjust relative imports after the move.
- Add TEST-ARCH-29 implementation report.

## Scope
- Manual-only.
- No Codex.
- No Claude.
- No runtime/producto changes.
- No DB/schema/migrations.
- No CI/deps/package.json/pnpm-lock.yaml changes.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface