### PR TITLE
fix(e2e): restore next-env hygiene after Playwright

### DIFF
--- a/docs/audit/e2e-next-env-hygiene-audit.md
+++ b/docs/audit/e2e-next-env-hygiene-audit.md
@@ -1,0 +1,61 @@
+# E2E Next Env Hygiene - Audit
+
+## Estado base
+- Fecha: 2026-07-10.
+- Repo: `C:\PORTAL-VETNEB`.
+- Rama recibida: `test-arch-113-codex-final-inspection`.
+- Rama esperada por la tarea: `fix/e2e-next-env-hygiene`.
+- Se verifico `git diff --stat main` sin salida y se creo `fix/e2e-next-env-hygiene` desde el HEAD limpio actual.
+- HEAD auditado: `ac392cf docs(test): close root migration readme state (#1432)`.
+- `git status --short --untracked-files=all`: limpio antes de implementar.
+- `git diff --check`: sin salida antes de implementar.
+
+## Scope incluido
+- Tooling E2E de frontend.
+- Guardrail nativo para higiene de `frontend/next-env.d.ts`.
+- Documentacion minima de auditoria y entrega.
+
+## Scope excluido
+- Sin backend productivo.
+- Sin API, auth, DB, migraciones, schema, cookies, CORS, CSP ni rate limits.
+- Sin dependencias, `package.json`, `pnpm-lock.yaml`, CI, workflows, commits, push ni PR.
+- Sin cambios en `frontend/src`.
+
+## Auditoria previa
+- `frontend/next-env.d.ts` ya estaba en ruta productiva:
+  `./.next/types/routes.d.ts`.
+- En este baseline de Next 16 el archivo usa `import "./.next/types/routes.d.ts";`; el contrato real protegido es la ruta productiva y la ausencia de `.next/dev`.
+- El guardrail existente en `test/unit/infrastructure/login-rate-limit-ux-safety.test.ts` detectaba el estado final incorrecto, pero no restauraba el archivo tras Playwright.
+- `frontend/playwright.config.ts` levantaba `pnpm dev --hostname 127.0.0.1` como `webServer`; ese `next dev` es el punto que puede regenerar `frontend/next-env.d.ts` hacia `.next/dev/types/routes.d.ts`.
+- `frontend/.gitignore` ya cubre `test-results/`, `playwright-report/`, `blob-report/` y `.next/`, por lo que el riesgo auditado era el archivo versionado `frontend/next-env.d.ts`.
+
+## Riesgos identificados
+- Restaurar con `git restore` dentro del tooling descartaria cambios locales legitimos y quedaria acoplado a Git.
+- Hardcodear todo el archivo `next-env.d.ts` podria romperse si Next cambia el encabezado generado.
+- Dejar solo el guardrail nativo seguiria permitiendo que la corrida E2E ensucie el working tree antes de ejecutar `pnpm test`.
+
+## Plan minimo aplicado
+- Usar `globalTeardown` de Playwright para ejecutar higiene al final de cada corrida E2E.
+- Normalizar solo la ruta `./.next/dev/types/routes.d.ts` hacia `./.next/types/routes.d.ts`.
+- Agregar guardrail que valide la config de Playwright y ejercite el helper contra un archivo temporal.
+
+## Validaciones realizadas
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/unit/infrastructure/next-env-hygiene.test.ts`: PASS, 3/3.
+- `pnpm --dir frontend exec playwright test e2e/theme-mode.spec.ts --project=chromium --workers=1`: PASS, 2/2.
+- `git status --short --untracked-files=all` post E2E: solo archivos intencionales de esta correccion; `frontend/next-env.d.ts` no aparece.
+- `git diff --name-only` post E2E: solo `frontend/playwright.config.ts`; los archivos nuevos no aparecen por no estar stageados y `frontend/next-env.d.ts` no aparece.
+- `pnpm test`: PASS, 2986/2986.
+- `pnpm build`: PASS.
+- `pnpm security:public-surface`: PASS.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend build`: PASS.
+
+## Resultado
+- La causa raiz queda corregida en el flujo Playwright.
+- `frontend/next-env.d.ts` no queda mutado tras el E2E validado.
+- No se tocaron superficies productivas fuera del scope.
+
+## Riesgo residual
+- Bajo. El helper depende de la ruta conocida que Next escribe hoy para typed routes.
+- Si Next cambia el nombre de la ruta generada en una version futura, el guardrail debera actualizarse junto con el helper.

--- a/docs/implementation/e2e-next-env-hygiene.md
+++ b/docs/implementation/e2e-next-env-hygiene.md
@@ -1,0 +1,65 @@
+# fix(e2e): next-env hygiene for Playwright
+
+## Estado base
+- Rama de trabajo final: `fix/e2e-next-env-hygiene`.
+- HEAD: `ac392cf docs(test): close root migration readme state (#1432)`.
+- Base inicial limpia: `git status --short --untracked-files=all` sin salida.
+- `git diff --check` inicial sin salida.
+
+## Scope incluido
+- Configuracion Playwright de frontend.
+- Helper E2E para restaurar la referencia de rutas de `next-env.d.ts`.
+- Test nativo de infraestructura para prevenir regresion.
+- Markdown de auditoria y entrega.
+
+## Scope excluido
+- Backend productivo, API, auth, DB, migraciones, schema, dependencias, lockfiles, CI, workflows, commits, push y PR.
+- Tests eliminados o guardrails relajados: ninguno.
+
+## Causa raiz
+- El `webServer` de Playwright ejecuta `pnpm dev --hostname 127.0.0.1`.
+- `next dev` puede regenerar `frontend/next-env.d.ts` apuntando a `./.next/dev/types/routes.d.ts`.
+- Ese archivo esta versionado, por lo que la corrida E2E puede dejar el working tree sucio y hacer fallar guardrails de `pnpm test`.
+
+## Correccion aplicada
+- `frontend/playwright.config.ts` ahora declara:
+  `globalTeardown: "./e2e/helpers/restore-next-env-hygiene.mjs"`.
+- `frontend/e2e/helpers/restore-next-env-hygiene.mjs` normaliza solo:
+  `./.next/dev/types/routes.d.ts` -> `./.next/types/routes.d.ts`.
+- No usa Git y no reemplaza el archivo completo; conserva el formato generado por Next.
+- `test/unit/infrastructure/next-env-hygiene.test.ts` valida:
+  - `frontend/next-env.d.ts` mantiene ruta productiva.
+  - Playwright conserva el teardown de higiene.
+  - El helper restaura un archivo temporal con ruta dev.
+
+## Archivos modificados
+- `frontend/playwright.config.ts`
+- `frontend/e2e/helpers/restore-next-env-hygiene.mjs`
+- `test/unit/infrastructure/next-env-hygiene.test.ts`
+- `docs/audit/e2e-next-env-hygiene-audit.md`
+- `docs/implementation/e2e-next-env-hygiene.md`
+
+## Validaciones
+- `node --experimental-strip-types --experimental-specifier-resolution=node --test test/unit/infrastructure/next-env-hygiene.test.ts`: PASS, 3/3.
+- `pnpm --dir frontend exec playwright test e2e/theme-mode.spec.ts --project=chromium --workers=1`: PASS, 2/2.
+- `git status --short --untracked-files=all` post E2E: solo archivos intencionales; `frontend/next-env.d.ts` no aparece.
+- `git diff --name-only` post E2E: `frontend/next-env.d.ts` no aparece.
+- `pnpm test`: PASS, 2986/2986.
+- `pnpm build`: PASS.
+- `pnpm security:public-surface`: PASS.
+- `pnpm --dir frontend lint`: PASS.
+- `pnpm --dir frontend typecheck`: PASS.
+- `pnpm --dir frontend build`: PASS.
+
+## Resultado
+- El flujo E2E validado ya no deja `frontend/next-env.d.ts` en ruta dev.
+- `frontend/next-env.d.ts` queda con `./.next/types/routes.d.ts`.
+- No hay cambios fuera de scope.
+
+## Riesgo residual
+- Bajo. El guardrail cubre la configuracion y el comportamiento del helper.
+- Si Next cambia la ruta generada de typed routes, actualizar constantes y test en la misma pasada.
+
+## Estado final esperado
+- Working tree con solo los archivos intencionales de esta correccion hasta que Nico haga stage/commit.
+- Sin commit, push ni PR realizados por el agente.

--- a/frontend/e2e/helpers/restore-next-env-hygiene.mjs
+++ b/frontend/e2e/helpers/restore-next-env-hygiene.mjs
@@ -1,0 +1,38 @@
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+export const DEV_ROUTES_REFERENCE = "./.next/dev/types/routes.d.ts";
+export const PRODUCTION_ROUTES_REFERENCE = "./.next/types/routes.d.ts";
+
+const FRONTEND_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const DEFAULT_NEXT_ENV_PATH = join(FRONTEND_DIR, "next-env.d.ts");
+
+export function restoreNextEnvSource(source) {
+  return source.split(DEV_ROUTES_REFERENCE).join(PRODUCTION_ROUTES_REFERENCE);
+}
+
+export async function restoreNextEnvHygiene({
+  nextEnvPath = DEFAULT_NEXT_ENV_PATH,
+} = {}) {
+  if (!existsSync(nextEnvPath)) {
+    return;
+  }
+
+  const source = readFileSync(nextEnvPath, "utf8");
+  const restored = restoreNextEnvSource(source);
+
+  if (restored !== source) {
+    writeFileSync(nextEnvPath, restored, "utf8");
+  }
+}
+
+export default restoreNextEnvHygiene;
+
+const invokedUrl = process.argv[1]
+  ? pathToFileURL(resolve(process.argv[1])).href
+  : "";
+
+if (import.meta.url === invokedUrl) {
+  await restoreNextEnvHygiene();
+}

--- a/frontend/playwright.config.ts
+++ b/frontend/playwright.config.ts
@@ -2,6 +2,7 @@ import { defineConfig, devices } from "@playwright/test";
 
 export default defineConfig({
   testDir: "./e2e",
+  globalTeardown: "./e2e/helpers/restore-next-env-hygiene.mjs",
   timeout: 30_000,
   expect: {
     timeout: 5_000,

--- a/test/unit/infrastructure/next-env-hygiene.test.ts
+++ b/test/unit/infrastructure/next-env-hygiene.test.ts
@@ -1,0 +1,89 @@
+import assert from "node:assert/strict";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { pathToFileURL } from "node:url";
+import test from "node:test";
+
+const NEXT_ENV_PATH = "frontend/next-env.d.ts";
+const PLAYWRIGHT_CONFIG_PATH = "frontend/playwright.config.ts";
+const NEXT_ENV_HYGIENE_HELPER_PATH =
+  "frontend/e2e/helpers/restore-next-env-hygiene.mjs";
+const DEV_ROUTES_REFERENCE = "./.next/dev/types/routes.d.ts";
+const PRODUCTION_ROUTES_REFERENCE = "./.next/types/routes.d.ts";
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(process.cwd(), relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+test("frontend next-env.d.ts keeps the production route type reference", () => {
+  const source = read(NEXT_ENV_PATH);
+
+  assert.ok(
+    source.includes(PRODUCTION_ROUTES_REFERENCE),
+    "next-env.d.ts must reference .next/types/routes.d.ts",
+  );
+  assert.equal(
+    source.includes(DEV_ROUTES_REFERENCE),
+    false,
+    "next-env.d.ts must not reference .next/dev/types/routes.d.ts",
+  );
+});
+
+test("Playwright has a next-env hygiene teardown", () => {
+  const config = read(PLAYWRIGHT_CONFIG_PATH);
+  const helper = read(NEXT_ENV_HYGIENE_HELPER_PATH);
+
+  assert.match(
+    config,
+    /globalTeardown:\s*"\.\/e2e\/helpers\/restore-next-env-hygiene\.mjs"/,
+    "Playwright must restore next-env.d.ts after E2E runs",
+  );
+  assert.ok(
+    helper.includes(DEV_ROUTES_REFERENCE),
+    "next-env hygiene helper must detect the dev route type reference",
+  );
+  assert.ok(
+    helper.includes(PRODUCTION_ROUTES_REFERENCE),
+    "next-env hygiene helper must restore the production route type reference",
+  );
+});
+
+test("next-env hygiene helper normalizes a dev route reference", async () => {
+  const helperUrl = pathToFileURL(
+    resolve(process.cwd(), NEXT_ENV_HYGIENE_HELPER_PATH),
+  ).href;
+  const helper = await import(helperUrl);
+  const tempDir = mkdtempSync(join(tmpdir(), "vetneb-next-env-"));
+  const tempNextEnvPath = join(tempDir, "next-env.d.ts");
+
+  try {
+    writeFileSync(
+      tempNextEnvPath,
+      [
+        '/// <reference types="next" />',
+        '/// <reference types="next/image-types/global" />',
+        `import "${DEV_ROUTES_REFERENCE}";`,
+        "",
+      ].join("\n"),
+      "utf8",
+    );
+
+    await helper.restoreNextEnvHygiene({ nextEnvPath: tempNextEnvPath });
+
+    assert.equal(
+      readFileSync(tempNextEnvPath, "utf8"),
+      [
+        '/// <reference types="next" />',
+        '/// <reference types="next/image-types/global" />',
+        `import "${PRODUCTION_ROUTES_REFERENCE}";`,
+        "",
+      ].join("\n"),
+    );
+  } finally {
+    rmSync(tempDir, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary
- restore the canonical Next typed-routes reference after Playwright runs
- add a focused next-env hygiene helper and regression guardrail
- document the audit cause, implementation, validations, and residual risk

## Validation
- pnpm test: 2986/2986
- pnpm build
- pnpm security:public-surface
- pnpm --dir frontend lint
- pnpm --dir frontend typecheck
- pnpm --dir frontend build
- Playwright theme-mode smoke: 2/2
- next-env.d.ts remains clean after E2E