### PR TITLE
test(architecture): move study tracking guardrails

### DIFF
--- a/docs/implementation/test-arch-84-study-tracking-guardrails.md
+++ b/docs/implementation/test-arch-84-study-tracking-guardrails.md
@@ -1,0 +1,29 @@
+﻿# TEST-ARCH-84 — Study tracking guardrail root tests
+
+## Scope
+
+Moved the remaining root-level study tracking guardrail tests into the contracts test tree.
+
+## Files moved
+
+- `test/study-tracking-runtime-timing-contract.test.ts`
+- `test/study-tracking-suite-completeness.test.ts`
+
+## Destination
+
+- `test/unit/contracts/study-tracking/`
+
+## Guardrail updates
+
+- Updated the suite completeness `REPO_ROOT` resolver for the new test depth.
+- Updated the suite completeness self-reference to the new path.
+
+## Allowed changes
+
+- Test file moves only.
+- Relative repo-root/path adjustments required by the new test depth.
+- Documentation under `docs/implementation/`.
+
+## Explicit non-scope
+
+No runtime, product, API, auth, database, schema, migrations, dependency, lockfile or CI changes.

--- a/test/unit/contracts/study-tracking/study-tracking-runtime-timing-contract.test.ts
+++ b/test/unit/contracts/study-tracking/study-tracking-runtime-timing-contract.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+﻿import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";

--- a/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
+++ b/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
@@ -4,7 +4,7 @@ import { basename, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const REPO_ROOT = resolve(fileURLToPath(new URL("../../../../", import.meta.url)));
 
 type FileAnchor = {
   path: string;
@@ -433,7 +433,7 @@ test("study tracking suite keeps particular surface token-scoped sin create/dele
 });
 
 test("study tracking suite completeness guardrail source stays ascii only", () => {
-  const source = readSource("test/study-tracking-suite-completeness.test.ts");
+  const source = readSource("test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts");
   const replacementCharacter = String.fromCharCode(0xfffd);
 
   assert.equal(


### PR DESCRIPTION
## Summary
- Move remaining root-level study tracking guardrails into test/unit/contracts/study-tracking.
- Update the suite completeness repo-root resolver and self-reference for the new test path.
- Document TEST-ARCH-84 under docs/implementation.

## Validation
- pnpm typecheck:test
- pnpm exec tsx --test test/unit/contracts/study-tracking/study-tracking-runtime-timing-contract.test.ts test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
- pnpm test