### PR TITLE
test(contracts): move token study tracking root test

### DIFF
--- a/test/unit/contracts/study-tracking/token-study-tracking.test.ts
+++ b/test/unit/contracts/study-tracking/token-study-tracking.test.ts
@@ -1,9 +1,9 @@
 import test from "node:test";
 import assert from "node:assert/strict";
 
-import type { StudyTrackingCase } from "../drizzle/schema.ts";
-import { calculateEstimatedDeliveryAt } from "../server/lib/study-tracking.ts";
-import { ensureStudyTrackingCaseForToken } from "../server/lib/token-study-tracking.ts";
+import type { StudyTrackingCase } from "../../../../drizzle/schema.ts";
+import { calculateEstimatedDeliveryAt } from "../../../../server/lib/study-tracking.ts";
+import { ensureStudyTrackingCaseForToken } from "../../../../server/lib/token-study-tracking.ts";
 
 function createStudyTrackingCaseFixture(
   input: Omit<StudyTrackingCase, "id" | "createdAt" | "updatedAt">,


### PR DESCRIPTION
## Summary
- Move token-study-tracking root test into test/unit/contracts/study-tracking
- Adjust relative imports after the move
- Reduce root test inventory from 27 to 26

## Validation
- pnpm exec tsx --test test/unit/contracts/study-tracking/token-study-tracking.test.ts
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface

Notes:
- security:public-surface PASS
- Known non-blocking server-only findings remain in frontend/src/proxy.ts for CLINIC_SESSION_COOKIE_NAME and ADMIN_SESSION_COOKIE_NAME