### PR TITLE
test(architecture): move logistics domain tests

### DIFF
--- a/docs/implementation/test-arch-77-logistics-domain-root-tests.md
+++ b/docs/implementation/test-arch-77-logistics-domain-root-tests.md
@@ -1,0 +1,27 @@
+# TEST-ARCH-77 — Logistics domain root tests
+
+## Scope
+
+Moved a focused batch of root-level logistics domain and pure logic tests into:
+
+- `test/unit/domain/logistics/`
+
+## Files moved
+
+- `test/logistics-domain-barrel.test.ts`
+- `test/logistics-pagination.test.ts`
+- `test/logistics-route-planning.test.ts`
+- `test/logistics-sla-compliance.test.ts`
+- `test/logistics-metrics.test.ts`
+- `test/logistics-route-event-aggregation.test.ts`
+- `test/logistics-heuristic-field-visit-ids.test.ts`
+
+## Allowed changes
+
+- Test file moves only.
+- Relative import/path adjustments required by the new test depth.
+- Documentation under `docs/implementation/`.
+
+## Explicit non-scope
+
+No runtime, product, API, auth, database, schema, migrations, dependency, lockfile or CI changes.

--- a/test/logistics-metrics-suite-completeness.test.ts
+++ b/test/logistics-metrics-suite-completeness.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -11,9 +11,9 @@ function readRepoFile(path: string): string {
 
 test("logistics metrics suite keeps required test files", () => {
   const requiredTestFiles = [
-    "test/logistics-metrics.test.ts",
-    "test/logistics-sla-compliance.test.ts",
-    "test/logistics-route-event-aggregation.test.ts",
+    "test/unit/domain/logistics/logistics-metrics.test.ts",
+    "test/unit/domain/logistics/logistics-sla-compliance.test.ts",
+    "test/unit/domain/logistics/logistics-route-event-aggregation.test.ts",
   ];
 
   for (const file of requiredTestFiles) {
@@ -22,7 +22,7 @@ test("logistics metrics suite keeps required test files", () => {
 });
 
 test("logistics metrics suite keeps route compliance coverage", () => {
-  const testFile = readRepoFile("test/logistics-metrics.test.ts");
+  const testFile = readRepoFile("test/unit/domain/logistics/logistics-metrics.test.ts");
 
   const requiredCoverage = [
     "calculateRouteDistanceCompliance",
@@ -38,7 +38,7 @@ test("logistics metrics suite keeps route compliance coverage", () => {
 });
 
 test("logistics metrics suite keeps SLA compliance coverage", () => {
-  const testFile = readRepoFile("test/logistics-sla-compliance.test.ts");
+  const testFile = readRepoFile("test/unit/domain/logistics/logistics-sla-compliance.test.ts");
 
   const requiredCoverage = [
     "classifySlaCompliance",
@@ -57,7 +57,7 @@ test("logistics metrics suite keeps SLA compliance coverage", () => {
 });
 
 test("logistics metrics suite keeps route event aggregation coverage", () => {
-  const testFile = readRepoFile("test/logistics-route-event-aggregation.test.ts");
+  const testFile = readRepoFile("test/unit/domain/logistics/logistics-route-event-aggregation.test.ts");
 
   const requiredCoverage = [
     "summarizeRouteEvents",

--- a/test/unit/domain/logistics/logistics-domain-barrel.test.ts
+++ b/test/unit/domain/logistics/logistics-domain-barrel.test.ts
@@ -7,7 +7,7 @@ import {
   normalizeGenerateHeuristicFieldVisitIds,
   normalizeLogisticsLimit,
   normalizeLogisticsOffset,
-} from "../server/features/logistics/domain/index.ts";
+} from "../../../../server/features/logistics/domain/index.ts";
 
 test("logistics domain barrel re-exports the pagination helpers unchanged", () => {
   assert.equal(LOGISTICS_DEFAULT_LIMIT, 50);

--- a/test/unit/domain/logistics/logistics-heuristic-field-visit-ids.test.ts
+++ b/test/unit/domain/logistics/logistics-heuristic-field-visit-ids.test.ts
@@ -1,7 +1,7 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import { normalizeGenerateHeuristicFieldVisitIds } from "../server/features/logistics/domain/route-plan-field-visits.ts";
+import { normalizeGenerateHeuristicFieldVisitIds } from "../../../../server/features/logistics/domain/route-plan-field-visits.ts";
 
 test("normalizeGenerateHeuristicFieldVisitIds keeps unique positive integers in first-seen order", () => {
   assert.deepEqual(

--- a/test/unit/domain/logistics/logistics-metrics.test.ts
+++ b/test/unit/domain/logistics/logistics-metrics.test.ts
@@ -7,7 +7,7 @@ import {
   calculateRouteStopComplianceMetrics,
   classifyTimeWindowCompliance,
   summarizeWindowCompliance,
-} from "../server/lib/logistics/metrics.ts";
+} from "../../../../server/lib/logistics/metrics.ts";
 
 test("calculateRouteDistanceCompliance returns planned vs actual distance metrics", () => {
   assert.deepEqual(

--- a/test/unit/domain/logistics/logistics-pagination.test.ts
+++ b/test/unit/domain/logistics/logistics-pagination.test.ts
@@ -6,7 +6,7 @@ import {
   LOGISTICS_MAX_LIMIT,
   normalizeLogisticsLimit,
   normalizeLogisticsOffset,
-} from "../server/features/logistics/domain/pagination.ts";
+} from "../../../../server/features/logistics/domain/pagination.ts";
 
 test("LOGISTICS_DEFAULT_LIMIT and LOGISTICS_MAX_LIMIT keep their bounded values", () => {
   assert.equal(LOGISTICS_DEFAULT_LIMIT, 50);

--- a/test/unit/domain/logistics/logistics-route-event-aggregation.test.ts
+++ b/test/unit/domain/logistics/logistics-route-event-aggregation.test.ts
@@ -1,11 +1,11 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import {
   calculateDurationBetweenRouteEvents,
   getRouteEventBoundariesByRoutePlan,
   getRouteEventBoundariesByRouteStop,
   summarizeRouteEvents,
-} from "../server/lib/logistics/metrics.ts";
+} from "../../../../server/lib/logistics/metrics.ts";
 
 const events = [
   {

--- a/test/unit/domain/logistics/logistics-route-planning.test.ts
+++ b/test/unit/domain/logistics/logistics-route-planning.test.ts
@@ -1,11 +1,11 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
   buildHeuristicRoutePlan,
   calculateHaversineKm,
   type RoutePlanningVisit,
-} from "../server/lib/logistics/route-planning.ts";
+} from "../../../../server/lib/logistics/route-planning.ts";
 
 const routeStart = new Date("2026-05-04T12:00:00.000Z");
 
@@ -194,4 +194,3 @@ test("buildHeuristicRoutePlan rejects invalid routeStart dates", () => {
     /routeStart must be a valid Date/,
   );
 });
-

--- a/test/unit/domain/logistics/logistics-sla-compliance.test.ts
+++ b/test/unit/domain/logistics/logistics-sla-compliance.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
   classifySlaCompliance,
   summarizeSlaCompliance,
-} from "../server/lib/logistics/metrics.ts";
+} from "../../../../server/lib/logistics/metrics.ts";
 
 const now = new Date("2026-05-03T12:00:00.000Z");
 


### PR DESCRIPTION
## Summary
- Move focused root-level logistics domain and pure logic tests into test/unit/domain/logistics.
- Update relative imports and logistics metrics suite guardrail path references after the move.
- Document TEST-ARCH-77 under docs/implementation.

## Validation
- pnpm typecheck:test
- pnpm exec tsx --test test/unit/domain/logistics/logistics-domain-barrel.test.ts test/unit/domain/logistics/logistics-pagination.test.ts test/unit/domain/logistics/logistics-route-planning.test.ts test/unit/domain/logistics/logistics-sla-compliance.test.ts test/unit/domain/logistics/logistics-metrics.test.ts test/unit/domain/logistics/logistics-route-event-aggregation.test.ts test/unit/domain/logistics/logistics-heuristic-field-visit-ids.test.ts
- pnpm exec tsx --test test/logistics-metrics-suite-completeness.test.ts
- pnpm test