### PR TITLE
test(architecture): move global auth boundary contract

### DIFF
--- a/docs/audit/global-e2e-extreme-production-audit.md
+++ b/docs/audit/global-e2e-extreme-production-audit.md
@@ -84,7 +84,7 @@ La accion aplicada en este PR es tests/docs only. Se agregaron guardrails global
   - G1-G6 registry tying runtime files, existing guardrails, docs and validation scripts.
 - `test/global-public-surface-hardening-contract.test.ts`
   - Runtime public API checks for headers, no session cookies, no public body leaks, public professionals storage path hiding and invalid report-token cut-off.
-- `test/global-auth-boundary-contract.test.ts`
+- `test/architecture/security/global-auth-boundary-contract.test.ts`
   - Route-family auth registry for admin, clinic, particular and public surfaces.
 - `test/global-storage-report-safety-contract.test.ts`
   - Runtime checks for safe report serialization, bounded report list with no eager signed URLs and public report access without `storagePath` or `tokenHash`.

--- a/docs/implementation/IMPLEMENTATION_DASHBOARD_401_LOGIN_REDIRECT.md
+++ b/docs/implementation/IMPLEMENTATION_DASHBOARD_401_LOGIN_REDIRECT.md
@@ -35,7 +35,7 @@
 - `test/frontend-extreme-speed-guardrails.test.ts`
 - `test/frontend-middleware.test.ts`
 - `test/frontend-next-config-security-headers.test.ts`
-- `test/global-auth-boundary-contract.test.ts`
+- `test/architecture/security/global-auth-boundary-contract.test.ts`
 - `frontend/e2e/dashboard-auth-redirect.spec.ts`
 
 ## Current behavior

--- a/docs/implementation/backend-cors-helper-auth-routes.md
+++ b/docs/implementation/backend-cors-helper-auth-routes.md
@@ -69,7 +69,7 @@
 - `node --experimental-strip-types --test test/security-trusted-origin-cors-boundaries.test.ts`: paso, 4/4.
 - `node --experimental-strip-types --test test/architecture/security/security-production-invariants.test.ts`: paso, 11/11.
 - `node --experimental-strip-types --test test/api-production-session-contract.test.ts`: paso, 4/4.
-- `node --experimental-strip-types --test test/global-auth-boundary-contract.test.ts`: paso, 5/5.
+- `node --experimental-strip-types --test test/architecture/security/global-auth-boundary-contract.test.ts`: paso, 5/5.
 - Bloque auth especifico encontrado por grep: paso, 167/167.
 - `pnpm build`: paso.
 - `pnpm security:public-surface`: paso.

--- a/docs/implementation/backend-cors-helper-logistics-sla.md
+++ b/docs/implementation/backend-cors-helper-logistics-sla.md
@@ -40,7 +40,7 @@
   `test/cors-headers-shared-helper.test.ts`,
   `test/architecture/security/security-production-invariants.test.ts`,
   `test/security-trusted-origin-cors-boundaries.test.ts`,
-  `test/global-auth-boundary-contract.test.ts` y
+  `test/architecture/security/global-auth-boundary-contract.test.ts` y
   `test/security-csrf-mutating-route-coverage.test.ts`.
 
 ## Cambios
@@ -82,7 +82,7 @@
 - `node --experimental-strip-types --test test/logistics-sla-routes-api.test.ts`: paso, 8/8.
 - `node --experimental-strip-types --test test/logistics-sla-routes-integration.fastify.test.ts`: paso, 16/16.
 - `node --experimental-strip-types --test test/logistics-sla-schema.test.ts test/logistics-sla-compliance.test.ts test/logistics-sla-breach-runtime.test.ts test/logistics-metrics-suite-completeness.test.ts`: paso, 32/32.
-- `node --experimental-strip-types --test test/global-auth-boundary-contract.test.ts`: paso, 5/5.
+- `node --experimental-strip-types --test test/architecture/security/global-auth-boundary-contract.test.ts`: paso, 5/5.
 - `node --experimental-strip-types --test test/security-csrf-mutating-route-coverage.test.ts`: paso, 17/17.
 - `corepack pnpm build`: paso.
 - `corepack pnpm security:public-surface`: paso; conserva findings informativos server-only existentes en `frontend/src/proxy.ts`.

--- a/docs/pr-history/pr-826-global-e2e-extreme-production-readiness.md
+++ b/docs/pr-history/pr-826-global-e2e-extreme-production-readiness.md
@@ -37,7 +37,7 @@ Out of scope:
 
 - `test/global-e2e-production-readiness-contract.test.ts`
 - `test/global-public-surface-hardening-contract.test.ts`
-- `test/global-auth-boundary-contract.test.ts`
+- `test/architecture/security/global-auth-boundary-contract.test.ts`
 - `test/global-storage-report-safety-contract.test.ts`
 - `test/global-performance-resilience-contract.test.ts`
 - `docs/audit/global-e2e-extreme-production-audit.md`
@@ -61,7 +61,7 @@ Validates public API hardening:
 - public professionals does not expose private avatar storage paths
 - invalid public report access tokens reject before hashing, lookup, signing or audit
 
-### `test/global-auth-boundary-contract.test.ts`
+### `test/architecture/security/global-auth-boundary-contract.test.ts`
 
 Validates global auth boundaries:
 

--- a/test/architecture/security/global-auth-boundary-contract.test.ts
+++ b/test/architecture/security/global-auth-boundary-contract.test.ts
@@ -179,7 +179,7 @@ test("trusted-origin hook stays global and precedes registered route surfaces", 
 });
 
 test("global auth boundary guardrail source stays ascii only", () => {
-  const source = read("test/global-auth-boundary-contract.test.ts");
+  const source = read("test/architecture/security/global-auth-boundary-contract.test.ts");
 
   for (let index = 0; index < source.length; index += 1) {
     assert.equal(


### PR DESCRIPTION
## Summary
- Move global auth boundary contract from root test folder into test/architecture/security.
- Keep the move mechanical and preserve test behavior.
- Update exact references from the old path to the new path.

## Validation
- pnpm exec tsx --test test/architecture/security/global-auth-boundary-contract.test.ts
- pnpm test
- pnpm build
- pnpm security:public-surface