### PR TITLE
test(architecture): move email logger infrastructure tests

### DIFF
--- a/docs/implementation/test-arch-76-root-email-logger-contracts.md
+++ b/docs/implementation/test-arch-76-root-email-logger-contracts.md
@@ -1,0 +1,28 @@
+# TEST-ARCH-76 — Email and logger root contracts
+
+## Scope
+
+Moved a focused batch of root-level email, logger and request logger contract tests into:
+
+- `test/unit/infrastructure/`
+
+## Files moved
+
+- `test/email-gmail-api.test.ts`
+- `test/email-html-templates.test.ts`
+- `test/email-safe-metadata.test.ts`
+- `test/email-success.test.ts`
+- `test/logger-and-email.test.ts`
+- `test/request-logger-edge.test.ts`
+- `test/request-logger-middleware.test.ts`
+- `test/request-logger.test.ts`
+
+## Allowed changes
+
+- Test file moves only.
+- Relative import/path adjustments required by the new test depth.
+- Documentation under `docs/implementation/`.
+
+## Explicit non-scope
+
+No runtime, product, API, auth, database, schema, migrations, dependency, lockfile or CI changes.

--- a/test/security-rate-limit-isolation-boundaries.test.ts
+++ b/test/security-rate-limit-isolation-boundaries.test.ts
@@ -581,7 +581,7 @@ test("rate-limited responses are logged with the shared RATE_LIMITED marker only
 
   for (const file of [
     "test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts",
-    "test/request-logger.test.ts",
+    "test/unit/infrastructure/request-logger.test.ts",
   ] as const) {
     const source = readSource(file);
     assertContains(source, "RATE_LIMITED", `${file} runtime marker coverage`);

--- a/test/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/security-sensitive-log-redaction-boundaries.test.ts
@@ -241,10 +241,10 @@ test("contact smtp failure logging keeps diagnostics allowlist and avoids secret
 });
 
 test("runtime tests remain explicit for redaction and secret-safe logging", () => {
-  const requestLoggerTests = readSource("test/request-logger.test.ts");
-  const requestLoggerEdgeTests = readSource("test/request-logger-edge.test.ts");
-  const requestLoggerMiddlewareTests = readSource("test/request-logger-middleware.test.ts");
-  const loggerAndEmailTests = readSource("test/logger-and-email.test.ts");
+  const requestLoggerTests = readSource("test/unit/infrastructure/request-logger.test.ts");
+  const requestLoggerEdgeTests = readSource("test/unit/infrastructure/request-logger-edge.test.ts");
+  const requestLoggerMiddlewareTests = readSource("test/unit/infrastructure/request-logger-middleware.test.ts");
+  const loggerAndEmailTests = readSource("test/unit/infrastructure/logger-and-email.test.ts");
   const productionInvariants = readSource("test/security-production-invariants.test.ts");
   const smokeEnvContract = readSource("test/unit/infrastructure/smoke-env-contract.test.ts");
 

--- a/test/study-tracking-suite-completeness.test.ts
+++ b/test/study-tracking-suite-completeness.test.ts
@@ -181,7 +181,7 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
       "Special stain email coverage keeps recipient normalization, SMTP payload construction and send logging explicit.",
     testFiles: [
       {
-        path: "test/email-success.test.ts",
+        path: "test/unit/infrastructure/email-success.test.ts",
         markers: [
           "sendSpecialStainRequiredEmail",
           "nodemailer.createTransport",
@@ -191,7 +191,7 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
         ],
       },
       {
-        path: "test/logger-and-email.test.ts",
+        path: "test/unit/infrastructure/logger-and-email.test.ts",
         markers: [
           "sendSpecialStainRequiredEmail",
           "SMTP",

--- a/test/unit/infrastructure/email-gmail-api.test.ts
+++ b/test/unit/infrastructure/email-gmail-api.test.ts
@@ -8,8 +8,8 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
-const { sendContactMessageEmail } = await import("../server/lib/email.ts");
+const { ENV } = await import("../../../server/lib/env.ts");
+const { sendContactMessageEmail } = await import("../../../server/lib/email.ts");
 
 type EmailEnvSnapshot = {
   isProduction: boolean;

--- a/test/unit/infrastructure/email-html-templates.test.ts
+++ b/test/unit/infrastructure/email-html-templates.test.ts
@@ -8,11 +8,11 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../server/lib/env.ts");
 const {
   sendParticularTokenEmail,
   sendContactMessageEmail,
-} = await import("../server/lib/email.ts");
+} = await import("../../../server/lib/email.ts");
 
 // ─── helpers ─────────────────────────────────────────────────────────────────
 
@@ -144,7 +144,7 @@ test("HTML builders escapan caracteres peligrosos en datos dinamicos", async () 
 test("Gmail API genera text/plain cuando la funcion no aporta html (sendSpecialStainRequiredEmail)", async () => {
   // sendSpecialStainRequiredEmail is NOT wired to an HTML builder — it still
   // sends text/plain only. This test confirms the no-html fallback path.
-  const { sendSpecialStainRequiredEmail } = await import("../server/lib/email.ts");
+  const { sendSpecialStainRequiredEmail } = await import("../../../server/lib/email.ts");
   const snap = snapshotEnv();
   const originalFetch = globalThis.fetch;
   let rawMessage = "";

--- a/test/unit/infrastructure/email-safe-metadata.test.ts
+++ b/test/unit/infrastructure/email-safe-metadata.test.ts
@@ -7,9 +7,9 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../server/lib/env.ts");
 const { getSafeEmailTransportErrorMetadata, sendContactMessageEmail } = await import(
-  "../server/lib/email.ts"
+  "../../../server/lib/email.ts"
 );
 
 type EmailEnvSnapshot = {

--- a/test/unit/infrastructure/email-success.test.ts
+++ b/test/unit/infrastructure/email-success.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import nodemailer from "nodemailer";
 
@@ -8,11 +8,11 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
+const { ENV } = await import("../../../server/lib/env.ts");
 const {
   sendParticularTokenEmail,
   sendSpecialStainRequiredEmail,
-} = await import("../server/lib/email.ts");
+} = await import("../../../server/lib/email.ts");
 
 test("sendParticularTokenEmail envia token particular con payload minimo", async () => {
   const originalInfo = console.info;

--- a/test/unit/infrastructure/logger-and-email.test.ts
+++ b/test/unit/infrastructure/logger-and-email.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -8,7 +8,7 @@ import {
   logInfo,
   logWarn,
   serializeError,
-} from "../server/lib/logger.ts";
+} from "../../../server/lib/logger.ts";
 
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
 process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
@@ -16,8 +16,8 @@ process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
 process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
-const { ENV } = await import("../server/lib/env.ts");
-const { sendContactMessageEmail, sendSpecialStainRequiredEmail } = await import("../server/lib/email.ts");
+const { ENV } = await import("../../../server/lib/env.ts");
+const { sendContactMessageEmail, sendSpecialStainRequiredEmail } = await import("../../../server/lib/email.ts");
 
 test("logInfo agrega prefijo [INFO]", () => {
   const original = console.log;

--- a/test/unit/infrastructure/request-logger-edge.test.ts
+++ b/test/unit/infrastructure/request-logger-edge.test.ts
@@ -1,10 +1,10 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildRequestLogLine,
   requestLogger,
   sanitizeUrlForLogs,
-} from "../server/middlewares/request-logger.ts";
+} from "../../../server/middlewares/request-logger.ts";
 
 function createMockResponse(statusCode = 200) {
   const listeners = new Map<string, Array<() => void>>();

--- a/test/unit/infrastructure/request-logger-middleware.test.ts
+++ b/test/unit/infrastructure/request-logger-middleware.test.ts
@@ -1,9 +1,9 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildRequestLogLine,
   requestLogger,
-} from "../server/middlewares/request-logger.ts";
+} from "../../../server/middlewares/request-logger.ts";
 
 function createMockResponse(statusCode = 200) {
   const listeners = new Map<string, Array<() => void>>();

--- a/test/unit/infrastructure/request-logger.test.ts
+++ b/test/unit/infrastructure/request-logger.test.ts
@@ -1,9 +1,9 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,
-} from "../server/middlewares/request-logger.ts";
+} from "../../../server/middlewares/request-logger.ts";
 
 test("sanitizeUrlForLogs redacts public report access token in path", () => {
   const rawUrl = `/api/public/report-access/${"a".repeat(64)}?foo=bar`;


### PR DESCRIPTION
## Summary
- Move root-level email, logger and request logger tests into test/unit/infrastructure.
- Update relative imports and guardrail path references after the move.
- Document TEST-ARCH-76 under docs/implementation.

## Validation
- pnpm typecheck:test
- pnpm exec tsx --test test/unit/infrastructure/email-gmail-api.test.ts test/unit/infrastructure/email-html-templates.test.ts test/unit/infrastructure/email-safe-metadata.test.ts test/unit/infrastructure/email-success.test.ts test/unit/infrastructure/logger-and-email.test.ts test/unit/infrastructure/request-logger-edge.test.ts test/unit/infrastructure/request-logger-middleware.test.ts test/unit/infrastructure/request-logger.test.ts
- pnpm exec tsx --test test/security-sensitive-log-redaction-boundaries.test.ts test/study-tracking-suite-completeness.test.ts test/security-rate-limit-isolation-boundaries.test.ts
- pnpm test