### PR TITLE
test(contracts): move particular auth middleware root test

### DIFF
--- a/test/unit/contracts/particular/particular-auth-middleware.test.ts
+++ b/test/unit/contracts/particular/particular-auth-middleware.test.ts
@@ -1,4 +1,4 @@
-﻿import test from "node:test";
+import test from "node:test";
 import assert from "node:assert/strict";
 
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -8,7 +8,7 @@ process.env.DATABASE_URL ??= "postgresql://postgres:postgres@127.0.0.1:5432/post
 process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 
 const { createRequireParticularAuth } = await import(
-  "../server/middlewares/particular-auth.ts"
+  "../../../../server/middlewares/particular-auth.ts"
 );
 
 function createMockResponse() {


### PR DESCRIPTION
## Summary
- Move particular-auth-middleware root test into test/unit/contracts/particular
- Adjust relative server middleware import after the move
- Reduce root test inventory from 23 to 22

## Validation
- pnpm exec tsx --test test/unit/contracts/particular/particular-auth-middleware.test.ts
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface

Notes:
- security:public-surface PASS
- Known non-blocking server-only findings remain in frontend/src/proxy.ts for CLINIC_SESSION_COOKIE_NAME and ADMIN_SESSION_COOKIE_NAME