### PR TITLE
test(governance): verify required-check blocking

### DIFF
--- a/docs/audit/branch-protection-required-check-canary.md
+++ b/docs/audit/branch-protection-required-check-canary.md
@@ -1,0 +1,5 @@
+# Branch Protection Required Check Canary
+
+This file exists only on the canary branch used to verify that `validate-pr-governance` is a required blocking check on `main`.
+
+The associated pull request is intentionally created with incomplete metadata so the governance workflow must fail. The pull request must remain unmergeable and will be closed without merge after evidence is captured.


### PR DESCRIPTION
Intentional negative canary. This body omits the required governance sections so `validate-pr-governance` must fail and branch protection must block merge.