### PR TITLE
test(architecture): move security boundary suite completeness

### DIFF
--- a/docs/implementation/test-arch-13-recursive-suite-census-and-source-path-guards.md
+++ b/docs/implementation/test-arch-13-recursive-suite-census-and-source-path-guards.md
@@ -29,7 +29,7 @@ corrigiendo los dos mecanismos que TEST-ARCH-12 probó como bloqueantes:
 - `docs/implementation/test-arch-12-enterprise-controller-bulk-batch-1.md`.
 - `test/README.md`; reportes TEST-ARCH-6..10 (patrón de move probado); audit/convención
   citadas como fuente de verdad.
-- `test/audit-suite-completeness.test.ts`, `test/security-boundary-suite-completeness.test.ts`,
+- `test/audit-suite-completeness.test.ts`, `test/architecture/security/security-boundary-suite-completeness.test.ts`,
   `test/architecture/security/security-session-cookie-boundaries.test.ts`,
   `test/architecture/security/security-response-disclosure-boundaries.test.ts`,
   `test/architecture/security/security-access-lifecycle-boundaries.test.ts`.
@@ -43,7 +43,7 @@ corrigiendo los dos mecanismos que TEST-ARCH-12 probó como bloqueantes:
 | Archivo | Cambio |
 |---|---|
 | `test/audit-suite-completeness.test.ts` | Censo → recursivo + canónico; `readSource`/`assertFileExists` subdirectory-aware; walker + resolver. |
-| `test/security-boundary-suite-completeness.test.ts` | Censo → recursivo + canónico; `readSource`/`assertFileExists` subdirectory-aware; walker + resolver. |
+| `test/architecture/security/security-boundary-suite-completeness.test.ts` | Censo → recursivo + canónico; `readSource`/`assertFileExists` subdirectory-aware; walker + resolver. |
 | `test/architecture/security/security-session-cookie-boundaries.test.ts` | `readSource` subdirectory-aware; walker + resolver. |
 | `test/architecture/security/security-response-disclosure-boundaries.test.ts` | `readSource` subdirectory-aware; walker + resolver. |
 | `test/architecture/security/security-access-lifecycle-boundaries.test.ts` | `readSource` subdirectory-aware; walker + resolver. |

--- a/docs/implementation/test-arch-16-controller-post-unlock-inventory.md
+++ b/docs/implementation/test-arch-16-controller-post-unlock-inventory.md
@@ -65,7 +65,7 @@ Get-Content -LiteralPath 'docs\implementation\test-arch-14-enterprise-controller
 Get-Content -LiteralPath 'docs\implementation\test-arch-15-source-path-guards-bd-unlock.md'
 Select-String -LiteralPath <test/docs/scripts/package files> -SimpleMatch -Pattern 'test/<legacy-fastify-basename>'
 Select-String -LiteralPath 'test\report-study-types-catalog.test.ts' -Pattern 'admin-reports.fastify|reports.fastify|reports-status.fastify|critical report tests stop using free-text|listSourceFiles|deepEqual' -Context 2,2
-Select-String -LiteralPath 'test\study-tracking-suite-completeness.test.ts','test\reports-suite-completeness.test.ts','test\storage-suite-completeness.test.ts','test\architecture\security\security-critical-route-surface-registry.test.ts','test\security-boundary-suite-completeness.test.ts' -Pattern '<legacy fastify basenames>|assertFileExists|readSource|existsSync|path:' -Context 1,1
+Select-String -LiteralPath 'test\study-tracking-suite-completeness.test.ts','test\reports-suite-completeness.test.ts','test\storage-suite-completeness.test.ts','test\architecture\security\security-critical-route-surface-registry.test.ts','test\architecture\security\security-boundary-suite-completeness.test.ts' -Pattern '<legacy fastify basenames>|assertFileExists|readSource|existsSync|path:' -Context 1,1
 Get-ChildItem -LiteralPath 'test' -Recurse -File -Filter '*.test.ts' | ForEach-Object { Select-String -LiteralPath $_.FullName -Pattern '\.inject\(' }
 ```
 

--- a/docs/implementation/test-arch-18-controller-auth-core-batch.md
+++ b/docs/implementation/test-arch-18-controller-auth-core-batch.md
@@ -69,7 +69,7 @@ Se actualizaron los anchors exactos necesarios:
 | Archivo | Paths actualizados |
 |---|---|
 | `test/architecture/security/security-critical-route-surface-registry.test.ts` | `test/auth.fastify.test.ts` -> `test/integration/adapters/controllers/auth.fastify.test.ts`; `test/admin-auth.fastify.test.ts` -> `test/integration/adapters/controllers/admin-auth.fastify.test.ts` |
-| `test/security-boundary-suite-completeness.test.ts` | `test/auth.fastify.test.ts` -> `test/integration/adapters/controllers/auth.fastify.test.ts`; `test/admin-auth.fastify.test.ts` -> `test/integration/adapters/controllers/admin-auth.fastify.test.ts` |
+| `test/architecture/security/security-boundary-suite-completeness.test.ts` | `test/auth.fastify.test.ts` -> `test/integration/adapters/controllers/auth.fastify.test.ts`; `test/admin-auth.fastify.test.ts` -> `test/integration/adapters/controllers/admin-auth.fastify.test.ts` |
 
 Referencias legacy detectadas y no editadas por no ser anchors exactos
 necesarios para este move:

--- a/docs/implementation/test-arch-4-enterprise-architecture-security-guards-batch.md
+++ b/docs/implementation/test-arch-4-enterprise-architecture-security-guards-batch.md
@@ -49,7 +49,7 @@
 | `test/toolchain-contract.test.ts` | Architecture guard | Elegido | Valida pin de PNPM/Node y orden de setup del workflow backend como contrato de toolchain; lectura local de config, sin tocar CI. |
 | `test/package-scripts-contract.test.ts` | Architecture guard | No elegido | Candidato viable, pero se mantuvo el lote en 3 archivos y se prefirieron guards mas directamente alineados con arquitectura/runtime boundaries. |
 | `test/architecture/security/security-session-cookie-boundaries.test.ts` | Security invariant | No elegido | Candidato claro, pero su path esta anclado por registries/guards de seguridad; moverlo exigia actualizar varios paths coordinados. |
-| `test/security-boundary-suite-completeness.test.ts` | Security invariant / suite completeness | No elegido | Candidato claro, pero es un registry de completitud que ancla la suite security; moverlo ampliaba el alcance mas que los architecture guards seguros. |
+| `test/architecture/security/security-boundary-suite-completeness.test.ts` | Security invariant / suite completeness | No elegido | Candidato claro, pero es un registry de completitud que ancla la suite security; moverlo ampliaba el alcance mas que los architecture guards seguros. |
 
 ## Candidatos elegidos
 

--- a/docs/implementation/test-arch-5-enterprise-security-invariants-batch.md
+++ b/docs/implementation/test-arch-5-enterprise-security-invariants-batch.md
@@ -59,7 +59,7 @@ Confirmaciones:
 | Candidato | Categoria evaluada | Decision | Razon |
 | --- | --- | --- | --- |
 | `test/architecture/security/security-session-cookie-boundaries.test.ts` | Security invariant | No elegido | Candidato claro, pero esta anclado por `global-e2e-production-readiness-contract`, `security-boundary-suite-completeness`, `security-critical-route-surface-registry`, `security-docs-matrix-drift-guard` y self-read. Moverlo exigia coordinar demasiados paths. |
-| `test/security-boundary-suite-completeness.test.ts` | Security invariant / suite completeness | No elegido | Es un registry de completitud de seguridad y esta anclado por otros guards. Moverlo ampliaba el alcance. |
+| `test/architecture/security/security-boundary-suite-completeness.test.ts` | Security invariant / suite completeness | No elegido | Es un registry de completitud de seguridad y esta anclado por otros guards. Moverlo ampliaba el alcance. |
 | `test/api-error-no-stack-traces-contract.test.ts` | Security invariant | No elegido | Elegible, pero se priorizaron sesiones/cookies, cache privado y rate-limit cross-realm por alineacion directa con la prioridad del lote. |
 | `test/auth-session-boundaries.test.ts` | Security invariant | Elegido | Protege separacion de sesiones/cookies entre clinica, admin y particular con stubs locales y `app.inject`, sin servidor real ni DB/red. |
 | `test/backend-api-no-store-cache-contract.test.ts` | Security invariant | Elegido | Protege `Cache-Control: no-store` para APIs privadas y confirma que rutas autenticadas delegan al hook global sin I/O externo. |

--- a/docs/pr-history/PR-perf-admin-request-permission-cache.md
+++ b/docs/pr-history/PR-perf-admin-request-permission-cache.md
@@ -61,7 +61,7 @@ Tests:
 - `test/audit-separated-surfaces.test.ts`
 - `test/audit-suite-completeness.test.ts`
 - `test/unit/infrastructure/routes-session-last-access-contract.test.ts`
-- `test/security-boundary-suite-completeness.test.ts`
+- `test/architecture/security/security-boundary-suite-completeness.test.ts`
 - `test/architecture/security/security-critical-route-surface-registry.test.ts`
 - `test/architecture/security/security-cross-auth-surface-boundaries.test.ts`
 - `test/architecture/security/security-production-invariants.test.ts`
@@ -99,7 +99,7 @@ node --experimental-strip-types --experimental-specifier-resolution=node --test 
 Resultado: OK.
 
 ```powershell
-node --experimental-strip-types --experimental-specifier-resolution=node --test test/architecture/security/security-cross-auth-surface-boundaries.test.ts test/architecture/security/security-production-invariants.test.ts test/architecture/security/security-response-disclosure-boundaries.test.ts test/security-boundary-suite-completeness.test.ts test/architecture/security/security-critical-route-surface-registry.test.ts test/audit-suite-completeness.test.ts
+node --experimental-strip-types --experimental-specifier-resolution=node --test test/architecture/security/security-cross-auth-surface-boundaries.test.ts test/architecture/security/security-production-invariants.test.ts test/architecture/security/security-response-disclosure-boundaries.test.ts test/architecture/security/security-boundary-suite-completeness.test.ts test/architecture/security/security-critical-route-surface-registry.test.ts test/audit-suite-completeness.test.ts
 ```
 
 Resultado: OK.

--- a/docs/security/ENDPOINT_TEST_MATRIX.md
+++ b/docs/security/ENDPOINT_TEST_MATRIX.md
@@ -24,7 +24,7 @@ staging/produccion.
 
 - `test/architecture/security/security-critical-route-surface-registry.test.ts` mantiene inventario de
   superficies criticas, rutas y guardrails obligatorios.
-- `test/security-boundary-suite-completeness.test.ts` protege cobertura minima
+- `test/architecture/security/security-boundary-suite-completeness.test.ts` protege cobertura minima
   del paquete security-*.
 - `test/architecture/security/security-cross-tenant-idor-contract.test.ts` fija contratos CTIDOR con
   estado `pending_runtime_staging_evidence`.

--- a/test/architecture/security/security-boundary-suite-completeness.test.ts
+++ b/test/architecture/security/security-boundary-suite-completeness.test.ts
@@ -4,7 +4,7 @@ import { basename, relative, resolve, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 import test from "node:test";
 
-const REPO_ROOT = resolve(fileURLToPath(new URL("../", import.meta.url)));
+const REPO_ROOT = resolve(fileURLToPath(new URL("../../../", import.meta.url)));
 
 type FileAnchor = {
   path: string;
@@ -662,7 +662,7 @@ test("security boundary suite keeps required downstream runtime tests explicit",
 });
 
 test("security boundary suite completeness guardrail source stays ascii only", () => {
-  const source = readSource("test/security-boundary-suite-completeness.test.ts");
+  const source = readSource("test/architecture/security/security-boundary-suite-completeness.test.ts");
   const replacementCharacter = String.fromCharCode(0xfffd);
 
   assert.equal(

--- a/test/architecture/security/security-critical-route-surface-registry.test.ts
+++ b/test/architecture/security/security-critical-route-surface-registry.test.ts
@@ -155,7 +155,7 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
         ],
       },
       {
-        path: "test/security-boundary-suite-completeness.test.ts",
+        path: "test/architecture/security/security-boundary-suite-completeness.test.ts",
         markers: [
           "security boundary suite completeness registry keeps canonical order",
           "security boundary guardrails remain connected to runtime anchors",
@@ -659,7 +659,7 @@ test("critical route surface registry cubre todos los guardrails finales obligat
     "test/architecture/security/security-production-invariants.test.ts",
     "test/architecture/security/security-session-cookie-boundaries.test.ts",
     "test/architecture/security/security-cross-auth-surface-boundaries.test.ts",
-    "test/security-boundary-suite-completeness.test.ts",
+    "test/architecture/security/security-boundary-suite-completeness.test.ts",
     "test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts",
     "test/security/security-audit-logging-phase-boundaries.test.ts",
     "test/architecture/security/security-actor-relationship-boundaries.test.ts",

--- a/test/security-docs-matrix-drift-guard.test.ts
+++ b/test/security-docs-matrix-drift-guard.test.ts
@@ -31,7 +31,7 @@ const REQUIRED_SECURITY_DOCS = [
 
 const REQUIRED_GUARDRAIL_TESTS = [
   "test/architecture/security/security-critical-route-surface-registry.test.ts",
-  "test/security-boundary-suite-completeness.test.ts",
+  "test/architecture/security/security-boundary-suite-completeness.test.ts",
   "test/architecture/security/security-cross-tenant-idor-contract.test.ts",
   "test/architecture/security/security-resource-ownership-boundaries.test.ts",
   "test/architecture/security/security-response-disclosure-boundaries.test.ts",


### PR DESCRIPTION
## Summary
- Move security boundary suite completeness guard from root test folder into test/architecture/security.
- Keep the move mechanical and preserve test behavior.
- Update exact references from the old path to the new path.

## Validation
- pnpm exec tsx --test test/architecture/security/security-boundary-suite-completeness.test.ts
- pnpm exec tsx --test test/security-docs-matrix-drift-guard.test.ts
- pnpm test
- pnpm build
- pnpm security:public-surface