### PR TITLE
test(architecture): move admin audit tests

### DIFF
--- a/docs/implementation/test-arch-53-admin-audit-tests.md
+++ b/docs/implementation/test-arch-53-admin-audit-tests.md
@@ -1,0 +1,7 @@
+# TEST-ARCH-53 - Admin audit tests
+
+Moved three admin audit contract tests from root test/ into test/unit/contracts/admin/.
+
+Updated only test-relative imports after relocation.
+
+Guardrails: no runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.

--- a/test/unit/contracts/admin/admin-audit-constants.test.ts
+++ b/test/unit/contracts/admin/admin-audit-constants.test.ts
@@ -1,10 +1,10 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   ADMIN_AUDIT_ACTOR_TYPES,
   ADMIN_AUDIT_EVENTS,
   AUDIT_LOG_CSV_HEADERS,
-} from "../server/lib/admin-audit.ts";
+} from "../../../../server/lib/admin-audit.ts";
 
 test("ADMIN_AUDIT_ACTOR_TYPES expone strings únicos y normalizados", () => {
   assert.equal(Array.isArray(ADMIN_AUDIT_ACTOR_TYPES), true);

--- a/test/unit/contracts/admin/admin-audit-edge.test.ts
+++ b/test/unit/contracts/admin/admin-audit-edge.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildAdminAuditCsv,
@@ -6,7 +6,7 @@ import {
   buildClinicAuditListFilters,
   normalizeAuditListMetadata,
   serializeAuditLogListItem,
-} from "../server/lib/admin-audit.ts";
+} from "../../../../server/lib/admin-audit.ts";
 
 test("buildAdminAuditListFilters acumula errores para filtros invalidos y limita paginacion maxima", () => {
   const { filters, errors } = buildAdminAuditListFilters({

--- a/test/unit/contracts/admin/admin-audit.test.ts
+++ b/test/unit/contracts/admin/admin-audit.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildAdminAuditCsv,
@@ -6,7 +6,7 @@ import {
   buildAdminAuditListFilters,
   normalizeAuditListMetadata,
   serializeAuditLogListItem,
-} from "../server/lib/admin-audit.ts";
+} from "../../../../server/lib/admin-audit.ts";
 
 test("buildAdminAuditListFilters parsea filtros validos", () => {
   const { filters, errors } = buildAdminAuditListFilters({


### PR DESCRIPTION
Moves three admin audit contract tests into test/unit/contracts/admin/ and updates only test-relative imports after relocation. Validated with pnpm typecheck:test, targeted node:test, and git diff checks. No runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.