### PR TITLE
test(architecture): move reports domain test

### DIFF
--- a/docs/implementation/test-arch-85-reports-domain-root-test.md
+++ b/docs/implementation/test-arch-85-reports-domain-root-test.md
@@ -1,0 +1,33 @@
+﻿# TEST-ARCH-85 — Reports domain root test
+
+## Scope
+
+Moved the focused root-level reports domain test into the domain test tree.
+
+## File moved
+
+- `test/reports.test.ts`
+
+## Destination
+
+- `test/unit/domain/reports/reports.test.ts`
+
+## Deferred from this batch
+
+- `test/reports-runtime-timing-contract.test.ts`
+- `test/reports-session-last-access-contract.test.ts`
+- `test/reports-status-runtime-timing-contract.test.ts`
+- `test/reports-status-session-last-access-contract.test.ts`
+- `test/reports-suite-completeness.test.ts`
+
+These files have runtime, session or suite guardrail semantics and should be handled in separate focused batches.
+
+## Allowed changes
+
+- Test file move only.
+- Relative import/path adjustments required by the new test depth.
+- Documentation under `docs/implementation/`.
+
+## Explicit non-scope
+
+No runtime, product, API, auth, database, schema, migrations, dependency, lockfile or CI changes.

--- a/test/unit/domain/reports/reports.test.ts
+++ b/test/unit/domain/reports/reports.test.ts
@@ -1,4 +1,4 @@
-import test from "node:test";
+﻿import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
@@ -11,9 +11,9 @@ import {
   parsePositiveInt,
   parseReportId,
   parseReportStatus,
-} from "../server/lib/reports.ts";
+} from "../../../../server/lib/reports.ts";
 
-test("reports helpers parsean enteros positivos con fallback y límite máximo", () => {
+test("reports helpers parsean enteros positivos con fallback y lÃ­mite mÃ¡ximo", () => {
   assert.equal(parsePositiveInt("25", 50, 100), 25);
   assert.equal(parsePositiveInt("500", 50, 100), 100);
   assert.equal(parsePositiveInt("0", 50, 100), 50);
@@ -54,7 +54,7 @@ test("reports helpers normalizan texto, notas y fechas opcionales", () => {
   assert.equal(parseOptionalDate("   "), undefined);
 });
 
-test("reports helpers calculan scope de lectura por clínica", () => {
+test("reports helpers calculan scope de lectura por clÃ­nica", () => {
   assert.deepEqual(getReadClinicScope(undefined, 3), {
     clinicId: 3,
     isForbidden: false,


### PR DESCRIPTION
## Summary
- Move the focused reports domain test from root into test/unit/domain/reports.
- Keep runtime/session/suite reports guardrails deferred for separate focused batches.
- Document TEST-ARCH-85 under docs/implementation.

## Validation
- pnpm typecheck:test
- pnpm exec tsx --test test/unit/domain/reports/reports.test.ts
- pnpm test