### PR TITLE
test(architecture): move contact route api test

### DIFF
--- a/docs/implementation/test-arch-32-contact-route-http-api.md
+++ b/docs/implementation/test-arch-32-contact-route-http-api.md
@@ -1,0 +1,96 @@
+# TEST-ARCH-32 - Contact route HTTP/API
+
+## Resumen ejecutivo
+
+TEST-ARCH-32 mueve manualmente el test HTTP/API de la ruta publica de contacto identificado por TEST-ARCH-24.
+
+Archivo movido:
+
+- `test/contact-route.test.ts`
+
+Destino:
+
+- `test/integration/adapters/controllers/contact-route.test.ts`
+
+El test cubre:
+
+- validacion de payload publico de contacto
+- envio exitoso de mensaje
+- preflight CORS permitido
+- SMTP disabled aceptado
+- error SMTP controlado con diagnosticos seguros
+- rechazo de origins no confiables
+- rate-limit del endpoint de contacto
+- resolucion de cliente con trusted proxy
+- aislamiento del rate-limit al plugin de contacto
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base esperado | `786b445 test(architecture): move performance load smoke (#1339)` |
+| Rama de trabajo | `test/contact-route-http-api-move` |
+| Working tree inicial | Limpio |
+| PRs abiertos esperados | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## Fuente de verdad
+
+- `docs/implementation/test-arch-24-non-fastify-http-api-test-inventory.md`
+- `docs/implementation/test-arch-31-performance-load-smoke.md`
+
+## Archivo movido
+
+| Origen | Destino |
+|---|---|
+| `test/contact-route.test.ts` | `test/integration/adapters/controllers/contact-route.test.ts` |
+
+## Imports ajustados
+
+Se ajustaron imports relativos mecanicos por nueva profundidad:
+
+- `../server/lib/rate-limit-store.ts` -> `../../../../server/lib/rate-limit-store.ts`
+- `../server/routes/contact.fastify.ts` -> `../../../../server/routes/contact.fastify.ts`
+
+## Anchors activos
+
+No se esperan anchors activos en `test/**` o `scripts/**` para el path antiguo del archivo.
+Las referencias documentales historicas se mantienen.
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Completadas antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado a contact-route HTTP/API y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' typecheck:test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | Pendiente |
+
+## Recomendacion para siguiente lote
+
+Mantener diferidos:
+
+- `test/fastify-app.test.ts`
+- security-sensitive groups con anchors activos hasta lote propio

--- a/test/integration/adapters/controllers/contact-route.test.ts
+++ b/test/integration/adapters/controllers/contact-route.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import test from "node:test";
 import Fastify, { type FastifyServerOptions } from "fastify";
 
-import type { RateLimitStore } from "../server/lib/rate-limit-store.ts";
+import type { RateLimitStore } from "../../../../server/lib/rate-limit-store.ts";
 
 type ContactEmailResult =
   | { sent: true; messageId: string }
@@ -41,7 +41,7 @@ async function createContactTestApp(
   ensureContactRouteTestEnv();
 
   const { contactNativeRoutes } = await import(
-    "../server/routes/contact.fastify.ts"
+    "../../../../server/routes/contact.fastify.ts"
   );
 
   const app = Fastify({ logger: false, ...fastifyOptions });


### PR DESCRIPTION
## Summary
- Move contact-route HTTP/API test under test/integration/adapters/controllers.
- Adjust relative imports after the move.
- Add TEST-ARCH-32 implementation report.

## Scope
- Manual-only.
- No Codex.
- No Claude.
- No runtime/producto changes.
- No DB/schema/migrations.
- No CI/deps/package.json/pnpm-lock.yaml changes.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface