### PR TITLE
test(architecture): move final admin root tests

### DIFF
--- a/docs/implementation/test-arch-55-admin-root-final.md
+++ b/docs/implementation/test-arch-55-admin-root-final.md
@@ -1,0 +1,7 @@
+# TEST-ARCH-55 - Admin root final cleanup
+
+Moved the final two admin root tests into structured test directories.
+
+Updated only test-relative imports after relocation.
+
+Guardrails: no runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.

--- a/test/unit/contracts/admin/admin-heavy-list-pagination-contract.test.ts
+++ b/test/unit/contracts/admin/admin-heavy-list-pagination-contract.test.ts
@@ -4,7 +4,7 @@ import { resolve } from "node:path";
 import test from "node:test";
 
 const { normalizeListPagination } = await import(
-  "../server/lib/list-pagination.ts"
+  "../../../../server/lib/list-pagination.ts"
 );
 
 function readSource(path: string) {

--- a/test/unit/ui/admin/admin-dashboard-responsive-touch.test.ts
+++ b/test/unit/ui/admin/admin-dashboard-responsive-touch.test.ts
@@ -2,7 +2,7 @@ import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import test from "node:test";
-import { readDashboardCssSource } from "./helpers/read-dashboard-css-source.ts";
+import { readDashboardCssSource } from "../../../helpers/read-dashboard-css-source.ts";
 
 function read(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(


### PR DESCRIPTION
Moves the final two admin root tests into structured test directories and updates only test-relative imports after relocation. Validated with pnpm typecheck:test, targeted node:test, git diff checks, and confirmed no test/admin-*.test.ts files remain. No runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.