### PR TITLE
test(contracts): move permissions report status root test

### DIFF
--- a/test/architecture/reports-suite-completeness.test.ts
+++ b/test/architecture/reports-suite-completeness.test.ts
@@ -108,7 +108,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
         ],
       },
       {
-        path: "test/permissions-and-report-status.test.ts",
+        path: "test/unit/contracts/reports/permissions-and-report-status.test.ts",
         markers: [
           "REPORT_STATUSES",
           "canTransitionReportStatus",

--- a/test/unit/contracts/reports/permissions-and-report-status.test.ts
+++ b/test/unit/contracts/reports/permissions-and-report-status.test.ts
@@ -4,13 +4,13 @@ import {
   getClinicPermissions,
   isClinicUserRole,
   normalizeClinicUserRole,
-} from "../server/lib/permissions.ts";
+} from "../../../../server/lib/permissions.ts";
 import {
   REPORT_STATUSES,
   canTransitionReportStatus,
   isReportStatus,
   normalizeReportStatus,
-} from "../server/lib/report-status.ts";
+} from "../../../../server/lib/report-status.ts";
 
 test("isClinicUserRole reconoce únicamente roles válidos", () => {
   assert.equal(isClinicUserRole("clinic_owner"), true);


### PR DESCRIPTION
## Summary
- Move permissions-and-report-status root test into test/unit/contracts/reports
- Adjust relative imports after the move
- Update reports-suite-completeness path guard
- Reduce root test inventory from 22 to 21

## Validation
- pnpm exec tsx --test test/unit/contracts/reports/permissions-and-report-status.test.ts test/architecture/reports-suite-completeness.test.ts
- pnpm typecheck:test
- pnpm test
- pnpm build
- pnpm security:public-surface

Notes:
- security:public-surface PASS
- Known non-blocking server-only findings remain in frontend/src/proxy.ts for CLINIC_SESSION_COOKIE_NAME and ADMIN_SESSION_COOKIE_NAME