### PR TITLE
test(architecture): move study tracking domain tests

### DIFF
--- a/docs/implementation/test-arch-83-study-tracking-domain-root-tests.md
+++ b/docs/implementation/test-arch-83-study-tracking-domain-root-tests.md
@@ -1,0 +1,39 @@
+﻿# TEST-ARCH-83 — Study tracking domain root tests
+
+## Scope
+
+Moved focused root-level study tracking domain tests into the domain test tree.
+
+## Files moved
+
+- `test/study-tracking.test.ts`
+- `test/study-tracking-clinic-schema.test.ts`
+- `test/study-tracking-edge.test.ts`
+
+## Destination
+
+- `test/unit/domain/study-tracking/`
+
+## Guardrail updated after validation failure
+
+- `test/study-tracking-suite-completeness.test.ts`
+
+The suite completeness guardrail had stale anchors pointing to the old root-level paths. Full local validation failed on those stale anchors, so the references were updated to the new test paths.
+
+## Deferred from this batch
+
+- `test/study-tracking-runtime-timing-contract.test.ts`
+- `test/study-tracking-suite-completeness.test.ts`
+
+These files have different suite/runtime guardrail semantics and should be handled as relocations in a separate focused batch.
+
+## Allowed changes
+
+- Test file moves only.
+- Relative import/path adjustments required by the new test depth.
+- Stale suite completeness guardrail path updates required by the move.
+- Documentation under `docs/implementation/`.
+
+## Explicit non-scope
+
+No runtime, product, API, auth, database, schema, migrations, dependency, lockfile or CI changes.

--- a/test/study-tracking-suite-completeness.test.ts
+++ b/test/study-tracking-suite-completeness.test.ts
@@ -1,4 +1,4 @@
-import assert from "node:assert/strict";
+﻿import assert from "node:assert/strict";
 import { existsSync, readFileSync } from "node:fs";
 import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -25,7 +25,7 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
       "Study tracking domain helpers keep schemas, delivery rules, stage timestamps, notification rules and serializers explicit.",
     testFiles: [
       {
-        path: "test/study-tracking.test.ts",
+        path: "test/unit/domain/study-tracking/study-tracking.test.ts",
         markers: [
           "adminCreateStudyTrackingSchema",
           "updateStudyTrackingSchema",

--- a/test/unit/domain/study-tracking/study-tracking-clinic-schema.test.ts
+++ b/test/unit/domain/study-tracking/study-tracking-clinic-schema.test.ts
@@ -3,7 +3,7 @@ import assert from "node:assert/strict";
 import {
   STUDY_TRACKING_STAGES,
   clinicCreateStudyTrackingSchema,
-} from "../server/lib/study-tracking.ts";
+} from "../../../../server/lib/study-tracking.ts";
 
 test("STUDY_TRACKING_STAGES conserva el orden público esperado", () => {
   assert.deepEqual(STUDY_TRACKING_STAGES, [

--- a/test/unit/domain/study-tracking/study-tracking-edge.test.ts
+++ b/test/unit/domain/study-tracking/study-tracking-edge.test.ts
@@ -6,7 +6,7 @@ import {
   applyStageTimestampDefaults,
   calculateEstimatedDeliveryAt,
   updateStudyTrackingSchema,
-} from "../server/lib/study-tracking.ts";
+} from "../../../../server/lib/study-tracking.ts";
 
 test("calculateEstimatedDeliveryAt rechaza labReceivedAt invalido", () => {
   assert.throws(

--- a/test/unit/domain/study-tracking/study-tracking.test.ts
+++ b/test/unit/domain/study-tracking/study-tracking.test.ts
@@ -22,7 +22,7 @@ import {
   serializeStudyTrackingNotification,
   shouldCreateSpecialStainNotification,
   updateStudyTrackingSchema,
-} from "../server/lib/study-tracking.ts";
+} from "../../../../server/lib/study-tracking.ts";
 
 test("adminCreateStudyTrackingSchema normaliza booleanos, textos y fechas", () => {
   const parsed = adminCreateStudyTrackingSchema.safeParse({


### PR DESCRIPTION
## Summary
- Move focused study tracking domain tests from root into test/unit/domain/study-tracking.
- Update the study tracking suite completeness guardrail to the new test paths after full validation exposed stale anchors.
- Document TEST-ARCH-83 under docs/implementation.

## Validation
- pnpm typecheck:test
- pnpm exec tsx --test test/unit/domain/study-tracking/study-tracking.test.ts test/unit/domain/study-tracking/study-tracking-clinic-schema.test.ts test/unit/domain/study-tracking/study-tracking-edge.test.ts test/study-tracking-suite-completeness.test.ts
- pnpm test