### PR TITLE
test(architecture): move schema health domain test

### DIFF
--- a/docs/implementation/test-arch-42-schema-health-domain.md
+++ b/docs/implementation/test-arch-42-schema-health-domain.md
@@ -1,0 +1,6 @@
+# TEST-ARCH-42 - Schema health domain test move
+
+Moved test/schema-health.lib.test.ts to test/unit/domain/schema-health.lib.test.ts.
+Updated import to ../../../server/lib/schema-health.ts.
+Validation: pnpm typecheck:test; node --import tsx --test test\unit\domain\schema-health.lib.test.ts.
+Safety: no runtime, API, database, schema, migration, dependency, lockfile, CI, or functional changes.

--- a/test/unit/domain/schema-health.lib.test.ts
+++ b/test/unit/domain/schema-health.lib.test.ts
@@ -8,7 +8,7 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 
 const { CRITICAL_SCHEMA_COLUMNS, buildSchemaHealthSnapshotFromRows } =
-  await import("../server/lib/schema-health.ts");
+  await import("../../../server/lib/schema-health.ts");
 
 function allPresentRows() {
   const rows: Array<{


### PR DESCRIPTION
## Summary
- Move schema health lib test into test/unit/domain
- Update relative import after mechanical git mv
- Add TEST-ARCH-42 implementation report

## Validation
- pnpm typecheck:test
- node --import tsx --test test\unit\domain\schema-health.lib.test.ts

## Safety
- No runtime/product changes
- No API changes
- No database/schema/migration/dependency/lockfile/CI changes
- No functional rewrite