### PR TITLE
test(architecture): update admin registry paths

### DIFF
--- a/docs/implementation/test-arch-56-admin-registry-paths.md
+++ b/docs/implementation/test-arch-56-admin-registry-paths.md
@@ -1,0 +1,7 @@
+# TEST-ARCH-56 - Admin registry paths
+
+Updated test registry expectations after the final admin root test relocation.
+
+The audit suite completeness registry now points to relocated admin audit tests, and the global e2e readiness registry now points to the relocated admin heavy-list pagination contract.
+
+Guardrails: no runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -293,7 +293,7 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         markers: ["adminAuditNativeRoutes", "export.csv", "filtros"],
       },
       {
-        path: "test/admin-audit-runtime-timing-contract.test.ts",
+        path: "test/unit/contracts/admin/admin-audit-runtime-timing-contract.test.ts",
         markers: [
           "admin audit request logging uses shared runtime timing helper",
           "createRuntimeTimer",
@@ -302,11 +302,11 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         ],
       },
       {
-        path: "test/admin-audit.test.ts",
+        path: "test/unit/contracts/admin/admin-audit.test.ts",
         markers: ["buildAdminAuditListFilters", "buildAdminAuditCsv"],
       },
       {
-        path: "test/admin-audit-constants.test.ts",
+        path: "test/unit/contracts/admin/admin-audit-constants.test.ts",
         markers: [
           "ADMIN_AUDIT_ACTOR_TYPES expone strings",
           "ADMIN_AUDIT_EVENTS expone eventos",
@@ -314,7 +314,7 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         ],
       },
       {
-        path: "test/admin-audit-edge.test.ts",
+        path: "test/unit/contracts/admin/admin-audit-edge.test.ts",
         markers: [
           "buildAdminAuditListFilters acumula errores",
           "normalizeAuditListMetadata rechaza roots",
@@ -323,7 +323,7 @@ const AUDIT_SUITE: readonly AuditSuiteEntry[] = [
         ],
       },
       {
-        path: "test/admin-audit-enterprise-density.test.ts",
+        path: "test/unit/ui/admin/admin-audit-enterprise-density.test.ts",
         markers: [
           "R-06 preserves the real audit-log navigation surface",
           "R-06 uses RF debounced viewport-adaptive pagination",
@@ -667,3 +667,4 @@ test("audit suite completeness guardrail source stays ascii only", () => {
     );
   }
 });
+

--- a/test/audit-suite-completeness.test.ts
+++ b/test/audit-suite-completeness.test.ts
@@ -667,4 +667,3 @@ test("audit suite completeness guardrail source stays ascii only", () => {
     );
   }
 });
-

--- a/test/global-e2e-production-readiness-contract.test.ts
+++ b/test/global-e2e-production-readiness-contract.test.ts
@@ -173,7 +173,7 @@ const GLOBAL_SURFACES: readonly GlobalSurface[] = [
     ],
     guardrailFiles: [
       {
-        path: "test/admin-heavy-list-pagination-contract.test.ts",
+        path: "test/unit/contracts/admin/admin-heavy-list-pagination-contract.test.ts",
         markers: ["normalizeListPagination clampa max limit y offset"],
       },
       {
@@ -347,3 +347,4 @@ test("global e2e readiness guardrail source stays ascii only", () => {
     );
   }
 });
+

--- a/test/global-e2e-production-readiness-contract.test.ts
+++ b/test/global-e2e-production-readiness-contract.test.ts
@@ -347,4 +347,3 @@ test("global e2e readiness guardrail source stays ascii only", () => {
     );
   }
 });
-


### PR DESCRIPTION
Updates test registry expectations after relocating the final admin root tests. Validated with pnpm typecheck:test, targeted registry tests, full pnpm test, and git diff checks. No runtime/product/API/auth/DB/schema/migration/dependency/lockfile/CI changes.