### PR TITLE
test(architecture): extract fastify app route stubs

### DIFF
--- a/docs/implementation/test-arch-38-fastify-app-helper-extraction.md
+++ b/docs/implementation/test-arch-38-fastify-app-helper-extraction.md
@@ -1,0 +1,97 @@
+# TEST-ARCH-38 - Fastify app helper extraction
+
+## Resumen ejecutivo
+
+TEST-ARCH-38 realiza una extraccion estructural controlada del monolito app-level `test/fastify-app.test.ts`.
+
+No divide los tests todavia.
+No mueve `fastify-app.test.ts` todavia.
+
+Extrae helpers, snapshots y route stubs a:
+
+- `test/helpers/fastify-app-route-stubs.ts`
+
+El objetivo es reducir acoplamiento fisico y preparar un split futuro por buckets sin cambiar comportamiento.
+
+## Contexto
+
+Auditoria local TEST-ARCH-37B:
+
+| Metrica | Resultado |
+|---|---:|
+| Archivo | `test/fastify-app.test.ts` |
+| Lineas | 3078 |
+| Tests | 26 |
+| `.inject()` | 49 |
+| Route stub builders | 26 |
+| Imports `../server/` | 3 |
+
+Buckets detectados por titulo:
+
+| Bucket | Tests |
+|---|---:|
+| admin-dispatch | 8 |
+| app-global-security-errors | 4 |
+| clinic-dispatch | 3 |
+| clinic-reporting-dispatch | 2 |
+| health-readiness-system | 2 |
+| public-dispatch | 2 |
+| particular-dispatch | 1 |
+| uncategorized | 4 |
+
+## Decision tecnica
+
+Se elige extraccion de helpers antes de mover o dividir el monolito.
+
+Motivo:
+
+- `fastify-app.test.ts` es app-level, no controller-level.
+- Mezcla dispatch global, health, errores, CORS, request-id, headers, admin, clinic, particular, public, reports y logistics.
+- Dividirlo sin extraer builders primero duplicaria stubs o aumentaria riesgo.
+- Moverlo entero solo cambiaria ubicacion fisica sin reducir deuda.
+
+## Cambios realizados
+
+| Archivo | Cambio |
+|---|---|
+| `test/fastify-app.test.ts` | Mantiene los 26 tests y consume helpers via `fastifyAppHelpers`. |
+| `test/helpers/fastify-app-route-stubs.ts` | Nuevo helper con snapshots y route stubs exportados. |
+
+## Scope confirmado
+
+No se modifico:
+
+- runtime/producto
+- backend productivo
+- DB/schema/migrations
+- CI
+- dependencias
+- `package.json`
+- `pnpm-lock.yaml`
+
+No se uso Codex ni Claude.
+
+## Validaciones
+
+Completadas antes de commit:
+
+| Comando | Resultado |
+|---|---|
+| `git diff --check` | OK, sin salida. |
+| `git diff --stat` | OK. |
+| `git diff --name-only` | OK, limitado a fastify-app helper extraction y reporte. |
+| `git status --short --untracked-files=all` | OK, solo cambios esperados antes de stage. |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' typecheck:test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' test` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' build` | Pendiente |
+| `& 'C:\Program Files\nodejs\pnpm.cmd' security:public-surface` | Pendiente |
+
+## Recomendacion posterior
+
+Despues de esta extraccion, evaluar split futuro por buckets:
+
+- app-global-security-errors
+- health-readiness-system
+- admin-dispatch
+- clinic/public/particular dispatch
+- reports/study-tracking/logistics dispatch

--- a/test/fastify-app.test.ts
+++ b/test/fastify-app.test.ts
@@ -19,770 +19,12 @@ const {
   assertRequestIdHeader,
   serializeConsoleCalls,
 } = await import("./helpers/api-request-id-contract.ts");
-
-function buildExpectedContactServiceSnapshot() {
-  const explicitRecipients = Array.from(
-    new Set(
-      ENV.contactTo
-        .flatMap((value) => value.split(/[;,]/g))
-        .map((value) => value.trim())
-        .filter(Boolean),
-    ),
-  );
-  const fallbackRecipients = ENV.isProduction
-    ? []
-    : Array.from(
-      new Set(
-        [ENV.gmailApi.enabled ? ENV.gmailApi.from : ENV.smtp.from]
-          .flatMap((value) => value.split(/[;,]/g))
-          .map((value) => value.trim())
-          .filter(Boolean),
-      ),
-    );
-  const recipients = explicitRecipients.length > 0
-    ? explicitRecipients
-    : fallbackRecipients;
-  const emailTransportReady = ENV.gmailApi.enabled || ENV.smtp.enabled;
-  const contactReady = emailTransportReady && (
-    ENV.isProduction ? explicitRecipients.length > 0 : recipients.length > 0
-  );
-
-  return {
-    contact_email: contactReady ? "configured" : "degraded",
-    contact_email_recipients: recipients,
-    contact_email_recipient_count: recipients.length,
-    contact_to_configured: explicitRecipients.length > 0,
-    smtp_from_configured: ENV.smtp.from.trim().length > 0,
-    gmail_api_from_configured: ENV.gmailApi.from.trim().length > 0,
-  };
-}
-
-function isLocalOrLanHostname(hostname: string): boolean {
-  const normalized = hostname.trim().toLowerCase();
-
-  if (normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1") {
-    return true;
-  }
-
-  return normalized.startsWith("192.168.");
-}
-
-function buildExpectedCorsSnapshot() {
-  const origins = Array.from(
-    new Set(
-      ENV.corsOrigins.map((origin) => origin.trim()).filter(Boolean),
-    ),
-  );
-  const hasLocalOrLanOrigins = origins.some((origin) => {
-    try {
-      return isLocalOrLanHostname(new URL(origin).hostname);
-    } catch {
-      return false;
-    }
-  });
-
-  return {
-    cors: origins.length > 0 ? "configured" : "not_configured",
-    cors_origins: origins,
-    cors_origin_count: origins.length,
-    cors_has_local_or_lan_origins: hasLocalOrLanOrigins,
-    node_env: ENV.nodeEnv,
-  };
-}
-
-function buildAdminAuditRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    listAuditLog: async () => ({
-      items: [],
-      total: 0,
-    }),
-    buildAdminAuditListFilters: (_query: Record<string, unknown>) => ({
-      filters: {
-        limit: 50,
-        offset: 0,
-      },
-      errors: [],
-    }),
-    buildAdminAuditCsv: () => "id,event",
-    buildAdminAuditCsvFilename: () => "admin-audit-log-test.csv",
-  };
-}
-
-function buildAdminAuthRouteStubs() {
-  return {
-    createAdminSession: async () => {},
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    getAdminUserByUsername: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    generateSessionToken: () => "admin-session-token",
-    hashSessionToken: (token: string) => `hash:${token}`,
-    verifyPassword: async () => ({
-      valid: false,
-      needsRehash: false,
-    }),
-    writeAuditLog: async () => {},
-  };
-}
-
-function buildAdminFailedLoginAlertsRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    listAdminFailedLoginAlerts: async () => ({
-      success: true as const,
-      failedLoginAlerts: [],
-      count: 0,
-      total: 0,
-      limit: 50,
-      offset: 0,
-      filters: {
-        surface: null,
-        reason: null,
-      },
-    }),
-    buildAdminFailedLoginAlertsCsv: () =>
-      "id,surface,username,reason,ipAddress,userAgent,createdAt",
-    buildAdminFailedLoginAlertsCsvFilename: () =>
-      "admin-failed-login-alerts-test.csv",
-  };
-}
-
-
-
-function buildAdminParticularTokensRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    generateSessionToken: () => "a".repeat(64),
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getClinicById: async () => null,
-    getReportById: async () => null,
-    createParticularToken: async () => ({
-      id: 7,
-      clinicId: 3,
-      reportId: null,
-      tokenHash: `hash:${"a".repeat(64)}`,
-      tokenLast4: "aaaa",
-      tutorLastName: "Gomez",
-      petName: "Luna",
-      petAge: "8 aÃƒÆ’Ã‚Â±os",
-      petBreed: "Caniche",
-      petSex: "Hembra",
-      petSpecies: "Canina",
-      sampleLocation: "PabellÃƒÆ’Ã‚Â³n auricular",
-      sampleEvolution: "15 dÃƒÆ’Ã‚Â­as",
-      detailsLesion: null,
-      extractionDate: new Date("2026-04-20T00:00:00.000Z"),
-      shippingDate: new Date("2026-04-21T00:00:00.000Z"),
-      isActive: true,
-      lastLoginAt: null,
-      createdAt: new Date("2026-04-20T12:00:00.000Z"),
-      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
-      createdByAdminId: 1,
-      createdByClinicUserId: null,
-    }),
-    getParticularTokenById: async () => null,
-    listParticularTokens: async () => [],
-    updateParticularTokenReport: async () => null,
-    revokeParticularToken: async () => null,
-    sendParticularTokenEmail: async () => ({
-      sent: true as const,
-      messageId: "particular-email-1",
-    }),
-    getParticularStudyTrackingCase: async () => null,
-    getStudyTrackingCaseByReportId: async () => null,
-    createStudyTrackingCase: async () => ({} as any),
-    updateStudyTrackingCase: async () => null,
-  };
-}
-function buildAdminReportsRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getClinicById: async () => null,
-    getReportById: async () => null,
-    uploadReport: async () => "reports/admin-test.pdf",
-    upsertReport: async () => ({
-      id: 88,
-      clinicId: 3,
-      uploadDate: new Date("2026-04-22T09:00:00.000Z"),
-      studyType: "Histopatologia",
-      patientName: "Luna",
-      fileName: "luna-report.pdf",
-      currentStatus: "uploaded",
-      statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
-      createdAt: new Date("2026-04-22T09:00:00.000Z"),
-      updatedAt: new Date("2026-04-22T09:30:00.000Z"),
-      storagePath: "reports/admin-test.pdf",
-    } as any),
-    getParticularTokenById: async () => null,
-    updateParticularTokenReport: async () => null,
-    getParticularStudyTrackingCase: async () => null,
-    getStudyTrackingCaseByReportId: async () => null,
-    createStudyTrackingCase: async () => ({} as any),
-    updateStudyTrackingCase: async () => null,
-    createStudyTrackingNotification: async () => ({} as any),
-    createSignedReportUrl: async (storagePath: string) =>
-      `signed-preview:${storagePath}`,
-    createSignedReportDownloadUrl: async (
-      storagePath: string,
-      fileName?: string,
-    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
-    writeAuditLog: async () => {},
-  };
-}
-
-function buildAdminReportAccessTokensRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    generateSessionToken: () => "a".repeat(64),
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getClinicById: async () => null,
-    getReportById: async () => null,
-    createReportAccessToken: async () => ({
-      id: 9,
-      clinicId: 3,
-      reportId: 55,
-      tokenHash: `hash:${"a".repeat(64)}`,
-      tokenLast4: "aaaa",
-      accessCount: 0,
-      lastAccessAt: null,
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-      revokedAt: null,
-      createdAt: new Date("2026-04-20T12:00:00.000Z"),
-      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
-      createdByClinicUserId: null,
-      createdByAdminUserId: 1,
-      revokedByClinicUserId: null,
-      revokedByAdminUserId: null,
-    }),
-    getReportAccessTokenById: async () => null,
-    listReportAccessTokens: async () => [],
-    revokeReportAccessToken: async () => null,
-    writeAuditLog: async () => {},
-  };
-}
-function buildAdminStudyTrackingRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getClinicById: async () => null,
-    getReportById: async () => null,
-    getParticularTokenById: async () => null,
-    updateParticularTokenReport: async () => null,
-    createStudyTrackingCase: async () => ({} as any),
-    updateStudyTrackingCase: async () => null,
-    getClinicScopedStudyTrackingCase: async () => null,
-    getStudyTrackingCaseById: async () => null,
-    listStudyTrackingCases: async () => [],
-    createStudyTrackingNotification: async () => ({} as any),
-    listStudyTrackingNotifications: async () => [],
-    writeAuditLog: async () => {},
-    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
-  };
-}
-function buildClinicAuthRouteStubs() {
-  return {
-    createActiveSession: async () => {},
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    getClinicUserByUsername: async () => null,
-    updateSessionLastAccess: async () => {},
-    upsertClinicUser: async () => {},
-    generateSessionToken: () => "session-token",
-    hashPassword: async () => "rehash-password",
-    hashSessionToken: (token: string) => `hash:${token}`,
-    verifyPassword: async () => ({
-      valid: false,
-      needsRehash: false,
-    }),
-    writeAuditLog: async () => {},
-  };
-}
-
-function buildClinicAuditRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    listAuditLog: async () => ({
-      items: [],
-      total: 0,
-    }),
-    buildClinicAuditListFilters: (
-      _query: Record<string, unknown>,
-      clinicId: number,
-    ) => ({
-      filters: {
-        clinicId,
-        limit: 50,
-        offset: 0,
-      },
-      errors: [],
-    }),
-    buildAdminAuditCsv: () => "id,event",
-  };
-}
-
-function buildClinicPublicProfileRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getClinicById: async () => null,
-    getClinicPublicProfileByClinicId: async () => null,
-    buildClinicPublicProfileResponse: (input: {
-      clinic: Record<string, unknown>;
-      profile: Record<string, unknown> | null;
-      avatarUrl: string | null;
-    }) => ({
-      clinicId: input.clinic.id,
-      clinicName: input.clinic.name,
-      avatarUrl: input.avatarUrl,
-      displayName: input.profile?.displayName ?? null,
-      isPublic: input.profile?.isPublic ?? false,
-    }),
-    evaluateClinicPublicProfilePublication: () => ({
-      isPublic: false,
-      hasRequiredPublicFields: true,
-      hasQualitySupplement: true,
-      qualityScore: 80,
-      isSearchEligible: true,
-      missingRequiredFields: [],
-      missingRecommendedFields: [],
-      publicationErrors: [],
-    }),
-    minPublicProfileQualityScore: 60,
-    patchClinicPublicProfile: async () => ({
-      clinicId: 3,
-      displayName: "Clinica Centro",
-      avatarStoragePath: "avatars/3/avatar.png",
-      isPublic: true,
-    }),
-    removeClinicPublicAvatar: async () => ({
-      previousAvatarStoragePath: "avatars/3/avatar.png",
-      profile: {
-        clinicId: 3,
-        displayName: "Clinica Centro",
-        avatarStoragePath: null,
-        isPublic: true,
-      },
-    }),
-    syncClinicPublicSearch: async () => ({
-      clinicId: 3,
-      isPublic: true,
-      hasRequiredPublicFields: true,
-      isSearchEligible: true,
-      profileQualityScore: 80,
-      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
-      searchText: "clinica centro",
-    }),
-    createSignedStorageUrl: async (storagePath: string) => `signed:${storagePath}`,
-    uploadClinicAvatar: async () => "avatars/3/avatar-new.png",
-    deleteStorageObject: async () => {},
-  };
-}
-
-function buildParticularAuditRouteStubs() {
-  return {
-    deleteParticularSession: async () => {},
-    getParticularSessionByToken: async () => null,
-    getParticularTokenById: async () => null,
-    updateParticularSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    listParticularAuditLog: async () => ({
-      items: [],
-      total: 0,
-    }),
-    buildParticularAuditListFilters: (_query: Record<string, unknown>) => ({
-      filters: {
-        limit: 50,
-        offset: 0,
-      },
-      errors: [],
-    }),
-    buildAuditCsv: () => "id,event",
-    buildParticularAuditCsvFilename: () =>
-      "particular-audit-log-test.csv",
-  };
-}
-
-function buildParticularAuthRouteStubs() {
-  return {
-    createParticularSession: async () => {},
-    deleteParticularSession: async () => {},
-    getParticularSessionByToken: async () => null,
-    getParticularTokenById: async () => null,
-    getParticularTokenByTokenHash: async () => null,
-    updateParticularSessionLastAccess: async () => {},
-    updateParticularTokenLastLogin: async () => {},
-    getReportById: async () => null,
-    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
-    createSignedReportDownloadUrl: async (
-      storagePath: string,
-      fileName?: string,
-    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
-    generateSessionToken: () => "particular-session-token",
-    hashSessionToken: (token: string) => `hash:${token}`,
-  };
-}
-
-
-function buildParticularTokensRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    generateSessionToken: () => "a".repeat(64),
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getReportById: async () => null,
-    createParticularToken: async () => ({
-      id: 7,
-      clinicId: 3,
-      reportId: null,
-      tokenHash: `hash:${"a".repeat(64)}`,
-      tokenLast4: "aaaa",
-      tutorLastName: "Gomez",
-      petName: "Luna",
-      petAge: "8 aÃƒÆ’Ã‚Â±os",
-      petBreed: "Caniche",
-      petSex: "Hembra",
-      petSpecies: "Canina",
-      sampleLocation: "PabellÃƒÆ’Ã‚Â³n auricular",
-      sampleEvolution: "15 dÃƒÆ’Ã‚Â­as",
-      detailsLesion: null,
-      extractionDate: new Date("2026-04-20T00:00:00.000Z"),
-      shippingDate: new Date("2026-04-21T00:00:00.000Z"),
-      isActive: true,
-      lastLoginAt: null,
-      createdAt: new Date("2026-04-20T12:00:00.000Z"),
-      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
-      createdByAdminId: null,
-      createdByClinicUserId: 9,
-    }),
-    getClinicScopedParticularToken: async () => null,
-    listParticularTokens: async () => [],
-    updateParticularTokenReport: async () => null,
-    revokeParticularToken: async () => null,
-    sendParticularTokenEmail: async () => ({
-      sent: true as const,
-      messageId: "particular-email-1",
-    }),
-    getParticularStudyTrackingCase: async () => null,
-    getStudyTrackingCaseByReportId: async () => null,
-    createStudyTrackingCase: async () => ({} as any),
-    updateStudyTrackingCase: async () => null,
-  };
-}
-function buildStudyTrackingRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getClinicById: async () => null,
-    getReportById: async () => null,
-    getParticularTokenById: async () => null,
-    updateParticularTokenReport: async () => null,
-    createStudyTrackingCase: async () => ({} as any),
-    updateStudyTrackingCase: async () => null,
-    getClinicScopedStudyTrackingCase: async () => null,
-    listStudyTrackingCases: async () => [],
-    createStudyTrackingNotification: async () => ({} as any),
-    listStudyTrackingNotifications: async () => [],
-    markStudyTrackingNotificationReadScoped: async () => null,
-    markAllStudyTrackingNotificationsReadScoped: async () => ({
-      updatedCount: 0,
-    }),
-    writeAuditLog: async () => {},
-    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
-  };
-}
-
-function buildPublicReportAccessRouteStubs() {
-  return {
-    getReportAccessTokenWithReportByTokenHash: async () => null,
-    recordReportAccessTokenAccess: async () => null,
-    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
-    createSignedReportDownloadUrl: async (
-      storagePath: string,
-      fileName?: string,
-    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
-    hashSessionToken: (token: string) => `hash:${token}`,
-    writeAuditLog: async () => {},
-  };
-}
-
-function buildReportAccessTokensRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    generateSessionToken: () => "a".repeat(64),
-    hashPassword: async () => "unused",
-    hashSessionToken: (token: string) => `hash:${token}`,
-    verifyPassword: async () => ({
-      valid: false,
-      needsRehash: false,
-    }),
-    getReportById: async () => null,
-    createReportAccessToken: async () => ({
-      id: 9,
-      clinicId: 3,
-      reportId: 55,
-      tokenHash: `hash:${"a".repeat(64)}`,
-      tokenLast4: "aaaa",
-      accessCount: 0,
-      lastAccessAt: null,
-      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
-      revokedAt: null,
-      createdAt: new Date("2026-04-20T12:00:00.000Z"),
-      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
-      createdByClinicUserId: 9,
-      createdByAdminUserId: null,
-      revokedByClinicUserId: null,
-      revokedByAdminUserId: null,
-    }),
-    getClinicScopedReportAccessToken: async () => null,
-    listReportAccessTokens: async () => [],
-    revokeReportAccessToken: async () => null,
-    writeAuditLog: async () => {},
-  };
-}
-
-function buildParticularStudyTrackingRouteStubs() {
-  return {
-    deleteParticularSession: async () => {},
-    getParticularSessionByToken: async () => null,
-    getParticularTokenById: async () => null,
-    updateParticularSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getParticularStudyTrackingCase: async () => null,
-    listStudyTrackingNotifications: async () => [],
-    markStudyTrackingNotificationReadScoped: async () => null,
-    markAllStudyTrackingNotificationsReadScoped: async () => ({
-      updatedCount: 0,
-    }),
-  };
-}
-
-function buildPublicProfessionalsRouteStubs() {
-  return {
-    searchPublicProfessionals: async () => ({
-      rows: [],
-      total: 0,
-      limit: 20,
-      offset: 0,
-    }),
-    getPublicProfessionalByClinicId: async () => null,
-    createSignedStorageUrl: async (path: string) => `signed:${path}`,
-  };
-}
-
-function buildReportsRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getReportsByClinicId: async () => [],
-    searchReports: async () => [],
-    getStudyTypes: async () => [],
-    getReportById: async () => null,
-    getReportStatusHistory: async () => [],
-    getClinicScopedStudyTrackingCase: async () => null,
-    updateStudyTrackingCase: async () => null,
-    uploadReport: async () => "reports/test.pdf",
-    upsertReport: async () => ({} as any),
-    createSignedReportUrl: async (storagePath: string) =>
-      `signed-preview:${storagePath}`,
-    createSignedReportDownloadUrl: async (
-      storagePath: string,
-      fileName?: string,
-    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
-  };
-}
-
-function buildReportsStatusRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getReportById: async () => null,
-    updateReportStatus: async () => null,
-    createSignedReportUrl: async (storagePath: string) =>
-      `signed-preview:${storagePath}`,
-    createSignedReportDownloadUrl: async (
-      storagePath: string,
-      fileName?: string,
-    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
-    writeAuditLog: async () => {},
-  };
-}
-
-function buildLogisticsRouteEventsRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    createRouteEvent: async () => null,
-    listClinicRouteEvents: async () => [],
-    listRouteEventsForClinicRoutePlan: async () => [],
-    listIncrementalClinicRouteEvents: async () => [],
-  };
-}
-
-function buildLogisticsRoutePlansRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    createRoutePlan: async () => null,
-    getClinicScopedRoutePlan: async () => null,
-    listClinicRoutePlans: async () => [],
-    updateClinicScopedRoutePlan: async () => null,
-    createRouteStopForClinicRoutePlan: async () => null,
-    listRouteStopsForClinicRoutePlan: async () => [],
-    updateClinicScopedRouteStop: async () => null,
-    transitionClinicScopedRoutePlanStatus: async () => ({
-      reason: "not_found" as const,
-    }),
-  };
-}
-
-function buildLogisticsFieldVisitsRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    createFieldVisit: async () => null,
-    listClinicFieldVisits: async () => [],
-    updateClinicScopedFieldVisit: async () => null,
-    getVisitLocationForClinicVisit: async () => null,
-    upsertVisitLocationForClinicVisit: async () => null,
-    createTimeWindowForClinicVisit: async () => null,
-    listTimeWindowsForClinicVisit: async () => [],
-  };
-}
-
-function buildLogisticsSlaRouteStubs() {
-  return {
-    deleteActiveSession: async () => {},
-    getActiveSessionByToken: async () => null,
-    getClinicUserById: async () => null,
-    updateSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    listActiveClinicSlaPolicies: async () => [],
-    listClinicSlaInstances: async () => [],
-    listOverdueActiveClinicSlaInstances: async () => [],
-    getClinicSlaSummary: async () => ({
-      clinicId: 1,
-      total: 0,
-      active: 0,
-      paused: 0,
-      breached: 0,
-      resolved: 0,
-      canceled: 0,
-    }),
-  };
-}
-function buildAdminSystemHealthRouteStubs() {
-  return {
-    deleteAdminSession: async () => {},
-    getAdminSessionByToken: async () => null,
-    getAdminUserById: async () => null,
-    updateAdminSessionLastAccess: async () => {},
-    hashSessionToken: (token: string) => `hash:${token}`,
-    getSystemHealthSnapshot: async () => ({
-      statusCode: 200,
-      payload: {
-        success: true,
-        status: "ok",
-        checks: {
-          database: "up",
-          storage: "up",
-        },
-      },
-    }),
-    getBackendVersion: () => "test-version",
-  };
-}
-
-function buildFastifyDispatchRouteStubs() {
-  return {
-    adminAuditRoutes: buildAdminAuditRouteStubs(),
-    adminAuthRoutes: buildAdminAuthRouteStubs(),
-    adminFailedLoginAlertsRoutes: buildAdminFailedLoginAlertsRouteStubs(),
-    adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-    adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-    adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-    clinicAuthRoutes: buildClinicAuthRouteStubs(),
-    clinicAuditRoutes: buildClinicAuditRouteStubs(),
-    clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-    particularAuditRoutes: buildParticularAuditRouteStubs(),
-    particularAuthRoutes: buildParticularAuthRouteStubs(),
-    particularStudyTrackingRoutes: buildParticularStudyTrackingRouteStubs(),
-    particularTokensRoutes: buildParticularTokensRouteStubs(),
-    publicProfessionalsRoutes: buildPublicProfessionalsRouteStubs(),
-    publicPricingRoutes: {
-      listPublicPricingItems: async () => [],
-    },
-    publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-    reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-    reportsRoutes: buildReportsRouteStubs(),
-    reportsStatusRoutes: buildReportsStatusRouteStubs(),
-    studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
-    logisticsRoutePlansRoutes: buildLogisticsRoutePlansRouteStubs(),
-    logisticsRouteEventsRoutes: buildLogisticsRouteEventsRouteStubs(),
-    logisticsSlaRoutes: buildLogisticsSlaRouteStubs(),
-  };
-}
+const fastifyAppHelpers = await import("./helpers/fastify-app-route-stubs.ts");
 
 test(
   "createFastifyApp aplica trusted origin global antes de rutas mutables",
   async () => {
-    const app = await createFastifyApp(buildFastifyDispatchRouteStubs());
+    const app = await createFastifyApp(fastifyAppHelpers.buildFastifyDispatchRouteStubs());
     const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
     const secretSessionToken = "secret-session-token";
     const consoleCalls: string[] = [];
@@ -892,7 +134,7 @@ test(
   "createFastifyApp expone root y health nativos",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       getServiceInfoPayload: () => ({
         success: true,
         service: "portal-vetneb-api",
@@ -912,19 +154,19 @@ test(
           timestamp: "2026-04-22T00:00:00.000Z",
         },
       }),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -935,10 +177,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -973,9 +215,9 @@ test(
   "createFastifyApp despacha /api/admin/audit-log al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       adminAuditRoutes: {
-        ...buildAdminAuditRouteStubs(),
+        ...fastifyAppHelpers.buildAdminAuditRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1023,18 +265,18 @@ test(
           errors: [],
         }),
       },
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1045,10 +287,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1080,10 +322,10 @@ test(
   "createFastifyApp despacha /api/admin/auth al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
       adminAuthRoutes: {
-        ...buildAdminAuthRouteStubs(),
+        ...fastifyAppHelpers.buildAdminAuthRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 7,
           expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
@@ -1095,17 +337,17 @@ test(
         }),
         updateAdminSessionLastAccess: async () => {},
       },
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1116,10 +358,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1155,16 +397,16 @@ test(
   "createFastifyApp despacha /api/auth al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
       clinicAuthRoutes: {
-        ...buildClinicAuthRouteStubs(),
+        ...fastifyAppHelpers.buildClinicAuthRouteStubs(),
         getActiveSessionByToken: async () => ({
           clinicUserId: 9,
           expiresAt: new Date(Date.UTC(2026, 3, 23, 1, 0, 0)),
@@ -1178,11 +420,11 @@ test(
         }),
         updateSessionLastAccess: async () => {},
       },
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1193,10 +435,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1238,17 +480,17 @@ test(
   "createFastifyApp despacha /api/clinic/audit-log al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
       clinicAuditRoutes: {
-        ...buildClinicAuditRouteStubs(),
+        ...fastifyAppHelpers.buildClinicAuditRouteStubs(),
         getActiveSessionByToken: async () => ({
           clinicUserId: 9,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1301,10 +543,10 @@ test(
           errors: [],
         }),
       },
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1315,10 +557,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1351,18 +593,18 @@ test(
   "createFastifyApp despacha /api/clinic/profile al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
       clinicPublicProfileRoutes: {
-        ...buildClinicPublicProfileRouteStubs(),
+        ...fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
         getActiveSessionByToken: async () => ({
           clinicUserId: 9,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1399,9 +641,9 @@ test(
           },
         }),
       },
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1412,10 +654,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1448,20 +690,20 @@ test(
   "createFastifyApp despacha /api/particular/auth al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
       particularAuthRoutes: {
-        ...buildParticularAuthRouteStubs(),
+        ...fastifyAppHelpers.buildParticularAuthRouteStubs(),
         getParticularSessionByToken: async () => ({
           particularTokenId: 7,
           expiresAt: new Date(Date.UTC(2026, 3, 24, 1, 0, 0)),
@@ -1513,7 +755,7 @@ test(
           updatedAt: new Date("2026-04-22T09:30:00.000Z"),
         }),
       },
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1524,10 +766,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1560,20 +802,20 @@ test(
   "createFastifyApp despacha /api/public/professionals al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1584,10 +826,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1629,20 +871,20 @@ test(
     const rawToken = "a".repeat(64);
 
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1654,7 +896,7 @@ test(
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
       publicReportAccessRoutes: {
-        ...buildPublicReportAccessRouteStubs(),
+        ...fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
         getReportAccessTokenWithReportByTokenHash: async () => ({
           token: {
             id: 9,
@@ -1716,9 +958,9 @@ test(
         createSignedReportDownloadUrl: async () =>
           "https://signed.example/download",
       },
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1751,20 +993,20 @@ test(
   "createFastifyApp despacha /api/report-access-tokens al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1775,11 +1017,11 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
       reportAccessTokensRoutes: {
-        ...buildReportAccessTokensRouteStubs(),
+        ...fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
         getActiveSessionByToken: async () => ({
           clinicUserId: 9,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1844,9 +1086,9 @@ test(
   "createFastifyApp despacha /api/admin/reports al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       adminReportsRoutes: {
-        ...buildAdminReportsRouteStubs(),
+        ...fastifyAppHelpers.buildAdminReportsRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1885,13 +1127,13 @@ test(
   "createFastifyApp despacha /api/admin/report-access-tokens al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
     adminReportAccessTokensRoutes: {
-        ...buildAdminReportAccessTokensRouteStubs(),
+        ...fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -1921,14 +1163,14 @@ test(
           },
         ],
       },
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -1939,10 +1181,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -1977,11 +1219,11 @@ test(
   "createFastifyApp despacha /api/admin/particular-tokens al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
       adminParticularTokensRoutes: {
-        ...buildAdminParticularTokensRouteStubs(),
+        ...fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -2018,16 +1260,16 @@ test(
           },
         ],
       },
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -2038,10 +1280,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -2073,29 +1315,29 @@ test(
   "createFastifyApp despacha /api/study-tracking al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({ rows: [], total: 0, limit: 20, offset: 0 }),
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -2118,14 +1360,14 @@ test(
   "createFastifyApp despacha /api/admin/study-tracking al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
       adminStudyTrackingRoutes: {
-        ...buildAdminStudyTrackingRouteStubs(),
+        ...fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -2137,12 +1379,12 @@ test(
         }),
         listStudyTrackingCases: async () => [],
       },
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -2153,10 +1395,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -2189,7 +1431,7 @@ test(
 test(
   "createFastifyApp despacha rutas nativas restantes al router nativo",
   async () => {
-    const app = await createFastifyApp(buildFastifyDispatchRouteStubs());
+    const app = await createFastifyApp(fastifyAppHelpers.buildFastifyDispatchRouteStubs());
 
     try {
       const reportsResponse = await app.inject({
@@ -2240,7 +1482,7 @@ test(
   "createFastifyApp usa handlers globales para 404 y errores no capturados",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       getServiceInfoPayload: () => ({
         success: true,
         service: "portal-vetneb-api",
@@ -2253,19 +1495,19 @@ test(
           status: "ok",
         },
       }),
-      adminAuditRoutes: buildAdminAuditRouteStubs(),
-      adminAuthRoutes: buildAdminAuthRouteStubs(),
-      adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
-      adminReportsRoutes: buildAdminReportsRouteStubs(),
-    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
-      adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
-    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
-      clinicAuthRoutes: buildClinicAuthRouteStubs(),
-      clinicAuditRoutes: buildClinicAuditRouteStubs(),
-      clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
-      particularAuditRoutes: buildParticularAuditRouteStubs(),
-      particularAuthRoutes: buildParticularAuthRouteStubs(),
-      particularTokensRoutes: buildParticularTokensRouteStubs(),
+      adminAuditRoutes: fastifyAppHelpers.buildAdminAuditRouteStubs(),
+      adminAuthRoutes: fastifyAppHelpers.buildAdminAuthRouteStubs(),
+      adminParticularTokensRoutes: fastifyAppHelpers.buildAdminParticularTokensRouteStubs(),
+      adminReportsRoutes: fastifyAppHelpers.buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: fastifyAppHelpers.buildAdminReportAccessTokensRouteStubs(),
+      adminStudyTrackingRoutes: fastifyAppHelpers.buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+      clinicAuthRoutes: fastifyAppHelpers.buildClinicAuthRouteStubs(),
+      clinicAuditRoutes: fastifyAppHelpers.buildClinicAuditRouteStubs(),
+      clinicPublicProfileRoutes: fastifyAppHelpers.buildClinicPublicProfileRouteStubs(),
+      particularAuditRoutes: fastifyAppHelpers.buildParticularAuditRouteStubs(),
+      particularAuthRoutes: fastifyAppHelpers.buildParticularAuthRouteStubs(),
+      particularTokensRoutes: fastifyAppHelpers.buildParticularTokensRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => ({
           rows: [],
@@ -2276,10 +1518,10 @@ test(
         getPublicProfessionalByClinicId: async () => null,
         createSignedStorageUrl: async (path: string) => `signed:${path}`,
       },
-      publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
-      reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
-      studyTrackingRoutes: buildStudyTrackingRouteStubs(),
-    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+      publicReportAccessRoutes: fastifyAppHelpers.buildPublicReportAccessRouteStubs(),
+      reportAccessTokensRoutes: fastifyAppHelpers.buildReportAccessTokensRouteStubs(),
+      studyTrackingRoutes: fastifyAppHelpers.buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: fastifyAppHelpers.buildLogisticsFieldVisitsRouteStubs(),
     });
 
     try {
@@ -2345,7 +1587,7 @@ test(
   "createFastifyApp incluye requestId en cuerpos JSON de errores API",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       getNativeHealthCheckResponse: async () => ({
         statusCode: 200,
         payload: {
@@ -2521,7 +1763,7 @@ test(
     let detailHelperWasCalled = false;
 
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async (input: {
           query?: string;
@@ -2627,7 +1869,7 @@ test(
 test(
   "createFastifyApp preserva Cache-Control publico de pricing",
   async () => {
-    const app = await createFastifyApp(buildFastifyDispatchRouteStubs());
+    const app = await createFastifyApp(fastifyAppHelpers.buildFastifyDispatchRouteStubs());
 
     try {
       const response = await app.inject({
@@ -2650,7 +1892,7 @@ test(
   "createFastifyApp aplica security headers a respuestas API publicas autenticadas y de error",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       getNativeHealthCheckResponse: async () => ({
         statusCode: 200,
         payload: {
@@ -2659,7 +1901,7 @@ test(
         },
       }),
       adminSystemHealthRoutes: {
-        ...buildAdminSystemHealthRouteStubs(),
+        ...fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -2781,7 +2023,7 @@ test(
     let searchHelperWasCalled = false;
 
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       publicProfessionalsRoutes: {
         searchPublicProfessionals: async () => {
           searchHelperWasCalled = true;
@@ -2852,9 +2094,9 @@ test(
   "createFastifyApp despacha /api/admin/system/health al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       adminSystemHealthRoutes: {
-        ...buildAdminSystemHealthRouteStubs(),
+        ...fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
         getAdminSessionByToken: async () => ({
           adminUserId: 1,
           expiresAt: new Date("2099-01-01T00:00:00.000Z"),
@@ -2904,8 +2146,8 @@ test(
           : ENV.smtp.enabled
             ? "smtp"
             : "not_configured",
-        ...buildExpectedContactServiceSnapshot(),
-        ...buildExpectedCorsSnapshot(),
+        ...fastifyAppHelpers.buildExpectedContactServiceSnapshot(),
+        ...fastifyAppHelpers.buildExpectedCorsSnapshot(),
       });
     } finally {
       await app.close();
@@ -2917,9 +2159,9 @@ test(
   "createFastifyApp despacha /api/admin/failed-login-alerts al router nativo",
   async () => {
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       adminFailedLoginAlertsRoutes: {
-        ...buildAdminFailedLoginAlertsRouteStubs(),
+        ...fastifyAppHelpers.buildAdminFailedLoginAlertsRouteStubs(),
         getAdminSessionByToken: async () => ({
           id: 99,
           adminUserId: 1,
@@ -2988,9 +2230,9 @@ test(
     let receivedParams: any = null;
 
     const app = await createFastifyApp({
-      ...buildFastifyDispatchRouteStubs(),
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
       adminFailedLoginAlertsRoutes: {
-        ...buildAdminFailedLoginAlertsRouteStubs(),
+        ...fastifyAppHelpers.buildAdminFailedLoginAlertsRouteStubs(),
         getAdminSessionByToken: async () => ({
           id: 99,
           adminUserId: 1,

--- a/test/helpers/fastify-app-route-stubs.ts
+++ b/test/helpers/fastify-app-route-stubs.ts
@@ -1,0 +1,760 @@
+import { ENV } from "../../server/lib/env.ts";
+
+export function buildExpectedContactServiceSnapshot() {
+  const explicitRecipients = Array.from(
+    new Set(
+      ENV.contactTo
+        .flatMap((value) => value.split(/[;,]/g))
+        .map((value) => value.trim())
+        .filter(Boolean),
+    ),
+  );
+  const fallbackRecipients = ENV.isProduction
+    ? []
+    : Array.from(
+      new Set(
+        [ENV.gmailApi.enabled ? ENV.gmailApi.from : ENV.smtp.from]
+          .flatMap((value) => value.split(/[;,]/g))
+          .map((value) => value.trim())
+          .filter(Boolean),
+      ),
+    );
+  const recipients = explicitRecipients.length > 0
+    ? explicitRecipients
+    : fallbackRecipients;
+  const emailTransportReady = ENV.gmailApi.enabled || ENV.smtp.enabled;
+  const contactReady = emailTransportReady && (
+    ENV.isProduction ? explicitRecipients.length > 0 : recipients.length > 0
+  );
+
+  return {
+    contact_email: contactReady ? "configured" : "degraded",
+    contact_email_recipients: recipients,
+    contact_email_recipient_count: recipients.length,
+    contact_to_configured: explicitRecipients.length > 0,
+    smtp_from_configured: ENV.smtp.from.trim().length > 0,
+    gmail_api_from_configured: ENV.gmailApi.from.trim().length > 0,
+  };
+}
+
+export function isLocalOrLanHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+
+  if (normalized === "localhost" || normalized === "127.0.0.1" || normalized === "::1") {
+    return true;
+  }
+
+  return normalized.startsWith("192.168.");
+}
+
+export function buildExpectedCorsSnapshot() {
+  const origins = Array.from(
+    new Set(
+      ENV.corsOrigins.map((origin) => origin.trim()).filter(Boolean),
+    ),
+  );
+  const hasLocalOrLanOrigins = origins.some((origin) => {
+    try {
+      return isLocalOrLanHostname(new URL(origin).hostname);
+    } catch {
+      return false;
+    }
+  });
+
+  return {
+    cors: origins.length > 0 ? "configured" : "not_configured",
+    cors_origins: origins,
+    cors_origin_count: origins.length,
+    cors_has_local_or_lan_origins: hasLocalOrLanOrigins,
+    node_env: ENV.nodeEnv,
+  };
+}
+
+export function buildAdminAuditRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAuditLog: async () => ({
+      items: [],
+      total: 0,
+    }),
+    buildAdminAuditListFilters: (_query: Record<string, unknown>) => ({
+      filters: {
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAdminAuditCsv: () => "id,event",
+    buildAdminAuditCsvFilename: () => "admin-audit-log-test.csv",
+  };
+}
+
+export function buildAdminAuthRouteStubs() {
+  return {
+    createAdminSession: async () => {},
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    getAdminUserByUsername: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "admin-session-token",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    writeAuditLog: async () => {},
+  };
+}
+
+export function buildAdminFailedLoginAlertsRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAdminFailedLoginAlerts: async () => ({
+      success: true as const,
+      failedLoginAlerts: [],
+      count: 0,
+      total: 0,
+      limit: 50,
+      offset: 0,
+      filters: {
+        surface: null,
+        reason: null,
+      },
+    }),
+    buildAdminFailedLoginAlertsCsv: () =>
+      "id,surface,username,reason,ipAddress,userAgent,createdAt",
+    buildAdminFailedLoginAlertsCsvFilename: () =>
+      "admin-failed-login-alerts-test.csv",
+  };
+}
+
+
+
+export function buildAdminParticularTokensRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    createParticularToken: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: null,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      tutorLastName: "Gomez",
+      petName: "Luna",
+      petAge: "8 aÃƒÆ’Ã‚Â±os",
+      petBreed: "Caniche",
+      petSex: "Hembra",
+      petSpecies: "Canina",
+      sampleLocation: "PabellÃƒÆ’Ã‚Â³n auricular",
+      sampleEvolution: "15 dÃƒÆ’Ã‚Â­as",
+      detailsLesion: null,
+      extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+      shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+      isActive: true,
+      lastLoginAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByAdminId: 1,
+      createdByClinicUserId: null,
+    }),
+    getParticularTokenById: async () => null,
+    listParticularTokens: async () => [],
+    updateParticularTokenReport: async () => null,
+    revokeParticularToken: async () => null,
+    sendParticularTokenEmail: async () => ({
+      sent: true as const,
+      messageId: "particular-email-1",
+    }),
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+  };
+}
+export function buildAdminReportsRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    uploadReport: async () => "reports/admin-test.pdf",
+    upsertReport: async () => ({
+      id: 88,
+      clinicId: 3,
+      uploadDate: new Date("2026-04-22T09:00:00.000Z"),
+      studyType: "Histopatologia",
+      patientName: "Luna",
+      fileName: "luna-report.pdf",
+      currentStatus: "uploaded",
+      statusChangedAt: new Date("2026-04-22T09:30:00.000Z"),
+      createdAt: new Date("2026-04-22T09:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T09:30:00.000Z"),
+      storagePath: "reports/admin-test.pdf",
+    } as any),
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+    createStudyTrackingNotification: async () => ({} as any),
+    createSignedReportUrl: async (storagePath: string) =>
+      `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    writeAuditLog: async () => {},
+  };
+}
+
+export function buildAdminReportAccessTokensRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    createReportAccessToken: async () => ({
+      id: 9,
+      clinicId: 3,
+      reportId: 55,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      accessCount: 0,
+      lastAccessAt: null,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      revokedAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByClinicUserId: null,
+      createdByAdminUserId: 1,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: null,
+    }),
+    getReportAccessTokenById: async () => null,
+    listReportAccessTokens: async () => [],
+    revokeReportAccessToken: async () => null,
+    writeAuditLog: async () => {},
+  };
+}
+export function buildAdminStudyTrackingRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+    getClinicScopedStudyTrackingCase: async () => null,
+    getStudyTrackingCaseById: async () => null,
+    listStudyTrackingCases: async () => [],
+    createStudyTrackingNotification: async () => ({} as any),
+    listStudyTrackingNotifications: async () => [],
+    writeAuditLog: async () => {},
+    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
+  };
+}
+export function buildClinicAuthRouteStubs() {
+  return {
+    createActiveSession: async () => {},
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    getClinicUserByUsername: async () => null,
+    updateSessionLastAccess: async () => {},
+    upsertClinicUser: async () => {},
+    generateSessionToken: () => "session-token",
+    hashPassword: async () => "rehash-password",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    writeAuditLog: async () => {},
+  };
+}
+
+export function buildClinicAuditRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listAuditLog: async () => ({
+      items: [],
+      total: 0,
+    }),
+    buildClinicAuditListFilters: (
+      _query: Record<string, unknown>,
+      clinicId: number,
+    ) => ({
+      filters: {
+        clinicId,
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAdminAuditCsv: () => "id,event",
+  };
+}
+
+export function buildClinicPublicProfileRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getClinicPublicProfileByClinicId: async () => null,
+    buildClinicPublicProfileResponse: (input: {
+      clinic: Record<string, unknown>;
+      profile: Record<string, unknown> | null;
+      avatarUrl: string | null;
+    }) => ({
+      clinicId: input.clinic.id,
+      clinicName: input.clinic.name,
+      avatarUrl: input.avatarUrl,
+      displayName: input.profile?.displayName ?? null,
+      isPublic: input.profile?.isPublic ?? false,
+    }),
+    evaluateClinicPublicProfilePublication: () => ({
+      isPublic: false,
+      hasRequiredPublicFields: true,
+      hasQualitySupplement: true,
+      qualityScore: 80,
+      isSearchEligible: true,
+      missingRequiredFields: [],
+      missingRecommendedFields: [],
+      publicationErrors: [],
+    }),
+    minPublicProfileQualityScore: 60,
+    patchClinicPublicProfile: async () => ({
+      clinicId: 3,
+      displayName: "Clinica Centro",
+      avatarStoragePath: "avatars/3/avatar.png",
+      isPublic: true,
+    }),
+    removeClinicPublicAvatar: async () => ({
+      previousAvatarStoragePath: "avatars/3/avatar.png",
+      profile: {
+        clinicId: 3,
+        displayName: "Clinica Centro",
+        avatarStoragePath: null,
+        isPublic: true,
+      },
+    }),
+    syncClinicPublicSearch: async () => ({
+      clinicId: 3,
+      isPublic: true,
+      hasRequiredPublicFields: true,
+      isSearchEligible: true,
+      profileQualityScore: 80,
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      searchText: "clinica centro",
+    }),
+    createSignedStorageUrl: async (storagePath: string) => `signed:${storagePath}`,
+    uploadClinicAvatar: async () => "avatars/3/avatar-new.png",
+    deleteStorageObject: async () => {},
+  };
+}
+
+export function buildParticularAuditRouteStubs() {
+  return {
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listParticularAuditLog: async () => ({
+      items: [],
+      total: 0,
+    }),
+    buildParticularAuditListFilters: (_query: Record<string, unknown>) => ({
+      filters: {
+        limit: 50,
+        offset: 0,
+      },
+      errors: [],
+    }),
+    buildAuditCsv: () => "id,event",
+    buildParticularAuditCsvFilename: () =>
+      "particular-audit-log-test.csv",
+  };
+}
+
+export function buildParticularAuthRouteStubs() {
+  return {
+    createParticularSession: async () => {},
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    getParticularTokenByTokenHash: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    updateParticularTokenLastLogin: async () => {},
+    getReportById: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    generateSessionToken: () => "particular-session-token",
+    hashSessionToken: (token: string) => `hash:${token}`,
+  };
+}
+
+
+export function buildParticularTokensRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getReportById: async () => null,
+    createParticularToken: async () => ({
+      id: 7,
+      clinicId: 3,
+      reportId: null,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      tutorLastName: "Gomez",
+      petName: "Luna",
+      petAge: "8 aÃƒÆ’Ã‚Â±os",
+      petBreed: "Caniche",
+      petSex: "Hembra",
+      petSpecies: "Canina",
+      sampleLocation: "PabellÃƒÆ’Ã‚Â³n auricular",
+      sampleEvolution: "15 dÃƒÆ’Ã‚Â­as",
+      detailsLesion: null,
+      extractionDate: new Date("2026-04-20T00:00:00.000Z"),
+      shippingDate: new Date("2026-04-21T00:00:00.000Z"),
+      isActive: true,
+      lastLoginAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByAdminId: null,
+      createdByClinicUserId: 9,
+    }),
+    getClinicScopedParticularToken: async () => null,
+    listParticularTokens: async () => [],
+    updateParticularTokenReport: async () => null,
+    revokeParticularToken: async () => null,
+    sendParticularTokenEmail: async () => ({
+      sent: true as const,
+      messageId: "particular-email-1",
+    }),
+    getParticularStudyTrackingCase: async () => null,
+    getStudyTrackingCaseByReportId: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+  };
+}
+export function buildStudyTrackingRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getClinicById: async () => null,
+    getReportById: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularTokenReport: async () => null,
+    createStudyTrackingCase: async () => ({} as any),
+    updateStudyTrackingCase: async () => null,
+    getClinicScopedStudyTrackingCase: async () => null,
+    listStudyTrackingCases: async () => [],
+    createStudyTrackingNotification: async () => ({} as any),
+    listStudyTrackingNotifications: async () => [],
+    markStudyTrackingNotificationReadScoped: async () => null,
+    markAllStudyTrackingNotificationsReadScoped: async () => ({
+      updatedCount: 0,
+    }),
+    writeAuditLog: async () => {},
+    sendSpecialStainRequiredEmail: async () => ({ sent: true }),
+  };
+}
+
+export function buildPublicReportAccessRouteStubs() {
+  return {
+    getReportAccessTokenWithReportByTokenHash: async () => null,
+    recordReportAccessTokenAccess: async () => null,
+    createSignedReportUrl: async (storagePath: string) => `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    hashSessionToken: (token: string) => `hash:${token}`,
+    writeAuditLog: async () => {},
+  };
+}
+
+export function buildReportAccessTokensRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    generateSessionToken: () => "a".repeat(64),
+    hashPassword: async () => "unused",
+    hashSessionToken: (token: string) => `hash:${token}`,
+    verifyPassword: async () => ({
+      valid: false,
+      needsRehash: false,
+    }),
+    getReportById: async () => null,
+    createReportAccessToken: async () => ({
+      id: 9,
+      clinicId: 3,
+      reportId: 55,
+      tokenHash: `hash:${"a".repeat(64)}`,
+      tokenLast4: "aaaa",
+      accessCount: 0,
+      lastAccessAt: null,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      revokedAt: null,
+      createdAt: new Date("2026-04-20T12:00:00.000Z"),
+      updatedAt: new Date("2026-04-22T12:00:00.000Z"),
+      createdByClinicUserId: 9,
+      createdByAdminUserId: null,
+      revokedByClinicUserId: null,
+      revokedByAdminUserId: null,
+    }),
+    getClinicScopedReportAccessToken: async () => null,
+    listReportAccessTokens: async () => [],
+    revokeReportAccessToken: async () => null,
+    writeAuditLog: async () => {},
+  };
+}
+
+export function buildParticularStudyTrackingRouteStubs() {
+  return {
+    deleteParticularSession: async () => {},
+    getParticularSessionByToken: async () => null,
+    getParticularTokenById: async () => null,
+    updateParticularSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getParticularStudyTrackingCase: async () => null,
+    listStudyTrackingNotifications: async () => [],
+    markStudyTrackingNotificationReadScoped: async () => null,
+    markAllStudyTrackingNotificationsReadScoped: async () => ({
+      updatedCount: 0,
+    }),
+  };
+}
+
+export function buildPublicProfessionalsRouteStubs() {
+  return {
+    searchPublicProfessionals: async () => ({
+      rows: [],
+      total: 0,
+      limit: 20,
+      offset: 0,
+    }),
+    getPublicProfessionalByClinicId: async () => null,
+    createSignedStorageUrl: async (path: string) => `signed:${path}`,
+  };
+}
+
+export function buildReportsRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getReportsByClinicId: async () => [],
+    searchReports: async () => [],
+    getStudyTypes: async () => [],
+    getReportById: async () => null,
+    getReportStatusHistory: async () => [],
+    getClinicScopedStudyTrackingCase: async () => null,
+    updateStudyTrackingCase: async () => null,
+    uploadReport: async () => "reports/test.pdf",
+    upsertReport: async () => ({} as any),
+    createSignedReportUrl: async (storagePath: string) =>
+      `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+  };
+}
+
+export function buildReportsStatusRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getReportById: async () => null,
+    updateReportStatus: async () => null,
+    createSignedReportUrl: async (storagePath: string) =>
+      `signed-preview:${storagePath}`,
+    createSignedReportDownloadUrl: async (
+      storagePath: string,
+      fileName?: string,
+    ) => `signed-download:${storagePath}:${fileName ?? ""}`,
+    writeAuditLog: async () => {},
+  };
+}
+
+export function buildLogisticsRouteEventsRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createRouteEvent: async () => null,
+    listClinicRouteEvents: async () => [],
+    listRouteEventsForClinicRoutePlan: async () => [],
+    listIncrementalClinicRouteEvents: async () => [],
+  };
+}
+
+export function buildLogisticsRoutePlansRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createRoutePlan: async () => null,
+    getClinicScopedRoutePlan: async () => null,
+    listClinicRoutePlans: async () => [],
+    updateClinicScopedRoutePlan: async () => null,
+    createRouteStopForClinicRoutePlan: async () => null,
+    listRouteStopsForClinicRoutePlan: async () => [],
+    updateClinicScopedRouteStop: async () => null,
+    transitionClinicScopedRoutePlanStatus: async () => ({
+      reason: "not_found" as const,
+    }),
+  };
+}
+
+export function buildLogisticsFieldVisitsRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createFieldVisit: async () => null,
+    listClinicFieldVisits: async () => [],
+    updateClinicScopedFieldVisit: async () => null,
+    getVisitLocationForClinicVisit: async () => null,
+    upsertVisitLocationForClinicVisit: async () => null,
+    createTimeWindowForClinicVisit: async () => null,
+    listTimeWindowsForClinicVisit: async () => [],
+  };
+}
+
+export function buildLogisticsSlaRouteStubs() {
+  return {
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async () => null,
+    getClinicUserById: async () => null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    listActiveClinicSlaPolicies: async () => [],
+    listClinicSlaInstances: async () => [],
+    listOverdueActiveClinicSlaInstances: async () => [],
+    getClinicSlaSummary: async () => ({
+      clinicId: 1,
+      total: 0,
+      active: 0,
+      paused: 0,
+      breached: 0,
+      resolved: 0,
+      canceled: 0,
+    }),
+  };
+}
+export function buildAdminSystemHealthRouteStubs() {
+  return {
+    deleteAdminSession: async () => {},
+    getAdminSessionByToken: async () => null,
+    getAdminUserById: async () => null,
+    updateAdminSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    getSystemHealthSnapshot: async () => ({
+      statusCode: 200,
+      payload: {
+        success: true,
+        status: "ok",
+        checks: {
+          database: "up",
+          storage: "up",
+        },
+      },
+    }),
+    getBackendVersion: () => "test-version",
+  };
+}
+
+export function buildFastifyDispatchRouteStubs() {
+  return {
+    adminAuditRoutes: buildAdminAuditRouteStubs(),
+    adminAuthRoutes: buildAdminAuthRouteStubs(),
+    adminFailedLoginAlertsRoutes: buildAdminFailedLoginAlertsRouteStubs(),
+    adminParticularTokensRoutes: buildAdminParticularTokensRouteStubs(),
+    adminReportsRoutes: buildAdminReportsRouteStubs(),
+    adminReportAccessTokensRoutes: buildAdminReportAccessTokensRouteStubs(),
+    adminStudyTrackingRoutes: buildAdminStudyTrackingRouteStubs(),
+    adminSystemHealthRoutes: buildAdminSystemHealthRouteStubs(),
+    clinicAuthRoutes: buildClinicAuthRouteStubs(),
+    clinicAuditRoutes: buildClinicAuditRouteStubs(),
+    clinicPublicProfileRoutes: buildClinicPublicProfileRouteStubs(),
+    particularAuditRoutes: buildParticularAuditRouteStubs(),
+    particularAuthRoutes: buildParticularAuthRouteStubs(),
+    particularStudyTrackingRoutes: buildParticularStudyTrackingRouteStubs(),
+    particularTokensRoutes: buildParticularTokensRouteStubs(),
+    publicProfessionalsRoutes: buildPublicProfessionalsRouteStubs(),
+    publicPricingRoutes: {
+      listPublicPricingItems: async () => [],
+    },
+    publicReportAccessRoutes: buildPublicReportAccessRouteStubs(),
+    reportAccessTokensRoutes: buildReportAccessTokensRouteStubs(),
+    reportsRoutes: buildReportsRouteStubs(),
+    reportsStatusRoutes: buildReportsStatusRouteStubs(),
+    studyTrackingRoutes: buildStudyTrackingRouteStubs(),
+    logisticsFieldVisitsRoutes: buildLogisticsFieldVisitsRouteStubs(),
+    logisticsRoutePlansRoutes: buildLogisticsRoutePlansRouteStubs(),
+    logisticsRouteEventsRoutes: buildLogisticsRouteEventsRouteStubs(),
+    logisticsSlaRoutes: buildLogisticsSlaRouteStubs(),
+  };
+}


### PR DESCRIPTION
## Summary
- Extract fastify-app test snapshots and route stubs to test/helpers/fastify-app-route-stubs.ts.
- Keep fastify-app.test.ts as the app-level suite for now.
- Prepare future split by buckets without changing runtime behavior.
- Add TEST-ARCH-38 implementation report.

## Scope
- Manual-only.
- No Codex.
- No Claude.
- No runtime/producto changes.
- No DB/schema/migrations.
- No CI/deps/package.json/pnpm-lock.yaml changes.

## Validation
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface