### PR TITLE
test(architecture): move report write surface security test

### DIFF
--- a/docs/implementation/test-arch-34-report-write-surface-security-batch.md
+++ b/docs/implementation/test-arch-34-report-write-surface-security-batch.md
@@ -1,0 +1,112 @@
+# TEST-ARCH-34 - Report write surface security batch
+
+## Resumen ejecutivo
+
+TEST-ARCH-34 mueve en un unico PR eficiente el test root-level de ownership de escritura de informes y actualiza sus anchors activos.
+
+Archivo movido:
+
+- `test/report-write-surface-ownership.test.ts`
+
+Destino:
+
+- `test/security/report-write-surface-ownership.test.ts`
+
+Anchors activos actualizados:
+
+- `test/report-study-types-catalog.test.ts`
+- `test/reports-suite-completeness.test.ts`
+
+## Criterio de eficiencia
+
+Este lote evita un micro-PR aislado y evita una correccion posterior de guards.
+
+Se agrupa en un solo PR:
+
+- movimiento del test
+- ajuste de imports
+- actualizacion de anchors activos
+- reporte de implementacion
+
+## Estado base
+
+| Item | Resultado |
+|---|---|
+| Repo | `C:\PORTAL-VETNEB` |
+| Rama base | `main` |
+| HEAD base esperado | `b77a888 test(architecture): move security boundary root tests (#1341)` |
+| Rama de trabajo | `test/report-write-surface-security-batch` |
+| Working tree inicial | Limpio |
+| PRs abiertos esperados | 0 |
+| Residuo remoto conocido | `origin/test/particular-authenticated-session-fixture`, no tocado |
+
+## Fuente de verdad
+
+- `docs/implementation/test-arch-24-non-fastify-http-api-test-inventory.md`
+- `docs/implementation/test-arch-33-security-boundary-root-batch.md`
+
+## Archivo movido
+
+| Origen | Destino |
+|---|---|
+| `test/report-write-surface-ownership.test.ts` | `test/security/report-write-surface-ownership.test.ts` |
+
+## Imports ajustados
+
+Se ajustaron imports relativos mecanicos por nueva profundidad:
+
+- `../server/lib/env.ts` -> `../../server/lib/env.ts`
+- `../server/routes/admin-reports.fastify.ts` -> `../../server/routes/admin-reports.fastify.ts`
+
+No se cambiaron rutas source leidas desde `process.cwd()` como:
+
+- `server/routes/...`
+
+Motivo: esas rutas son relativas a la raiz del repo.
+
+## Anchors actualizados
+
+Se actualizo el path canonico del test movido en:
+
+- `test/report-study-types-catalog.test.ts`
+- `test/reports-suite-completeness.test.ts`
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Completadas antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado al lote report write surface security y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' typecheck:test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | Pendiente |
+
+## Recomendacion para siguiente lote
+
+Mantener diferidos hasta lote propio con anchors:
+
+- `test/audit-export-boundaries.test.ts`
+- `test/security-trusted-origin-cors-boundaries.test.ts`
+
+Mantener diferido por decision arquitectonica:
+
+- `test/fastify-app.test.ts`

--- a/test/report-study-types-catalog.test.ts
+++ b/test/report-study-types-catalog.test.ts
@@ -141,7 +141,7 @@ test("critical report tests stop using free-text or abbreviated studyType", () =
     [
       "test/integration/adapters/controllers/admin-reports.fastify.test.ts",
       "test/integration/adapters/controllers/reports.fastify.test.ts",
-      "test/report-write-surface-ownership.test.ts",
+      "test/security/report-write-surface-ownership.test.ts",
       "test/integration/adapters/controllers/reports-status.fastify.test.ts",
     ].includes(file),
   );
@@ -152,7 +152,7 @@ test("critical report tests stop using free-text or abbreviated studyType", () =
       "test/integration/adapters/controllers/admin-reports.fastify.test.ts",
       "test/integration/adapters/controllers/reports-status.fastify.test.ts",
       "test/integration/adapters/controllers/reports.fastify.test.ts",
-      "test/report-write-surface-ownership.test.ts",
+      "test/security/report-write-surface-ownership.test.ts",
     ],
   );
 

--- a/test/reports-suite-completeness.test.ts
+++ b/test/reports-suite-completeness.test.ts
@@ -25,7 +25,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       "Admin report upload remains the only report write surface and persists admin attribution before returning signed URLs.",
     testFiles: [
       {
-        path: "test/report-write-surface-ownership.test.ts",
+        path: "test/security/report-write-surface-ownership.test.ts",
         markers: [
           "report write surface owner registry",
           "createdByAdminUserId",

--- a/test/security/report-write-surface-ownership.test.ts
+++ b/test/security/report-write-surface-ownership.test.ts
@@ -11,10 +11,10 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../server/lib/env.ts");
 const {
   adminReportsNativeRoutes,
-} = await import("../server/routes/admin-reports.fastify.ts");
+} = await import("../../server/routes/admin-reports.fastify.ts");
 
 function readSource(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(


### PR DESCRIPTION
## Summary
- Move report-write-surface ownership test under test/security.
- Update active guards that anchor the test path.
- Adjust relative imports after the move.
- Add TEST-ARCH-34 implementation report.
- Keep this as one efficient PR to reduce CI runs.

## Scope
- Manual-only.
- No Codex.
- No Claude.
- No runtime/producto changes.
- No DB/schema/migrations.
- No CI/deps/package.json/pnpm-lock.yaml changes.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface