### PR TITLE
test(architecture): move admin token schema tests

### DIFF
--- a/docs/implementation/test-arch-52-admin-token-schema-tests.md
+++ b/docs/implementation/test-arch-52-admin-token-schema-tests.md
@@ -1,0 +1,7 @@
+# TEST-ARCH-52 - Admin token schema tests
+
+Moved two admin token schema contract tests from root test/ into test/unit/contracts/admin/.
+
+Updated only test-relative imports after relocation.
+
+Guardrails: no runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.

--- a/test/unit/contracts/admin/admin-particular-token-schema.test.ts
+++ b/test/unit/contracts/admin/admin-particular-token-schema.test.ts
@@ -1,8 +1,8 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   adminCreateParticularTokenSchema,
-} from "../server/lib/particular-token.ts";
+} from "../../../../server/lib/particular-token.ts";
 
 test("adminCreateParticularTokenSchema requiere clinicId válido y normaliza campos base", () => {
   const parsed = adminCreateParticularTokenSchema.safeParse({

--- a/test/unit/contracts/admin/admin-report-access-token-schema.test.ts
+++ b/test/unit/contracts/admin/admin-report-access-token-schema.test.ts
@@ -1,8 +1,8 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   adminCreateReportAccessTokenSchema,
-} from "../server/lib/report-access-token.ts";
+} from "../../../../server/lib/report-access-token.ts";
 
 test("adminCreateReportAccessTokenSchema requiere clinicId y reportId válidos", () => {
   const parsed = adminCreateReportAccessTokenSchema.safeParse({


### PR DESCRIPTION
Moves two admin token schema contract tests into test/unit/contracts/admin/ and updates only test-relative imports after relocation. Validated with pnpm typecheck:test, targeted node:test, and git diff checks. No runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.