### PR TITLE
test(architecture): move logistics schema tests

### DIFF
--- a/docs/implementation/test-arch-78-logistics-schema-root-tests.md
+++ b/docs/implementation/test-arch-78-logistics-schema-root-tests.md
@@ -1,0 +1,25 @@
+# TEST-ARCH-78 — Logistics schema root tests
+
+## Scope
+
+Moved a focused batch of root-level logistics schema tests into:
+
+- `test/unit/migrations/logistics/`
+
+## Files moved
+
+- `test/logistics-field-visits-schema.test.ts`
+- `test/logistics-route-events-schema.test.ts`
+- `test/logistics-route-plans-stops-schema.test.ts`
+- `test/logistics-sla-schema.test.ts`
+- `test/logistics-time-windows-schema.test.ts`
+
+## Allowed changes
+
+- Test file moves only.
+- Relative import/path adjustments required by the new test depth.
+- Documentation under `docs/implementation/`.
+
+## Explicit non-scope
+
+No runtime, product, API, auth, database, schema, migrations, dependency, lockfile or CI changes.

--- a/test/unit/migrations/logistics/logistics-field-visits-schema.test.ts
+++ b/test/unit/migrations/logistics/logistics-field-visits-schema.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
@@ -8,7 +8,7 @@ import {
   VISIT_LOCATION_GEO_QUALITIES,
   fieldVisits,
   visitLocations,
-} from "../drizzle/schema.ts";
+} from "../../../../drizzle/schema.ts";
 
 function assertNormalizedUniqueValues(
   values: readonly string[],

--- a/test/unit/migrations/logistics/logistics-route-events-schema.test.ts
+++ b/test/unit/migrations/logistics/logistics-route-events-schema.test.ts
@@ -6,7 +6,7 @@ import {
   ROUTE_EVENT_SOURCES,
   ROUTE_EVENT_TYPES,
   routeEvents,
-} from "../drizzle/schema.ts";
+} from "../../../../drizzle/schema.ts";
 
 function assertUniqueValues(values: readonly string[], label: string) {
   const unique = new Set(values);

--- a/test/unit/migrations/logistics/logistics-route-plans-stops-schema.test.ts
+++ b/test/unit/migrations/logistics/logistics-route-plans-stops-schema.test.ts
@@ -10,7 +10,7 @@ import {
   ROUTE_STOP_STATUSES,
   routePlans,
   routeStops,
-} from "../drizzle/schema.ts";
+} from "../../../../drizzle/schema.ts";
 
 function assertNormalizedUniqueValues(
   values: readonly string[],

--- a/test/unit/migrations/logistics/logistics-sla-schema.test.ts
+++ b/test/unit/migrations/logistics/logistics-sla-schema.test.ts
@@ -8,7 +8,7 @@ import {
   SLA_TARGET_TYPES,
   slaInstances,
   slaPolicies,
-} from "../drizzle/schema.ts";
+} from "../../../../drizzle/schema.ts";
 
 function assertNormalizedUniqueValues(
   values: readonly string[],

--- a/test/unit/migrations/logistics/logistics-time-windows-schema.test.ts
+++ b/test/unit/migrations/logistics/logistics-time-windows-schema.test.ts
@@ -2,14 +2,14 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { timeWindows } from "../drizzle/schema.ts";
+import { timeWindows } from "../../../../drizzle/schema.ts";
 import {
   DEFAULT_TIME_WINDOW_TIMEZONE,
   TIME_WINDOW_TIMEZONE_MAX_LENGTH,
   assertValidTimeWindowRange,
   isValidTimeWindowRange,
   normalizeTimeWindowTimezone,
-} from "../server/lib/logistics/time-window.ts";
+} from "../../../../server/lib/logistics/time-window.ts";
 
 test("logistics schema exports time windows table", () => {
   assert.equal(typeof timeWindows, "object");


### PR DESCRIPTION
## Summary
- Move focused root-level logistics schema tests into test/unit/migrations/logistics.
- Update relative imports after the move.
- Document TEST-ARCH-78 under docs/implementation.

## Validation
- pnpm typecheck:test
- pnpm exec tsx --test test/unit/migrations/logistics/logistics-field-visits-schema.test.ts test/unit/migrations/logistics/logistics-route-events-schema.test.ts test/unit/migrations/logistics/logistics-route-plans-stops-schema.test.ts test/unit/migrations/logistics/logistics-sla-schema.test.ts test/unit/migrations/logistics/logistics-time-windows-schema.test.ts
- pnpm test