### PR TITLE
test(architecture): move token domain batch

### DIFF
--- a/docs/implementation/test-arch-40-token-domain-batch.md
+++ b/docs/implementation/test-arch-40-token-domain-batch.md
@@ -1,0 +1,55 @@
+# TEST-ARCH-40 - Token domain batch
+
+## Summary
+
+Moves a small pure token/domain test batch from root test/ into test/unit/domain.
+
+## Files moved
+
+- test/particular-token.test.ts -> test/unit/domain/particular-token.test.ts
+- test/report-access-token.test.ts -> test/unit/domain/report-access-token.test.ts
+- test/report-access-token-serializers.test.ts -> test/unit/domain/report-access-token-serializers.test.ts
+- test/report-access-token-helpers.test.ts -> test/unit/domain/report-access-token-helpers.test.ts
+
+## Imports adjusted
+
+- ../server/lib/particular-token.ts -> ../../../server/lib/particular-token.ts
+- ../server/lib/report-access-token.ts -> ../../../server/lib/report-access-token.ts
+
+## Guardrails updated
+
+- test/reports-suite-completeness.test.ts now points to the moved token/domain paths:
+  - test/unit/domain/report-access-token.test.ts
+  - test/unit/domain/particular-token.test.ts
+
+## Scope
+
+Test/docs only.
+
+No runtime changes.
+No functional rewrites.
+No DB changes.
+No schema or migrations.
+No dependency changes.
+No lockfile changes.
+No CI changes.
+
+## Rationale
+
+The moved files exercise pure token schemas, helpers and serializers through node:test and node:assert/strict.
+
+They do not use Fastify, app.inject, HTTP, DB, filesystem, network, Playwright or production credentials.
+
+The reports suite completeness guardrail owns explicit report and particular token lifecycle anchors, so its registry must follow the mechanical file move.
+
+## Validation
+
+Required before commit:
+
+- git diff --check
+- pnpm typecheck:test
+- pnpm exec node --experimental-strip-types --test test/reports-suite-completeness.test.ts
+- pnpm exec node --experimental-strip-types --test test/unit/domain/particular-token.test.ts test/unit/domain/report-access-token.test.ts test/unit/domain/report-access-token-serializers.test.ts test/unit/domain/report-access-token-helpers.test.ts
+- pnpm test
+- pnpm build
+- pnpm security:public-surface

--- a/test/reports-suite-completeness.test.ts
+++ b/test/reports-suite-completeness.test.ts
@@ -184,7 +184,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       "Clinic and admin report access tokens preserve creation, revoke, state, public path and lifecycle behavior.",
     testFiles: [
       {
-        path: "test/report-access-token.test.ts",
+        path: "test/unit/domain/report-access-token.test.ts",
         markers: [
           "reportAccessTokenRawTokenSchema",
           "clinicCreateReportAccessTokenSchema",
@@ -288,7 +288,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
         ],
       },
       {
-        path: "test/particular-token.test.ts",
+        path: "test/unit/domain/particular-token.test.ts",
         markers: [
           "serializeParticularToken",
           "serializeParticularTokenDetail",

--- a/test/unit/domain/particular-token.test.ts
+++ b/test/unit/domain/particular-token.test.ts
@@ -9,7 +9,7 @@ import {
   serializeParticularToken,
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
-} from "../server/lib/particular-token.ts";
+} from "../../../server/lib/particular-token.ts";
 
 test("clinicCreateParticularTokenSchema normaliza detailsLesion vacío y reportId null", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({

--- a/test/unit/domain/report-access-token-helpers.test.ts
+++ b/test/unit/domain/report-access-token-helpers.test.ts
@@ -6,7 +6,7 @@ import {
   parseEntityId,
   parseOffset,
   parsePositiveInt,
-} from "../server/lib/report-access-token.ts";
+} from "../../../server/lib/report-access-token.ts";
 
 test("parsePositiveInt respeta fallback y límite máximo", () => {
   assert.equal(parsePositiveInt("25", 50, 100), 25);

--- a/test/unit/domain/report-access-token-serializers.test.ts
+++ b/test/unit/domain/report-access-token-serializers.test.ts
@@ -4,7 +4,7 @@ import {
   serializePublicReportAccess,
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
-} from "../server/lib/report-access-token.ts";
+} from "../../../server/lib/report-access-token.ts";
 
 test("serializeReportAccessToken expone estado y banderas derivadas", () => {
   const token = {

--- a/test/unit/domain/report-access-token.test.ts
+++ b/test/unit/domain/report-access-token.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+﻿import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildPublicReportAccessPath,
@@ -8,7 +8,7 @@ import {
   isReportAccessTokenExpired,
   isReportAccessTokenRevoked,
   reportAccessTokenRawTokenSchema,
-} from "../server/lib/report-access-token.ts";
+} from "../../../server/lib/report-access-token.ts";
 
 test("reportAccessTokenRawTokenSchema acepta tokens hex de 64 caracteres", () => {
   const token = "a".repeat(64);
@@ -70,7 +70,7 @@ test("public report access solo permite ready y delivered", () => {
   assert.equal(canAccessReportPublicly("delivered"), true);
 });
 
-test("helpers de expiración y revocación funcionan correctamente", () => {
+test("helpers de expiraciÃ³n y revocaciÃ³n funcionan correctamente", () => {
   const now = new Date("2026-04-15T12:00:00.000Z");
 
   assert.equal(
@@ -85,7 +85,7 @@ test("helpers de expiración y revocación funcionan correctamente", () => {
   assert.equal(isReportAccessTokenRevoked(null), false);
 });
 
-test("buildPublicReportAccessPath construye la ruta pública esperada", () => {
+test("buildPublicReportAccessPath construye la ruta pÃºblica esperada", () => {
   const token = "b".repeat(64);
   assert.equal(
     buildPublicReportAccessPath(token),


### PR DESCRIPTION
## Summary
- Moves a small pure token/domain test batch into test/unit/domain
- Updates relative imports required by the mechanical move
- Updates reports suite completeness guardrail paths
- Documents the migration in docs/implementation/test-arch-40-token-domain-batch.md

## Validation
- pnpm typecheck:test
- pnpm exec node --experimental-strip-types --test test/reports-suite-completeness.test.ts
- pnpm exec node --experimental-strip-types --test test/unit/domain/particular-token.test.ts test/unit/domain/report-access-token.test.ts test/unit/domain/report-access-token-serializers.test.ts test/unit/domain/report-access-token-helpers.test.ts
- pnpm test
- pnpm build
- pnpm security:public-surface

Test/docs only. No runtime, deps, lockfiles, CI, DB, schema, migrations, or functional rewrites.