### PR TITLE
test(infrastructure): distinguish scripts from dependency changes

### DIFF
--- a/docs/implementation/clean.md
+++ b/docs/implementation/clean.md
@@ -1,0 +1,64 @@
+# CLEAN
+
+## Objetivo
+
+Corregir el guardrail de dependencias que interpretaba cualquier modificación de
+`frontend/package.json` como un cambio de dependencias y exigía modificar
+`pnpm-lock.yaml`, incluso cuando el cambio afectaba únicamente `scripts`.
+
+## Causa raíz
+
+El helper `test/helpers/clean7a-dependency-cleanup-scope.ts` evaluaba solamente
+los nombres de los manifiestos modificados. No comparaba las secciones
+`dependencies` y `devDependencies` entre `HEAD` y el working tree.
+
+Como consecuencia, un cambio legítimo de scripts en `frontend/package.json`
+producía un falso positivo.
+
+## Solución
+
+El guardrail ahora separa:
+
+- descubrimiento de manifiestos modificados;
+- lectura del `frontend/package.json` base desde Git;
+- lectura del archivo actual desde el filesystem;
+- comparación estructural de `dependencies` y `devDependencies`;
+- validación pura del scope;
+- invariantes históricas de CLEAN7A, CLEAN7C y CLEAN7D.
+
+## Contrato
+
+- Un cambio exclusivamente en `scripts` no requiere modificar `pnpm-lock.yaml`.
+- Un cambio real en `dependencies` o `devDependencies` requiere
+  `frontend/package.json` y `pnpm-lock.yaml`.
+- Un lockfile modificado sin cambio real de dependencias es rechazado.
+- `package.json` raíz y `frontend/pnpm-lock.yaml` permanecen fuera del allowlist.
+- Las dependencias eliminadas siguen ausentes.
+- Las dependencias Radix activas siguen presentes.
+- La nota histórica de CLEAN7A continúa validándose.
+
+## Pruebas
+
+Se añadió `test/unit/infrastructure/clean.test.ts` con 14 escenarios:
+
+- scripts-only;
+- cambios válidos de dependencies y devDependencies;
+- ausencia obligatoria o presencia indebida del lockfile;
+- manifiestos fuera de scope;
+- orden de propiedades;
+- cambios de versión;
+- invariantes CLEAN históricas.
+
+## Validaciones ejecutadas
+
+- Matriz CLEAN aislada: 14/14 PASS.
+- Consumidores directos del helper: PASS.
+- `pnpm typecheck:test`: PASS.
+- `pnpm test`: 3000/3000 PASS.
+- `pnpm build`: PASS.
+- `pnpm security:public-surface`: PASS.
+
+## Scope
+
+Este cambio no modifica frontend runtime, backend, API, auth, DB, schema,
+migraciones, dependencias, lockfiles ni CI.

--- a/test/helpers/clean7a-dependency-cleanup-scope.ts
+++ b/test/helpers/clean7a-dependency-cleanup-scope.ts
@@ -2,11 +2,19 @@ import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
+import { isDeepStrictEqual } from "node:util";
 
 const CLEAN7A_DEPENDENCY_FILES = new Set([
   "frontend/package.json",
   "pnpm-lock.yaml",
 ]);
+
+const CLEAN7A_MANIFEST_FILES = [
+  "package.json",
+  "frontend/package.json",
+  "pnpm-lock.yaml",
+  "frontend/pnpm-lock.yaml",
+] as const;
 
 const CLEAN7A_REMOVED_DEPENDENCIES = [
   "@tanstack/react-query",
@@ -37,57 +45,103 @@ const CLEAN7C_REMOVED_DEV_DEPENDENCIES = [
   "@next/eslint-plugin-next",
 ] as const;
 
-type PackageJson = {
+export type Clean7aPackageJson = {
+  scripts?: Record<string, string>;
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;
 };
 
-function readJson(relativePath: string): PackageJson {
-  return JSON.parse(readFileSync(resolve(process.cwd(), relativePath), "utf8")) as PackageJson;
+export type Clean7aDependencyCleanupScopeInput = {
+  changedManifestFiles: readonly string[];
+  baseFrontendPackage: Clean7aPackageJson;
+  currentFrontendPackage: Clean7aPackageJson;
+  implementationNote: string;
+};
+
+function parsePackageJson(
+  source: string,
+  label: string,
+): Clean7aPackageJson {
+  try {
+    return JSON.parse(source) as Clean7aPackageJson;
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`No se pudo parsear ${label}: ${detail}`);
+  }
+}
+
+function readCurrentPackageJson(relativePath: string): Clean7aPackageJson {
+  return parsePackageJson(
+    readFileSync(resolve(process.cwd(), relativePath), "utf8"),
+    relativePath,
+  );
 }
 
 function readText(relativePath: string): string {
   return readFileSync(resolve(process.cwd(), relativePath), "utf8");
 }
 
-function gitDiffNameOnly(paths: string[]): string[] {
-  return execFileSync("git", ["diff", "--name-only", "--", ...paths], {
-    encoding: "utf8",
-  })
+function gitDiffNameOnly(paths: readonly string[]): string[] {
+  return execFileSync(
+    "git",
+    ["diff", "HEAD", "--name-only", "--", ...paths],
+    {
+      encoding: "utf8",
+    },
+  )
     .trim()
     .split(/\r?\n/)
     .filter(Boolean);
 }
 
-export function isClean7aAllowedDependencyFile(file: string): boolean {
-  return CLEAN7A_DEPENDENCY_FILES.has(file);
-}
+function readBaseFrontendPackage(): Clean7aPackageJson {
+  let source: string;
 
-export function assertClean7aDependencyCleanupScope(): void {
-  const changedPackageFiles = gitDiffNameOnly([
-    "package.json",
-    "frontend/package.json",
-    "pnpm-lock.yaml",
-    "frontend/pnpm-lock.yaml",
-  ]);
-
-  if (changedPackageFiles.length > 0) {
-    assert.deepEqual(
-      changedPackageFiles.sort(),
-      [...CLEAN7A_DEPENDENCY_FILES].sort(),
-      "PR-CLEAN7A may only modify frontend/package.json and pnpm-lock.yaml among dependency manifests",
+  try {
+    source = execFileSync(
+      "git",
+      ["show", "HEAD:frontend/package.json"],
+      {
+        encoding: "utf8",
+      },
+    );
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `No se pudo leer HEAD:frontend/package.json: ${detail}`,
     );
   }
 
-  const frontendPkg = readJson("frontend/package.json");
-  const dependencies = frontendPkg.dependencies ?? {};
-  const devDependencies = frontendPkg.devDependencies ?? {};
+  return parsePackageJson(source, "HEAD:frontend/package.json");
+}
+
+function dependencySectionsChanged(
+  basePackage: Clean7aPackageJson,
+  currentPackage: Clean7aPackageJson,
+): boolean {
+  const baseDependencies = basePackage.dependencies ?? {};
+  const currentDependencies = currentPackage.dependencies ?? {};
+  const baseDevDependencies = basePackage.devDependencies ?? {};
+  const currentDevDependencies = currentPackage.devDependencies ?? {};
+
+  return (
+    !isDeepStrictEqual(baseDependencies, currentDependencies) ||
+    !isDeepStrictEqual(baseDevDependencies, currentDevDependencies)
+  );
+}
+
+function assertCurrentDependencyInvariants(
+  currentFrontendPackage: Clean7aPackageJson,
+  implementationNote: string,
+): void {
+  const dependencies = currentFrontendPackage.dependencies ?? {};
+  const devDependencies = currentFrontendPackage.devDependencies ?? {};
 
   for (const dependency of CLEAN7A_REMOVED_DEPENDENCIES) {
     assert.equal(
       dependencies[dependency],
       undefined,
-      `PR-CLEAN7A must remove only the approved unused dependency ${dependency}`,
+      `PR-CLEAN7A must keep removed dependency absent: ${dependency}`,
     );
   }
 
@@ -95,14 +149,14 @@ export function assertClean7aDependencyCleanupScope(): void {
     assert.equal(
       dependencies[dependency],
       undefined,
-      `PR-CLEAN7D must remove only the approved unused Radix dependency ${dependency}`,
+      `PR-CLEAN7D must keep removed Radix dependency absent: ${dependency}`,
     );
   }
 
   for (const dependency of RADIX_DEPENDENCIES_LEFT_UNTOUCHED) {
     assert.ok(
       dependencies[dependency],
-      `PR-CLEAN7D must preserve active or deferred Radix dependency ${dependency}`,
+      `PR-CLEAN7D must preserve active or deferred Radix dependency: ${dependency}`,
     );
   }
 
@@ -110,18 +164,83 @@ export function assertClean7aDependencyCleanupScope(): void {
     assert.equal(
       devDependencies[dependency],
       undefined,
-      `PR-CLEAN7C must remove only the approved ESLint tooling dependency ${dependency}`,
+      `PR-CLEAN7C must keep removed ESLint dependency absent: ${dependency}`,
     );
   }
 
-  const implementationNote = readText("docs/implementation/frontend-unused-deps-clean7a.md");
-  assert.ok(implementationNote.includes("PR-CLEAN7A"));
+  assert.ok(
+    implementationNote.includes("PR-CLEAN7A"),
+    "CLEAN7A implementation note must mention PR-CLEAN7A",
+  );
+
   for (const dependency of CLEAN7A_REMOVED_DEPENDENCIES) {
     assert.ok(
       implementationNote.includes(dependency),
       `PR-CLEAN7A implementation note must mention ${dependency}`,
     );
   }
+}
+
+export function assertClean7aDependencyCleanupScopeInput(
+  input: Clean7aDependencyCleanupScopeInput,
+): void {
+  const changedManifestFiles = [...new Set(input.changedManifestFiles)].sort();
+
+  const forbiddenManifestFiles = changedManifestFiles.filter(
+    (file) => !CLEAN7A_DEPENDENCY_FILES.has(file),
+  );
+
+  assert.deepEqual(
+    forbiddenManifestFiles,
+    [],
+    `CLEAN7A scope forbids manifest changes outside frontend/package.json and pnpm-lock.yaml: ${forbiddenManifestFiles.join(", ")}`,
+  );
+
+  const frontendPackageChanged = changedManifestFiles.includes(
+    "frontend/package.json",
+  );
+  const rootLockfileChanged = changedManifestFiles.includes("pnpm-lock.yaml");
+  const dependenciesChanged = dependencySectionsChanged(
+    input.baseFrontendPackage,
+    input.currentFrontendPackage,
+  );
+
+  if (dependenciesChanged) {
+    assert.ok(
+      frontendPackageChanged,
+      "A dependencies/devDependencies change must include frontend/package.json",
+    );
+    assert.ok(
+      rootLockfileChanged,
+      "A dependencies/devDependencies change must include pnpm-lock.yaml",
+    );
+  } else {
+    assert.equal(
+      rootLockfileChanged,
+      false,
+      "pnpm-lock.yaml must not change when dependencies/devDependencies are unchanged",
+    );
+  }
+
+  assertCurrentDependencyInvariants(
+    input.currentFrontendPackage,
+    input.implementationNote,
+  );
+}
+
+export function isClean7aAllowedDependencyFile(file: string): boolean {
+  return CLEAN7A_DEPENDENCY_FILES.has(file);
+}
+
+export function assertClean7aDependencyCleanupScope(): void {
+  assertClean7aDependencyCleanupScopeInput({
+    changedManifestFiles: gitDiffNameOnly(CLEAN7A_MANIFEST_FILES),
+    baseFrontendPackage: readBaseFrontendPackage(),
+    currentFrontendPackage: readCurrentPackageJson("frontend/package.json"),
+    implementationNote: readText(
+      "docs/implementation/frontend-unused-deps-clean7a.md",
+    ),
+  });
 }
 
 export function isClean7aAllowedDependencyChange(file: string): boolean {

--- a/test/unit/infrastructure/clean.test.ts
+++ b/test/unit/infrastructure/clean.test.ts
@@ -1,0 +1,310 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  assertClean7aDependencyCleanupScopeInput,
+  type Clean7aDependencyCleanupScopeInput,
+  type Clean7aPackageJson,
+} from "../../helpers/clean7a-dependency-cleanup-scope.ts";
+
+const activeRadixDependencies = {
+  "@radix-ui/react-dialog": "1.0.0",
+  "@radix-ui/react-separator": "1.0.0",
+  "@radix-ui/react-slot": "1.0.0",
+  "@radix-ui/react-toast": "1.0.0",
+  "@radix-ui/react-tooltip": "1.0.0",
+} as const;
+
+const implementationNote = [
+  "PR-CLEAN7A",
+  "@tanstack/react-query",
+  "@tanstack/react-table",
+  "echarts",
+  "echarts-for-react",
+  "react-hook-form",
+].join("\n");
+
+function packageFixture(
+  overrides: Partial<Clean7aPackageJson> = {},
+): Clean7aPackageJson {
+  return {
+    scripts: {
+      build: "next build",
+    },
+    dependencies: {
+      ...activeRadixDependencies,
+      next: "16.2.7",
+      react: "19.2.7",
+    },
+    devDependencies: {
+      typescript: "5.9.3",
+    },
+    ...overrides,
+  };
+}
+
+function scopeInput(
+  overrides: Partial<Clean7aDependencyCleanupScopeInput> = {},
+): Clean7aDependencyCleanupScopeInput {
+  const baseFrontendPackage = packageFixture();
+
+  return {
+    changedManifestFiles: [],
+    baseFrontendPackage,
+    currentFrontendPackage: packageFixture(),
+    implementationNote,
+    ...overrides,
+  };
+}
+
+function assertScopePasses(
+  input: Clean7aDependencyCleanupScopeInput,
+): void {
+  assert.doesNotThrow(() => {
+    assertClean7aDependencyCleanupScopeInput(input);
+  });
+}
+
+function assertScopeFails(
+  input: Clean7aDependencyCleanupScopeInput,
+  expectedMessage: RegExp,
+): void {
+  assert.throws(
+    () => {
+      assertClean7aDependencyCleanupScopeInput(input);
+    },
+    expectedMessage,
+  );
+}
+
+test("allows a scripts-only frontend package change without pnpm-lock.yaml", () => {
+  assertScopePasses(
+    scopeInput({
+      changedManifestFiles: ["frontend/package.json"],
+      currentFrontendPackage: packageFixture({
+        scripts: {
+          build: "next build",
+          "e2e:extended": "playwright test e2e/example.spec.ts",
+        },
+      }),
+    }),
+  );
+});
+
+test("allows a dependencies change when frontend package and root lockfile both change", () => {
+  assertScopePasses(
+    scopeInput({
+      changedManifestFiles: [
+        "frontend/package.json",
+        "pnpm-lock.yaml",
+      ],
+      currentFrontendPackage: packageFixture({
+        dependencies: {
+          ...activeRadixDependencies,
+          next: "16.2.8",
+          react: "19.2.7",
+        },
+      }),
+    }),
+  );
+});
+
+test("allows a devDependencies change when frontend package and root lockfile both change", () => {
+  assertScopePasses(
+    scopeInput({
+      changedManifestFiles: [
+        "frontend/package.json",
+        "pnpm-lock.yaml",
+      ],
+      currentFrontendPackage: packageFixture({
+        devDependencies: {
+          typescript: "5.9.4",
+        },
+      }),
+    }),
+  );
+});
+
+test("rejects a dependencies change without pnpm-lock.yaml", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: ["frontend/package.json"],
+      currentFrontendPackage: packageFixture({
+        dependencies: {
+          ...activeRadixDependencies,
+          next: "16.2.8",
+          react: "19.2.7",
+        },
+      }),
+    }),
+    /dependencies\/devDependencies change must include pnpm-lock\.yaml/,
+  );
+});
+
+test("rejects a devDependencies change without pnpm-lock.yaml", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: ["frontend/package.json"],
+      currentFrontendPackage: packageFixture({
+        devDependencies: {
+          typescript: "5.9.4",
+        },
+      }),
+    }),
+    /dependencies\/devDependencies change must include pnpm-lock\.yaml/,
+  );
+});
+
+test("rejects pnpm-lock.yaml without a dependency change", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: ["pnpm-lock.yaml"],
+    }),
+    /pnpm-lock\.yaml must not change/,
+  );
+});
+
+test("rejects scripts-only frontend package plus pnpm-lock.yaml", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: [
+        "frontend/package.json",
+        "pnpm-lock.yaml",
+      ],
+      currentFrontendPackage: packageFixture({
+        scripts: {
+          build: "next build",
+          test: "playwright test",
+        },
+      }),
+    }),
+    /pnpm-lock\.yaml must not change/,
+  );
+});
+
+test("rejects a root package.json change", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: ["package.json"],
+    }),
+    /forbids manifest changes outside/,
+  );
+});
+
+test("rejects a frontend-local lockfile change", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: ["frontend/pnpm-lock.yaml"],
+    }),
+    /forbids manifest changes outside/,
+  );
+});
+
+test("ignores dependency property order when values are unchanged", () => {
+  const baseFrontendPackage = packageFixture({
+    dependencies: {
+      next: "16.2.7",
+      react: "19.2.7",
+      ...activeRadixDependencies,
+    },
+  });
+
+  const currentFrontendPackage = packageFixture({
+    dependencies: {
+      ...activeRadixDependencies,
+      react: "19.2.7",
+      next: "16.2.7",
+    },
+  });
+
+  assertScopePasses(
+    scopeInput({
+      changedManifestFiles: ["frontend/package.json"],
+      baseFrontendPackage,
+      currentFrontendPackage,
+    }),
+  );
+});
+
+test("detects a dependency version change as a real dependency mutation", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: ["frontend/package.json"],
+      baseFrontendPackage: packageFixture({
+        dependencies: {
+          ...activeRadixDependencies,
+          next: "16.2.7",
+          react: "19.2.7",
+        },
+      }),
+      currentFrontendPackage: packageFixture({
+        dependencies: {
+          ...activeRadixDependencies,
+          next: "16.2.8",
+          react: "19.2.7",
+        },
+      }),
+    }),
+    /dependencies\/devDependencies change must include pnpm-lock\.yaml/,
+  );
+});
+
+test("preserves CLEAN removed-dependency invariants", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: [
+        "frontend/package.json",
+        "pnpm-lock.yaml",
+      ],
+      currentFrontendPackage: packageFixture({
+        dependencies: {
+          ...activeRadixDependencies,
+          next: "16.2.7",
+          react: "19.2.7",
+          "@tanstack/react-query": "5.0.0",
+        },
+      }),
+    }),
+    /must keep removed dependency absent/,
+  );
+});
+
+test("preserves CLEAN active Radix dependency invariants", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: [
+        "frontend/package.json",
+        "pnpm-lock.yaml",
+      ],
+      currentFrontendPackage: packageFixture({
+        dependencies: {
+          "@radix-ui/react-separator": "1.0.0",
+          "@radix-ui/react-slot": "1.0.0",
+          "@radix-ui/react-toast": "1.0.0",
+          "@radix-ui/react-tooltip": "1.0.0",
+          next: "16.2.7",
+          react: "19.2.7",
+        },
+      }),
+    }),
+    /must preserve active or deferred Radix dependency/,
+  );
+});
+
+test("preserves CLEAN removed devDependency invariants", () => {
+  assertScopeFails(
+    scopeInput({
+      changedManifestFiles: [
+        "frontend/package.json",
+        "pnpm-lock.yaml",
+      ],
+      currentFrontendPackage: packageFixture({
+        devDependencies: {
+          typescript: "5.9.3",
+          "@eslint/eslintrc": "3.0.0",
+        },
+      }),
+    }),
+    /must keep removed ESLint dependency absent/,
+  );
+});


### PR DESCRIPTION
## Objetivo

Corregir el falso positivo que exigía modificar pnpm-lock.yaml ante cambios scripts-only en frontend/package.json.

## Cambios

- Comparación estructural de dependencies y devDependencies contra HEAD.
- Validación pura y testeable del scope.
- Matriz de 14 escenarios CLEAN.
- Documentación de causa, contrato y validaciones.

## Validaciones

- CLEAN aislado: 14/14 PASS
- Consumidores directos: PASS
- pnpm typecheck:test: PASS
- pnpm test: 3000/3000 PASS
- pnpm build: PASS
- pnpm security:public-surface: PASS

## Scope excluido

Sin cambios en runtime, frontend/src, backend, API, auth, DB, schema, migraciones, dependencias, lockfiles o CI.