### PR TITLE
ci(governance): enforce quality gate impact mapping

### DIFF
--- a/scripts/governance/pr-governance-validator.mjs
+++ b/scripts/governance/pr-governance-validator.mjs
@@ -151,7 +151,7 @@ export function classifyPath(inputPath) {
   if (
     lower.startsWith(".github/") ||
     lower.startsWith(".vscode/") ||
-    [".gitignore", ".gitattributes", ".npmrc", ".pnpmrc", "agents.md", "tsconfig.json"].includes(name)
+    [".gitignore", ".gitattributes", ".npmrc", ".pnpmrc", ".cursorignore", "agents.md", "tsconfig.json"].includes(name)
   ) {
     return "repository configuration";
   }
@@ -302,7 +302,7 @@ function changedFiles(baseSha, headSha) {
     if (status.startsWith("R")) {
       const oldPath = normalizePath(tokens[index++]);
       const newPath = normalizePath(tokens[index++]);
-      entries.push({ status, path: newPath, display: `${oldPath} -> ${newPath}` });
+      entries.push({ status, path: newPath, oldPath, newPath, display: `${oldPath} -> ${newPath}` });
     } else {
       const path = normalizePath(tokens[index++]);
       entries.push({ status, path, display: path });

--- a/scripts/governance/pr-governance-validator.mjs
+++ b/scripts/governance/pr-governance-validator.mjs
@@ -4,6 +4,10 @@ import { appendFileSync, existsSync, readFileSync } from "node:fs";
 import { basename, posix, resolve, sep } from "node:path";
 import { spawnSync } from "node:child_process";
 import { pathToFileURL } from "node:url";
+import {
+  renderQualityGateImpactSummary,
+  validateQualityGateImpact,
+} from "./quality-gate-impact-validator.mjs";
 
 const ROOT = resolve(process.cwd());
 const EVENT_NAME = process.env.GITHUB_EVENT_NAME ?? "";
@@ -448,7 +452,7 @@ function validateMarkdown(entries, pass, fail) {
   }
 }
 
-function writeSummary({ baseSha, headSha, entries, categories, results, details, failures }) {
+function writeSummary({ baseSha, headSha, entries, categories, results, details, failures, qualityImpact }) {
   if (!SUMMARY_PATH) return;
   const escape = (value) => String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
   const rows = Object.keys(results).map(
@@ -486,6 +490,8 @@ function writeSummary({ baseSha, headSha, entries, categories, results, details,
       "",
       failures.length === 0 ? "`PASS`" : "`FAIL`",
       "",
+      renderQualityGateImpactSummary(qualityImpact).trimEnd(),
+      "",
     ].join("\n"),
     "utf8",
   );
@@ -498,6 +504,7 @@ export function main() {
     "sensitive-file policy": "NOT RUN",
     "secret scan": "NOT RUN",
     Markdown: "NOT RUN",
+    "quality gate impact": "NOT RUN",
     metadata: "NOT RUN",
     scope: "NOT RUN",
   };
@@ -516,6 +523,7 @@ export function main() {
   const event = readEvent();
   const [baseSha, headSha] = determineRange(event, fail, detail);
   let entries = [];
+  let qualityImpact = null;
   const categories = new Map(CATEGORY_ORDER.map((category) => [category, []]));
 
   if (baseSha && headSha && ensureCommit(baseSha) && ensureCommit(headSha)) {
@@ -533,6 +541,17 @@ export function main() {
       validateSensitivePaths(entries, pass, fail);
       validateSecrets(baseSha, headSha, pass, fail);
       validateMarkdown(entries, pass, fail);
+
+      try {
+        qualityImpact = validateQualityGateImpact({ entries, rootDir: ROOT });
+        qualityImpact.details.forEach((message) => detail("quality gate impact", message));
+        qualityImpact.failures.forEach((message) => fail("quality gate impact", message));
+        if (qualityImpact.failures.length === 0) {
+          pass("quality gate impact", "Quality gate impact routing and taxonomy validation passed.");
+        }
+      } catch (error) {
+        fail("quality gate impact", `Quality gate impact validation crashed: ${error.message}`);
+      }
 
       if (EVENT_NAME === "pull_request") {
         const body = event.pull_request?.body ?? "";
@@ -556,7 +575,7 @@ export function main() {
     }
   }
 
-  writeSummary({ baseSha, headSha, entries, categories, results, details, failures });
+  writeSummary({ baseSha, headSha, entries, categories, results, details, failures, qualityImpact });
 
   if (failures.length > 0) {
     failures.forEach(({ section, message }) =>
@@ -565,6 +584,9 @@ export function main() {
     return 1;
   }
 
+  if (results["quality gate impact"] === "PASS") {
+    console.log("Quality gate impact PASS.");
+  }
   console.log("PR Governance passed.");
   return 0;
 }

--- a/scripts/governance/quality-gate-impact-policy.d.mts
+++ b/scripts/governance/quality-gate-impact-policy.d.mts
@@ -1,0 +1,58 @@
+export interface PackageScriptCommand {
+  id: string;
+  type: "package-script";
+  packageScope: "root" | "frontend";
+  script: string;
+  command: string;
+}
+
+export interface DirectCommand {
+  id: string;
+  type: "direct";
+  command: string;
+  reason: string;
+}
+
+export type QualityGateCommand = PackageScriptCommand | DirectCommand;
+
+export interface QualityGate {
+  id: string;
+  name: string;
+  workflow: string | null;
+  check: string | null;
+  execution: string;
+  required: boolean;
+  owner: string;
+  commands: QualityGateCommand[];
+  responsibility: string;
+}
+
+export interface ImpactRule {
+  id: string;
+  matcher:
+    | { type: "exact"; path: string }
+    | { type: "prefix"; path: string }
+    | { type: "root-markdown" };
+  impacts: string[];
+  gates: string[];
+  suiteIds: string[];
+  description: string;
+}
+
+export interface TestTaxonomySuite {
+  id: string;
+  purpose: string;
+  representativePaths: string[];
+  gate: string;
+  commands: PackageScriptCommand[];
+  packageScope: "root" | "frontend";
+  requirement: "mandatory" | "conditional";
+}
+
+export const POLICY_VERSION: string;
+export const README_MARKERS: Readonly<{ start: string; end: string }>;
+export const QUALITY_GATES: readonly QualityGate[];
+export const IMPACT_RULES: readonly ImpactRule[];
+export const TEST_TAXONOMY: readonly TestTaxonomySuite[];
+export const REQUIRED_SOURCE_PATHS: readonly string[];
+export const DIRECT_COMMAND_ALLOWLIST: readonly { command: string; reason: string }[];

--- a/scripts/governance/quality-gate-impact-policy.mjs
+++ b/scripts/governance/quality-gate-impact-policy.mjs
@@ -354,6 +354,9 @@ export const TEST_TAXONOMY = deepFreeze([
   },
 ]);
 
+const BACKEND_SUITE_IDS = TEST_TAXONOMY.filter((suite) => suite.gate === "backend-ci").map((suite) => suite.id);
+const FRONTEND_SUITE_IDS = TEST_TAXONOMY.filter((suite) => suite.gate === "frontend-ci").map((suite) => suite.id);
+
 export const IMPACT_RULES = deepFreeze([
   {
     id: "test-readme-taxonomy",
@@ -377,12 +380,84 @@ export const IMPACT_RULES = deepFreeze([
     description: "Playwright tests and fixtures affect frontend browser validation.",
   },
   {
+    id: "frontend-ci-workflow",
+    matcher: { type: "exact", path: ".github/workflows/frontend-ci.yml" },
+    impacts: ["workflow-policy", "ci-routing", "frontend-ci-routing"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci", "manual-review"],
+    suiteIds: ["backend-tests", ...FRONTEND_SUITE_IDS],
+    description: "Frontend CI workflow changes affect frontend validation routing and required governance summaries.",
+  },
+  {
+    id: "backend-ci-workflow",
+    matcher: { type: "exact", path: ".github/workflows/backend-ci.yml" },
+    impacts: ["workflow-policy", "ci-routing", "backend-ci-routing"],
+    gates: ["pr-governance", "backend-ci", "manual-review"],
+    suiteIds: BACKEND_SUITE_IDS,
+    description: "Backend CI workflow changes affect backend validation routing and required governance summaries.",
+  },
+  {
+    id: "pr-governance-workflow",
+    matcher: { type: "exact", path: ".github/workflows/pr-governance.yml" },
+    impacts: ["workflow-policy", "required-pr-governance"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Required PR governance workflow changes require governance validation and owner review.",
+  },
+  {
     id: "github-workflows",
     matcher: { type: "prefix", path: ".github/workflows/" },
     impacts: ["workflow-policy", "ci-routing"],
     gates: ["pr-governance", "backend-ci", "manual-review"],
     suiteIds: ["backend-tests"],
     description: "Workflow changes affect CI routing and required-check architecture.",
+  },
+  {
+    id: "repo-config-gitignore",
+    matcher: { type: "exact", path: ".gitignore" },
+    impacts: ["repository-configuration"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Git ignore rules affect repository configuration and require governance review.",
+  },
+  {
+    id: "repo-config-gitattributes",
+    matcher: { type: "exact", path: ".gitattributes" },
+    impacts: ["repository-configuration"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Git attributes affect repository configuration and require governance review.",
+  },
+  {
+    id: "repo-config-npmrc",
+    matcher: { type: "exact", path: ".npmrc" },
+    impacts: ["repository-configuration", "package-tooling"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Root npm configuration affects package tooling policy and requires governance review.",
+  },
+  {
+    id: "repo-config-pnpmrc",
+    matcher: { type: "exact", path: ".pnpmrc" },
+    impacts: ["repository-configuration", "package-tooling"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Root pnpm configuration affects package tooling policy and requires governance review.",
+  },
+  {
+    id: "repo-config-cursorignore",
+    matcher: { type: "exact", path: ".cursorignore" },
+    impacts: ["repository-configuration", "agent-tooling"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Cursor ignore rules affect repository agent configuration and require governance review.",
+  },
+  {
+    id: "repo-config-vscode",
+    matcher: { type: "prefix", path: ".vscode/" },
+    impacts: ["repository-configuration", "editor-tooling"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "VS Code workspace settings affect repository editor configuration and require governance review.",
   },
   {
     id: "root-package",

--- a/scripts/governance/quality-gate-impact-policy.mjs
+++ b/scripts/governance/quality-gate-impact-policy.mjs
@@ -1,0 +1,543 @@
+const deepFreeze = (value) => {
+  if (value && typeof value === "object" && !Object.isFrozen(value)) {
+    Object.freeze(value);
+    for (const nested of Object.values(value)) deepFreeze(nested);
+  }
+  return value;
+};
+
+const packageCommand = ({ id, packageScope, script, command }) => ({
+  id,
+  type: "package-script",
+  packageScope,
+  script,
+  command,
+});
+
+const directCommand = ({ id, command, reason }) => ({
+  id,
+  type: "direct",
+  command,
+  reason,
+});
+
+export const POLICY_VERSION = "QGA-2.1";
+
+export const README_MARKERS = deepFreeze({
+  start: "<!-- quality-gate-taxonomy:start -->",
+  end: "<!-- quality-gate-taxonomy:end -->",
+});
+
+export const QUALITY_GATES = deepFreeze([
+  {
+    id: "pr-governance",
+    name: "PR Governance",
+    workflow: "PR Governance",
+    check: "validate-pr-governance",
+    execution: "required",
+    required: true,
+    owner: "CI owner",
+    commands: [
+      directCommand({
+        id: "pr-governance-validator",
+        command: "node scripts/governance/pr-governance-validator.mjs",
+        reason: "This repository script is the existing required PR governance entrypoint.",
+      }),
+    ],
+    responsibility:
+      "Required branch-protection context that validates PR metadata, scope, diff integrity, sensitive-file policy, Markdown hygiene, secrets and quality impact routing.",
+  },
+  {
+    id: "backend-ci",
+    name: "Backend CI",
+    workflow: "Backend CI",
+    check: "validate-backend",
+    execution: "conditional, non-required",
+    required: false,
+    owner: "Backend owner",
+    commands: [
+      packageCommand({
+        id: "backend-typecheck",
+        packageScope: "root",
+        script: "typecheck",
+        command: "pnpm typecheck",
+      }),
+      packageCommand({
+        id: "backend-test-typecheck",
+        packageScope: "root",
+        script: "typecheck:test",
+        command: "pnpm typecheck:test",
+      }),
+      packageCommand({
+        id: "backend-tests",
+        packageScope: "root",
+        script: "test",
+        command: "pnpm test",
+      }),
+      packageCommand({
+        id: "backend-build",
+        packageScope: "root",
+        script: "build",
+        command: "pnpm build",
+      }),
+    ],
+    responsibility:
+      "Conditional backend validation for runtime, schema, script and test changes. This workflow is observable but is not the required merge context.",
+  },
+  {
+    id: "frontend-ci",
+    name: "Frontend CI",
+    workflow: "Frontend CI",
+    check: "validate-frontend",
+    execution: "conditional, non-required",
+    required: false,
+    owner: "Frontend / QA owner",
+    commands: [
+      packageCommand({
+        id: "frontend-lint",
+        packageScope: "frontend",
+        script: "lint",
+        command: "pnpm --dir frontend lint",
+      }),
+      packageCommand({
+        id: "frontend-typecheck",
+        packageScope: "frontend",
+        script: "typecheck",
+        command: "pnpm --dir frontend typecheck",
+      }),
+      packageCommand({
+        id: "frontend-build",
+        packageScope: "frontend",
+        script: "build",
+        command: "pnpm --dir frontend build",
+      }),
+      packageCommand({
+        id: "public-surface-audit",
+        packageScope: "root",
+        script: "security:public-surface",
+        command: "pnpm security:public-surface",
+      }),
+      packageCommand({
+        id: "frontend-e2e-smoke",
+        packageScope: "frontend",
+        script: "e2e:smoke",
+        command: "pnpm --dir frontend e2e:smoke",
+      }),
+      packageCommand({
+        id: "frontend-e2e-admin-mobile",
+        packageScope: "frontend",
+        script: "e2e:admin-mobile",
+        command: "pnpm --dir frontend e2e:admin-mobile",
+      }),
+      packageCommand({
+        id: "frontend-e2e-visual-contract",
+        packageScope: "frontend",
+        script: "e2e:visual-contract",
+        command: "pnpm --dir frontend e2e:visual-contract",
+      }),
+      packageCommand({
+        id: "frontend-e2e-public-clinic",
+        packageScope: "frontend",
+        script: "e2e:public-clinic",
+        command: "pnpm --dir frontend e2e:public-clinic",
+      }),
+    ],
+    responsibility:
+      "Conditional frontend validation for UI, public-surface, build and Playwright layers. This workflow is observable but is not the required merge context.",
+  },
+  {
+    id: "manual-review",
+    name: "Manual review",
+    workflow: null,
+    check: null,
+    execution: "governance fallback",
+    required: false,
+    owner: "Engineering governance",
+    commands: [],
+    responsibility:
+      "Human governance fallback for documentation, repository policy and configuration changes that need owner judgment in addition to automated routing.",
+  },
+]);
+
+export const TEST_TAXONOMY = deepFreeze([
+  {
+    id: "backend-typecheck",
+    purpose: "TypeScript contract for backend runtime and shared test-facing types.",
+    representativePaths: ["server/**", "test/**/*.test.ts", "tsconfig.json"],
+    gate: "backend-ci",
+    commands: [
+      packageCommand({
+        id: "backend-typecheck",
+        packageScope: "root",
+        script: "typecheck",
+        command: "pnpm typecheck",
+      }),
+    ],
+    packageScope: "root",
+    requirement: "mandatory",
+  },
+  {
+    id: "backend-test-typecheck",
+    purpose: "TypeScript contract for the Node test suite.",
+    representativePaths: ["test/**/*.test.ts", "test/tsconfig.json"],
+    gate: "backend-ci",
+    commands: [
+      packageCommand({
+        id: "backend-test-typecheck",
+        packageScope: "root",
+        script: "typecheck:test",
+        command: "pnpm typecheck:test",
+      }),
+    ],
+    packageScope: "root",
+    requirement: "mandatory",
+  },
+  {
+    id: "backend-tests",
+    purpose: "Recursive Node test suite for backend, architecture, security, contracts and static frontend source contracts.",
+    representativePaths: ["test/**/*.test.ts"],
+    gate: "backend-ci",
+    commands: [
+      packageCommand({
+        id: "backend-tests",
+        packageScope: "root",
+        script: "test",
+        command: "pnpm test",
+      }),
+    ],
+    packageScope: "root",
+    requirement: "mandatory",
+  },
+  {
+    id: "backend-build",
+    purpose: "Backend production bundle check.",
+    representativePaths: ["server/**", "package.json"],
+    gate: "backend-ci",
+    commands: [
+      packageCommand({
+        id: "backend-build",
+        packageScope: "root",
+        script: "build",
+        command: "pnpm build",
+      }),
+    ],
+    packageScope: "root",
+    requirement: "mandatory",
+  },
+  {
+    id: "frontend-lint",
+    purpose: "ESLint contract for the Next.js frontend workspace.",
+    representativePaths: ["frontend/**"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-lint",
+        packageScope: "frontend",
+        script: "lint",
+        command: "pnpm --dir frontend lint",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+  {
+    id: "frontend-typecheck",
+    purpose: "TypeScript contract for the Next.js frontend workspace.",
+    representativePaths: ["frontend/**"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-typecheck",
+        packageScope: "frontend",
+        script: "typecheck",
+        command: "pnpm --dir frontend typecheck",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+  {
+    id: "frontend-build",
+    purpose: "Next.js production build contract.",
+    representativePaths: ["frontend/**", "frontend/package.json"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-build",
+        packageScope: "frontend",
+        script: "build",
+        command: "pnpm --dir frontend build",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+  {
+    id: "public-surface-audit",
+    purpose: "Audit of the built public surface for unintended devtools exposure.",
+    representativePaths: ["frontend/**", "scripts/security/**"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "public-surface-audit",
+        packageScope: "root",
+        script: "security:public-surface",
+        command: "pnpm security:public-surface",
+      }),
+    ],
+    packageScope: "root",
+    requirement: "conditional",
+  },
+  {
+    id: "frontend-e2e-smoke",
+    purpose: "Fast Playwright smoke for auth, public routes, hydration, theme and dashboard foundation.",
+    representativePaths: ["frontend/e2e/**", "frontend/src/**"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-e2e-smoke",
+        packageScope: "frontend",
+        script: "e2e:smoke",
+        command: "pnpm --dir frontend e2e:smoke",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+  {
+    id: "frontend-e2e-admin-mobile",
+    purpose: "Playwright mobile admin app-shell and module operability contracts.",
+    representativePaths: ["frontend/e2e/admin-*.spec.ts", "frontend/e2e/dashboard-*.spec.ts"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-e2e-admin-mobile",
+        packageScope: "frontend",
+        script: "e2e:admin-mobile",
+        command: "pnpm --dir frontend e2e:admin-mobile",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+  {
+    id: "frontend-e2e-visual-contract",
+    purpose: "Playwright visual and layout contracts for dashboard shells and responsive behavior.",
+    representativePaths: ["frontend/e2e/dashboard-*.spec.ts"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-e2e-visual-contract",
+        packageScope: "frontend",
+        script: "e2e:visual-contract",
+        command: "pnpm --dir frontend e2e:visual-contract",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+  {
+    id: "frontend-e2e-public-clinic",
+    purpose: "Playwright public and clinic-facing route contracts.",
+    representativePaths: ["frontend/e2e/public-*.spec.ts", "frontend/e2e/dashboard-clinic-*.spec.ts"],
+    gate: "frontend-ci",
+    commands: [
+      packageCommand({
+        id: "frontend-e2e-public-clinic",
+        packageScope: "frontend",
+        script: "e2e:public-clinic",
+        command: "pnpm --dir frontend e2e:public-clinic",
+      }),
+    ],
+    packageScope: "frontend",
+    requirement: "conditional",
+  },
+]);
+
+export const IMPACT_RULES = deepFreeze([
+  {
+    id: "test-readme-taxonomy",
+    matcher: { type: "exact", path: "test/README.md" },
+    impacts: ["test-taxonomy", "quality-gate-documentation"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci", "manual-review"],
+    suiteIds: TEST_TAXONOMY.map((suite) => suite.id),
+    description: "Canonical test taxonomy documentation must stay synchronized with executable policy.",
+  },
+  {
+    id: "frontend-e2e",
+    matcher: { type: "prefix", path: "frontend/e2e/" },
+    impacts: ["frontend-e2e", "browser-behavior"],
+    gates: ["pr-governance", "frontend-ci"],
+    suiteIds: [
+      "frontend-e2e-smoke",
+      "frontend-e2e-admin-mobile",
+      "frontend-e2e-visual-contract",
+      "frontend-e2e-public-clinic",
+    ],
+    description: "Playwright tests and fixtures affect frontend browser validation.",
+  },
+  {
+    id: "github-workflows",
+    matcher: { type: "prefix", path: ".github/workflows/" },
+    impacts: ["workflow-policy", "ci-routing"],
+    gates: ["pr-governance", "backend-ci", "manual-review"],
+    suiteIds: ["backend-tests"],
+    description: "Workflow changes affect CI routing and required-check architecture.",
+  },
+  {
+    id: "root-package",
+    matcher: { type: "exact", path: "package.json" },
+    impacts: ["root-package-scripts", "backend-toolchain", "frontend-public-surface"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci", "manual-review"],
+    suiteIds: [
+      "backend-typecheck",
+      "backend-test-typecheck",
+      "backend-tests",
+      "backend-build",
+      "public-surface-audit",
+    ],
+    description: "Root package changes can affect backend scripts, tooling and public-surface audit.",
+  },
+  {
+    id: "frontend-package",
+    matcher: { type: "exact", path: "frontend/package.json" },
+    impacts: ["frontend-package-scripts", "frontend-toolchain"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci", "manual-review"],
+    suiteIds: [
+      "frontend-lint",
+      "frontend-typecheck",
+      "frontend-build",
+      "frontend-e2e-smoke",
+      "frontend-e2e-admin-mobile",
+      "frontend-e2e-visual-contract",
+      "frontend-e2e-public-clinic",
+    ],
+    description: "Frontend package changes can affect lint, typecheck, build and Playwright scripts.",
+  },
+  {
+    id: "pnpm-lockfile",
+    matcher: { type: "exact", path: "pnpm-lock.yaml" },
+    impacts: ["dependency-lockfile", "supply-chain"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci", "manual-review"],
+    suiteIds: ["backend-tests", "frontend-build", "public-surface-audit"],
+    description: "Lockfile changes can affect all package-backed validation gates.",
+  },
+  {
+    id: "pnpm-workspace",
+    matcher: { type: "exact", path: "pnpm-workspace.yaml" },
+    impacts: ["workspace-topology", "toolchain"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci", "manual-review"],
+    suiteIds: ["backend-tests", "frontend-build"],
+    description: "Workspace topology changes affect root and frontend package resolution.",
+  },
+  {
+    id: "drizzle-config",
+    matcher: { type: "exact", path: "drizzle.config.ts" },
+    impacts: ["database-config", "migration-tooling"],
+    gates: ["pr-governance", "backend-ci", "manual-review"],
+    suiteIds: ["backend-typecheck", "backend-tests"],
+    description: "Drizzle configuration affects schema and migration validation.",
+  },
+  {
+    id: "agents-protocol",
+    matcher: { type: "exact", path: "AGENTS.md" },
+    impacts: ["repository-governance", "agent-protocol"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Agent protocol changes require governance review and PR metadata enforcement.",
+  },
+  {
+    id: "root-tsconfig",
+    matcher: { type: "exact", path: "tsconfig.json" },
+    impacts: ["typescript-toolchain"],
+    gates: ["pr-governance", "backend-ci", "manual-review"],
+    suiteIds: ["backend-typecheck", "backend-test-typecheck"],
+    description: "Root TypeScript config affects backend and test typechecking.",
+  },
+  {
+    id: "server-runtime",
+    matcher: { type: "prefix", path: "server/" },
+    impacts: ["backend-runtime"],
+    gates: ["pr-governance", "backend-ci"],
+    suiteIds: ["backend-typecheck", "backend-test-typecheck", "backend-tests", "backend-build"],
+    description: "Backend runtime changes require backend validation.",
+  },
+  {
+    id: "frontend-runtime",
+    matcher: { type: "prefix", path: "frontend/" },
+    impacts: ["frontend-runtime"],
+    gates: ["pr-governance", "frontend-ci"],
+    suiteIds: [
+      "frontend-lint",
+      "frontend-typecheck",
+      "frontend-build",
+      "public-surface-audit",
+      "frontend-e2e-smoke",
+    ],
+    description: "Frontend runtime changes require frontend lint, typecheck, build and public-surface validation.",
+  },
+  {
+    id: "node-tests",
+    matcher: { type: "prefix", path: "test/" },
+    impacts: ["node-test-suite", "test-taxonomy"],
+    gates: ["pr-governance", "backend-ci"],
+    suiteIds: ["backend-test-typecheck", "backend-tests"],
+    description: "Node test changes affect recursive test execution and test typechecking.",
+  },
+  {
+    id: "database-migrations",
+    matcher: { type: "prefix", path: "drizzle/" },
+    impacts: ["database-schema", "migrations"],
+    gates: ["pr-governance", "backend-ci", "manual-review"],
+    suiteIds: ["backend-typecheck", "backend-tests", "backend-build"],
+    description: "Database schema or migration changes require backend and data review.",
+  },
+  {
+    id: "governance-scripts",
+    matcher: { type: "prefix", path: "scripts/" },
+    impacts: ["governance-tooling", "repository-scripts"],
+    gates: ["pr-governance", "backend-ci", "manual-review"],
+    suiteIds: ["backend-test-typecheck", "backend-tests"],
+    description: "Script changes affect local or CI governance tooling.",
+  },
+  {
+    id: "github-config",
+    matcher: { type: "prefix", path: ".github/" },
+    impacts: ["repository-configuration", "pr-governance"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "GitHub configuration changes require governance validation and review.",
+  },
+  {
+    id: "docs",
+    matcher: { type: "prefix", path: "docs/" },
+    impacts: ["documentation", "governance-documentation"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Documentation changes require PR governance, Markdown hygiene and owner review when normative.",
+  },
+  {
+    id: "root-markdown",
+    matcher: { type: "root-markdown" },
+    impacts: ["root-documentation"],
+    gates: ["pr-governance", "manual-review"],
+    suiteIds: [],
+    description: "Root Markdown changes affect repository-level documentation.",
+  },
+]);
+
+export const REQUIRED_SOURCE_PATHS = deepFreeze([
+  "scripts/governance/pr-governance-validator.mjs",
+  "scripts/governance/quality-gate-impact-policy.mjs",
+  "scripts/governance/quality-gate-impact-validator.mjs",
+  "test/README.md",
+  "package.json",
+  "frontend/package.json",
+]);
+
+export const DIRECT_COMMAND_ALLOWLIST = deepFreeze([
+  {
+    command: "node scripts/governance/pr-governance-validator.mjs",
+    reason: "Existing required PR governance entrypoint.",
+  },
+]);

--- a/scripts/governance/quality-gate-impact-validator.d.mts
+++ b/scripts/governance/quality-gate-impact-validator.d.mts
@@ -1,0 +1,105 @@
+import type { ImpactRule, QualityGate, QualityGateCommand, TestTaxonomySuite } from "./quality-gate-impact-policy.mjs";
+
+export interface ChangedFileEntry {
+  status: string;
+  path: string;
+  display: string;
+}
+
+export interface ChangedPathImpact {
+  status: string;
+  path: string;
+  display: string;
+  rule: ImpactRule | null;
+  gates: QualityGate[];
+  suites: Array<TestTaxonomySuite | { id: string }>;
+}
+
+export interface QualityGateImpactReport {
+  passed: boolean;
+  failures: string[];
+  details: string[];
+  policyVersion: string;
+  changedPaths: ChangedPathImpact[];
+  impactedGates: QualityGate[];
+  impactedSuites: Array<TestTaxonomySuite | { id: string }>;
+  scriptsPassed: boolean;
+  readmePassed: boolean;
+}
+
+export function findImpactRuleForPath(inputPath: string, rules?: readonly ImpactRule[]): ImpactRule | null;
+
+export function validateImpactPolicy(input?: {
+  gates?: readonly QualityGate[];
+  rules?: readonly ImpactRule[];
+  taxonomy?: readonly TestTaxonomySuite[];
+}): { passed: boolean; failures: string[] };
+
+export function validateRulePrecedence(input: {
+  rules?: readonly ImpactRule[];
+  specificPath: string;
+  generalPath: string;
+  expectedSpecificRuleId: string;
+  expectedGeneralRuleId: string;
+}): { passed: boolean; failures: string[] };
+
+export function parsePackageScripts(packageJsonText: string, label: string): Record<string, string>;
+
+export function collectPolicyCommands(input?: {
+  gates?: readonly QualityGate[];
+  taxonomy?: readonly TestTaxonomySuite[];
+}): QualityGateCommand[];
+
+export function validateCommandReferences(input: {
+  rootPackageJsonText: string;
+  frontendPackageJsonText: string;
+  commands?: readonly QualityGateCommand[];
+  directAllowlist?: readonly { command: string; reason: string }[];
+}): { passed: boolean; failures: string[] };
+
+export function renderTestTaxonomyProjection(input?: {
+  taxonomy?: readonly TestTaxonomySuite[];
+  gates?: readonly QualityGate[];
+}): string;
+
+export function renderReadmeTaxonomyBlock(input?: {
+  taxonomy?: readonly TestTaxonomySuite[];
+  gates?: readonly QualityGate[];
+}): string;
+
+export function validateReadmeTaxonomyProjection(input?: {
+  readmeText: string;
+  expectedProjection?: string;
+  markers?: Readonly<{ start: string; end: string }>;
+}): { passed: boolean; failures: string[] };
+
+export function evaluateChangedPathImpact(input?: {
+  entries: readonly ChangedFileEntry[];
+  rules?: readonly ImpactRule[];
+  gates?: readonly QualityGate[];
+  taxonomy?: readonly TestTaxonomySuite[];
+  requiredSourcePaths?: readonly string[];
+}): {
+  passed: boolean;
+  failures: string[];
+  changedPaths: ChangedPathImpact[];
+  impactedGates: QualityGate[];
+  impactedSuites: Array<TestTaxonomySuite | { id: string }>;
+};
+
+export function evaluateQualityGateImpact(input?: {
+  entries: readonly ChangedFileEntry[];
+  rootPackageJsonText: string;
+  frontendPackageJsonText: string;
+  readmeText: string;
+  gates?: readonly QualityGate[];
+  rules?: readonly ImpactRule[];
+  taxonomy?: readonly TestTaxonomySuite[];
+}): QualityGateImpactReport;
+
+export function validateQualityGateImpact(input?: {
+  entries: readonly ChangedFileEntry[];
+  rootDir?: string;
+}): QualityGateImpactReport;
+
+export function renderQualityGateImpactSummary(report: QualityGateImpactReport | null): string;

--- a/scripts/governance/quality-gate-impact-validator.d.mts
+++ b/scripts/governance/quality-gate-impact-validator.d.mts
@@ -3,14 +3,27 @@ import type { ImpactRule, QualityGate, QualityGateCommand, TestTaxonomySuite } f
 export interface ChangedFileEntry {
   status: string;
   path: string;
+  oldPath?: string;
+  newPath?: string;
   display: string;
+}
+
+export interface ChangedPathRoute {
+  role: "path" | "old" | "new";
+  path: string;
+  rule: ImpactRule | null;
 }
 
 export interface ChangedPathImpact {
   status: string;
   path: string;
+  oldPath?: string;
+  newPath?: string;
   display: string;
   rule: ImpactRule | null;
+  rules: ImpactRule[];
+  routes: ChangedPathRoute[];
+  impacts: string[];
   gates: QualityGate[];
   suites: Array<TestTaxonomySuite | { id: string }>;
 }
@@ -21,6 +34,7 @@ export interface QualityGateImpactReport {
   details: string[];
   policyVersion: string;
   changedPaths: ChangedPathImpact[];
+  impactedImpacts: string[];
   impactedGates: QualityGate[];
   impactedSuites: Array<TestTaxonomySuite | { id: string }>;
   scriptsPassed: boolean;
@@ -83,6 +97,7 @@ export function evaluateChangedPathImpact(input?: {
   passed: boolean;
   failures: string[];
   changedPaths: ChangedPathImpact[];
+  impactedImpacts: string[];
   impactedGates: QualityGate[];
   impactedSuites: Array<TestTaxonomySuite | { id: string }>;
 };

--- a/scripts/governance/quality-gate-impact-validator.mjs
+++ b/scripts/governance/quality-gate-impact-validator.mjs
@@ -38,6 +38,10 @@ function formatList(values) {
   return values.length > 0 ? values.join(", ") : "(none)";
 }
 
+function uniqueById(values) {
+  return [...new Map(values.map((value) => [value.id, value])).values()];
+}
+
 function commandText(command) {
   return command.command;
 }
@@ -68,6 +72,26 @@ export function findImpactRuleForPath(inputPath, rules = IMPACT_RULES) {
   }
 
   return null;
+}
+
+function impactPathsForEntry(entry) {
+  const status = String(entry.status ?? "");
+  const paths = [];
+  const push = (role, value) => {
+    if (!value) return;
+    const path = normalizePath(value);
+    if (!paths.some((candidate) => candidate.path === path)) paths.push({ role, path });
+  };
+
+  if (status.startsWith("R")) {
+    push("old", entry.oldPath);
+    push("new", entry.newPath ?? entry.path);
+  } else {
+    push("path", entry.path);
+  }
+
+  if (paths.length === 0) push("path", entry.path);
+  return paths;
 }
 
 export function validateImpactPolicy({
@@ -284,39 +308,68 @@ export function evaluateChangedPathImpact({
   const changedPaths = [];
   const impactedGateIds = new Set();
   const impactedSuiteIds = new Set();
+  const impactedImpactIds = new Set();
 
   for (const entry of entries ?? []) {
     const path = normalizePath(entry.path);
-    const rule = findImpactRuleForPath(path, rules);
-    const gatesForPath = [];
-    const suitesForPath = [];
+    const oldPath = entry.oldPath ? normalizePath(entry.oldPath) : undefined;
+    const newPath = entry.newPath ? normalizePath(entry.newPath) : undefined;
+    const impactPaths = impactPathsForEntry({ ...entry, path, oldPath, newPath });
+    const routes = [];
+    const rulesForPath = [];
+    const impactsForPath = new Set();
+    const gateIdsForPath = new Set();
+    const suiteIdsForPath = new Set();
 
-    if (!rule) {
-      failures.push(`Quality gate impact policy has no route for changed path: ${path}`);
-      changedPaths.push({ ...entry, path, rule: null, gates: [], suites: [] });
-      continue;
+    for (const impactPath of impactPaths) {
+      const rule = findImpactRuleForPath(impactPath.path, rules);
+      routes.push({ ...impactPath, rule });
+
+      if (!rule) {
+        failures.push(`Quality gate impact policy has no route for changed path: ${impactPath.path}`);
+        continue;
+      }
+
+      rulesForPath.push(rule);
+      for (const impact of rule.impacts ?? []) {
+        impactsForPath.add(impact);
+        impactedImpactIds.add(impact);
+      }
+      for (const gateId of rule.gates) gateIdsForPath.add(gateId);
+      for (const suiteId of rule.suiteIds ?? []) suiteIdsForPath.add(suiteId);
     }
 
     if (String(entry.status ?? "").startsWith("D") && requiredSourcePaths.includes(path)) {
       failures.push(`Quality gate impact policy cannot delete required source: ${path}`);
     }
 
-    for (const gateId of rule.gates) {
+    for (const gateId of gateIdsForPath) {
       impactedGateIds.add(gateId);
-      gatesForPath.push(gateMap.get(gateId) ?? { id: gateId, execution: "unknown", required: false });
     }
-    for (const suiteId of rule.suiteIds ?? []) {
+    for (const suiteId of suiteIdsForPath) {
       impactedSuiteIds.add(suiteId);
-      suitesForPath.push(suiteMap.get(suiteId) ?? { id: suiteId });
     }
 
-    changedPaths.push({ ...entry, path, rule, gates: gatesForPath, suites: suitesForPath });
+    const routedRules = uniqueById(rulesForPath);
+    changedPaths.push({
+      ...entry,
+      path,
+      oldPath,
+      newPath,
+      rule: routedRules[0] ?? null,
+      rules: routedRules,
+      routes,
+      impacts: [...impactsForPath],
+      gates: [...gateIdsForPath].map((id) => gateMap.get(id) ?? { id, execution: "unknown", required: false }),
+      suites: [...suiteIdsForPath].map((id) => suiteMap.get(id) ?? { id }),
+    });
   }
 
   return {
     passed: failures.length === 0,
     failures,
     changedPaths,
+    impactedImpacts: [...impactedImpactIds],
     impactedGates: [...impactedGateIds].map((id) => gateMap.get(id) ?? { id, execution: "unknown", required: false }),
     impactedSuites: [...impactedSuiteIds].map((id) => suiteMap.get(id) ?? { id }),
   };
@@ -360,6 +413,7 @@ export function evaluateQualityGateImpact({
     details,
     policyVersion: POLICY_VERSION,
     changedPaths: impact.changedPaths,
+    impactedImpacts: impact.impactedImpacts,
     impactedGates: impact.impactedGates,
     impactedSuites: impact.impactedSuites,
     scriptsPassed: commands.passed,
@@ -398,6 +452,7 @@ export function validateQualityGateImpact({ entries, rootDir = process.cwd() } =
       details: [],
       policyVersion: POLICY_VERSION,
       changedPaths: [],
+      impactedImpacts: [],
       impactedGates: [],
       impactedSuites: [],
       scriptsPassed: false,
@@ -417,9 +472,12 @@ export function renderQualityGateImpactSummary(report) {
   if (!report) return "";
 
   const changedRows = report.changedPaths.map((entry) => {
-    const ruleId = entry.rule?.id ?? "UNCLASSIFIED";
+    const ruleId = entry.rules?.length > 0
+      ? entry.rules.map((rule) => rule.id).join(", ")
+      : (entry.rule?.id ?? "UNCLASSIFIED");
+    const impacts = entry.impacts?.join(", ") || "(none)";
     const gates = entry.gates.map((gate) => `${gate.id} (${gate.execution})`).join(", ") || "(none)";
-    return `| \`${entry.display ?? entry.path}\` | \`${entry.status ?? ""}\` | \`${ruleId}\` | ${gates} |`;
+    return `| \`${entry.display ?? entry.path}\` | \`${entry.status ?? ""}\` | \`${ruleId}\` | ${impacts} | ${gates} |`;
   });
 
   const gateRows = report.impactedGates.map(
@@ -444,9 +502,9 @@ export function renderQualityGateImpactSummary(report) {
     "",
     "### Changed path routing",
     "",
-    "| Path | Status | Rule | Gates |",
-    "| --- | --- | --- | --- |",
-    ...(changedRows.length > 0 ? changedRows : ["| n/a | n/a | n/a | n/a |"]),
+    "| Path | Status | Rule | Impacts | Gates |",
+    "| --- | --- | --- | --- | --- |",
+    ...(changedRows.length > 0 ? changedRows : ["| n/a | n/a | n/a | n/a | n/a |"]),
     "",
     "### Impacted gates",
     "",

--- a/scripts/governance/quality-gate-impact-validator.mjs
+++ b/scripts/governance/quality-gate-impact-validator.mjs
@@ -1,0 +1,464 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  DIRECT_COMMAND_ALLOWLIST,
+  IMPACT_RULES,
+  POLICY_VERSION,
+  QUALITY_GATES,
+  README_MARKERS,
+  REQUIRED_SOURCE_PATHS,
+  TEST_TAXONOMY,
+} from "./quality-gate-impact-policy.mjs";
+
+const ROOT_PACKAGE_PATH = "package.json";
+const FRONTEND_PACKAGE_PATH = "frontend/package.json";
+const TEST_README_PATH = "test/README.md";
+
+function unique(values) {
+  return [...new Set(values)];
+}
+
+function normalizePath(value) {
+  return String(value).replaceAll("\\", "/");
+}
+
+function normalizeMarkdown(value) {
+  const normalized = String(value)
+    .replace(/\r\n/g, "\n")
+    .replace(/\r/g, "\n")
+    .split("\n")
+    .map((line) => line.replace(/[ \t]+$/g, ""))
+    .join("\n")
+    .replace(/\n*$/g, "\n");
+  return normalized;
+}
+
+function formatList(values) {
+  return values.length > 0 ? values.join(", ") : "(none)";
+}
+
+function commandText(command) {
+  return command.command;
+}
+
+function commandSort(left, right) {
+  return commandText(left).localeCompare(commandText(right));
+}
+
+function gateById(gates = QUALITY_GATES) {
+  return new Map(gates.map((gate) => [gate.id, gate]));
+}
+
+function suiteById(taxonomy = TEST_TAXONOMY) {
+  return new Map(taxonomy.map((suite) => [suite.id, suite]));
+}
+
+function isRootMarkdown(path) {
+  return !path.includes("/") && path.toLowerCase().endsWith(".md");
+}
+
+export function findImpactRuleForPath(inputPath, rules = IMPACT_RULES) {
+  const path = normalizePath(inputPath);
+
+  for (const rule of rules) {
+    if (rule.matcher.type === "exact" && path === rule.matcher.path) return rule;
+    if (rule.matcher.type === "prefix" && path.startsWith(rule.matcher.path)) return rule;
+    if (rule.matcher.type === "root-markdown" && isRootMarkdown(path)) return rule;
+  }
+
+  return null;
+}
+
+export function validateImpactPolicy({
+  gates = QUALITY_GATES,
+  rules = IMPACT_RULES,
+  taxonomy = TEST_TAXONOMY,
+} = {}) {
+  const failures = [];
+  const gateIds = gates.map((gate) => gate.id);
+  const ruleIds = rules.map((rule) => rule.id);
+  const suiteIds = taxonomy.map((suite) => suite.id);
+  const gateMap = gateById(gates);
+  const suiteMap = suiteById(taxonomy);
+
+  if (new Set(gateIds).size !== gateIds.length) failures.push("Quality gate IDs must be unique.");
+  if (new Set(ruleIds).size !== ruleIds.length) failures.push("Quality gate impact rule IDs must be unique.");
+  if (new Set(suiteIds).size !== suiteIds.length) failures.push("Quality gate taxonomy suite IDs must be unique.");
+
+  for (const rule of rules) {
+    if (!rule.id || !rule.matcher || !Array.isArray(rule.gates) || rule.gates.length === 0) {
+      failures.push(`Quality gate impact rule is incomplete: ${rule.id || "(missing id)"}.`);
+      continue;
+    }
+    if (rule.matcher.type === "exact" && !rule.matcher.path) {
+      failures.push(`Quality gate impact rule ${rule.id} has an empty exact path.`);
+    }
+    if (rule.matcher.type === "prefix" && !rule.matcher.path) {
+      failures.push(`Quality gate impact rule ${rule.id} has an empty prefix path.`);
+    }
+    if (!["exact", "prefix", "root-markdown"].includes(rule.matcher.type)) {
+      failures.push(`Quality gate impact rule ${rule.id} has an invalid matcher type.`);
+    }
+    for (const gateId of rule.gates) {
+      if (!gateMap.has(gateId)) failures.push(`Quality gate impact rule ${rule.id} references unknown gate: ${gateId}.`);
+    }
+    for (const suiteId of rule.suiteIds ?? []) {
+      if (!suiteMap.has(suiteId)) failures.push(`Quality gate impact rule ${rule.id} references unknown suite: ${suiteId}.`);
+    }
+  }
+
+  for (const suite of taxonomy) {
+    if (!suite.gate || !gateMap.has(suite.gate)) {
+      failures.push(`Quality gate taxonomy suite ${suite.id} references unknown gate: ${suite.gate || "(missing)"}.`);
+    }
+    if (!Array.isArray(suite.commands) || suite.commands.length === 0) {
+      failures.push(`Quality gate taxonomy suite ${suite.id} has no commands.`);
+    }
+  }
+
+  return { passed: failures.length === 0, failures };
+}
+
+export function validateRulePrecedence({
+  rules = IMPACT_RULES,
+  specificPath,
+  generalPath,
+  expectedSpecificRuleId,
+  expectedGeneralRuleId,
+}) {
+  const specific = findImpactRuleForPath(specificPath, rules);
+  const general = findImpactRuleForPath(generalPath, rules);
+  const failures = [];
+
+  if (specific?.id !== expectedSpecificRuleId) {
+    failures.push(`Expected ${specificPath} to resolve to ${expectedSpecificRuleId}, got ${specific?.id || "(none)"}.`);
+  }
+  if (general?.id !== expectedGeneralRuleId) {
+    failures.push(`Expected ${generalPath} to resolve to ${expectedGeneralRuleId}, got ${general?.id || "(none)"}.`);
+  }
+
+  return { passed: failures.length === 0, failures };
+}
+
+export function parsePackageScripts(packageJsonText, label) {
+  const parsed = JSON.parse(packageJsonText);
+  if (!parsed || typeof parsed !== "object" || !parsed.scripts || typeof parsed.scripts !== "object") {
+    throw new Error(`Package file ${label} does not contain a scripts object.`);
+  }
+  return parsed.scripts;
+}
+
+export function collectPolicyCommands({
+  gates = QUALITY_GATES,
+  taxonomy = TEST_TAXONOMY,
+} = {}) {
+  const commands = [];
+  for (const gate of gates) commands.push(...(gate.commands ?? []));
+  for (const suite of taxonomy) commands.push(...(suite.commands ?? []));
+  return commands;
+}
+
+export function validateCommandReferences({
+  rootPackageJsonText,
+  frontendPackageJsonText,
+  commands = collectPolicyCommands(),
+  directAllowlist = DIRECT_COMMAND_ALLOWLIST,
+}) {
+  const failures = [];
+  const rootScripts = parsePackageScripts(rootPackageJsonText, ROOT_PACKAGE_PATH);
+  const frontendScripts = parsePackageScripts(frontendPackageJsonText, FRONTEND_PACKAGE_PATH);
+  const allowedDirect = new Set(directAllowlist.map((entry) => entry.command));
+
+  for (const command of commands) {
+    if (command.type === "package-script") {
+      if (command.packageScope === "root" && !Object.hasOwn(rootScripts, command.script)) {
+        failures.push(`Quality gate taxonomy references missing root script: ${command.script}`);
+      } else if (command.packageScope === "frontend" && !Object.hasOwn(frontendScripts, command.script)) {
+        failures.push(`Quality gate taxonomy references missing frontend script: ${command.script}`);
+      } else if (!["root", "frontend"].includes(command.packageScope)) {
+        failures.push(`Quality gate taxonomy references invalid package scope: ${command.packageScope}`);
+      }
+    } else if (command.type === "direct") {
+      if (!allowedDirect.has(command.command)) {
+        failures.push(`Quality gate taxonomy references non-package command without allowlist entry: ${command.command}`);
+      }
+    } else {
+      failures.push(`Quality gate taxonomy references unsupported command type: ${command.type || "(missing)"}`);
+    }
+  }
+
+  return { passed: failures.length === 0, failures };
+}
+
+export function renderTestTaxonomyProjection({
+  taxonomy = TEST_TAXONOMY,
+  gates = QUALITY_GATES,
+} = {}) {
+  const gatesById = gateById(gates);
+  const rows = [...taxonomy]
+    .sort((left, right) => left.id.localeCompare(right.id))
+    .map((suite) => {
+      const gate = gatesById.get(suite.gate);
+      const commands = [...suite.commands].sort(commandSort).map((command) => `\`${command.command}\``).join("<br>");
+      const paths = suite.representativePaths.map((path) => `\`${path}\``).join("<br>");
+
+      return `| \`${suite.id}\` | ${suite.purpose} | \`${suite.gate}\` (${gate?.execution ?? "unknown"}) | \`${suite.packageScope}\` | ${commands} | ${paths} | \`${suite.requirement}\` |`;
+    });
+
+  return normalizeMarkdown([
+    "_Generated from `scripts/governance/quality-gate-impact-policy.mjs`. Do not edit this block manually._",
+    "",
+    "| Suite ID | Purpose | Gate | Package scope | Commands | Representative paths | Requirement |",
+    "| --- | --- | --- | --- | --- | --- | --- |",
+    ...rows,
+    "",
+  ].join("\n"));
+}
+
+export function renderReadmeTaxonomyBlock(options = {}) {
+  return normalizeMarkdown([
+    README_MARKERS.start,
+    renderTestTaxonomyProjection(options).trimEnd(),
+    README_MARKERS.end,
+    "",
+  ].join("\n"));
+}
+
+function markerIndexes(readmeText, marker) {
+  const indexes = [];
+  let position = readmeText.indexOf(marker);
+  while (position !== -1) {
+    indexes.push(position);
+    position = readmeText.indexOf(marker, position + marker.length);
+  }
+  return indexes;
+}
+
+export function validateReadmeTaxonomyProjection({
+  readmeText,
+  expectedProjection = renderTestTaxonomyProjection(),
+  markers = README_MARKERS,
+} = {}) {
+  const text = String(readmeText ?? "").replace(/\r\n/g, "\n").replace(/\r/g, "\n");
+  const startIndexes = markerIndexes(text, markers.start);
+  const endIndexes = markerIndexes(text, markers.end);
+  const failures = [];
+
+  if (startIndexes.length === 0) failures.push("test/README.md quality gate taxonomy start marker is missing.");
+  if (endIndexes.length === 0) failures.push("test/README.md quality gate taxonomy end marker is missing.");
+  if (startIndexes.length > 1) failures.push("test/README.md quality gate taxonomy start marker is duplicated.");
+  if (endIndexes.length > 1) failures.push("test/README.md quality gate taxonomy end marker is duplicated.");
+  if (failures.length > 0) return { passed: false, failures };
+
+  const start = startIndexes[0];
+  const end = endIndexes[0];
+  if (start > end) {
+    return {
+      passed: false,
+      failures: ["test/README.md quality gate taxonomy markers are in an invalid order."],
+    };
+  }
+
+  const inner = text.slice(start + markers.start.length, end).replace(/^[ \t]*\n/, "");
+  if (normalizeMarkdown(inner) !== normalizeMarkdown(expectedProjection)) {
+    return {
+      passed: false,
+      failures: ["test/README.md quality gate taxonomy is out of sync with the executable policy."],
+    };
+  }
+
+  return { passed: true, failures: [] };
+}
+
+export function evaluateChangedPathImpact({
+  entries,
+  rules = IMPACT_RULES,
+  gates = QUALITY_GATES,
+  taxonomy = TEST_TAXONOMY,
+  requiredSourcePaths = REQUIRED_SOURCE_PATHS,
+} = {}) {
+  const failures = [];
+  const gateMap = gateById(gates);
+  const suiteMap = suiteById(taxonomy);
+  const changedPaths = [];
+  const impactedGateIds = new Set();
+  const impactedSuiteIds = new Set();
+
+  for (const entry of entries ?? []) {
+    const path = normalizePath(entry.path);
+    const rule = findImpactRuleForPath(path, rules);
+    const gatesForPath = [];
+    const suitesForPath = [];
+
+    if (!rule) {
+      failures.push(`Quality gate impact policy has no route for changed path: ${path}`);
+      changedPaths.push({ ...entry, path, rule: null, gates: [], suites: [] });
+      continue;
+    }
+
+    if (String(entry.status ?? "").startsWith("D") && requiredSourcePaths.includes(path)) {
+      failures.push(`Quality gate impact policy cannot delete required source: ${path}`);
+    }
+
+    for (const gateId of rule.gates) {
+      impactedGateIds.add(gateId);
+      gatesForPath.push(gateMap.get(gateId) ?? { id: gateId, execution: "unknown", required: false });
+    }
+    for (const suiteId of rule.suiteIds ?? []) {
+      impactedSuiteIds.add(suiteId);
+      suitesForPath.push(suiteMap.get(suiteId) ?? { id: suiteId });
+    }
+
+    changedPaths.push({ ...entry, path, rule, gates: gatesForPath, suites: suitesForPath });
+  }
+
+  return {
+    passed: failures.length === 0,
+    failures,
+    changedPaths,
+    impactedGates: [...impactedGateIds].map((id) => gateMap.get(id) ?? { id, execution: "unknown", required: false }),
+    impactedSuites: [...impactedSuiteIds].map((id) => suiteMap.get(id) ?? { id }),
+  };
+}
+
+export function evaluateQualityGateImpact({
+  entries,
+  rootPackageJsonText,
+  frontendPackageJsonText,
+  readmeText,
+  gates = QUALITY_GATES,
+  rules = IMPACT_RULES,
+  taxonomy = TEST_TAXONOMY,
+} = {}) {
+  const failures = [];
+  const details = [];
+
+  const policy = validateImpactPolicy({ gates, rules, taxonomy });
+  if (!policy.passed) failures.push(...policy.failures);
+  else details.push("Impact policy structure is valid.");
+
+  const commands = validateCommandReferences({
+    rootPackageJsonText,
+    frontendPackageJsonText,
+    commands: collectPolicyCommands({ gates, taxonomy }),
+  });
+  if (!commands.passed) failures.push(...commands.failures);
+  else details.push("Package script references are valid.");
+
+  const readme = validateReadmeTaxonomyProjection({ readmeText, expectedProjection: renderTestTaxonomyProjection({ taxonomy, gates }) });
+  if (!readme.passed) failures.push(...readme.failures);
+  else details.push("test/README.md taxonomy projection is synchronized.");
+
+  const impact = evaluateChangedPathImpact({ entries, rules, gates, taxonomy });
+  if (!impact.passed) failures.push(...impact.failures);
+  else details.push("All changed paths are classified by impact policy.");
+
+  return {
+    passed: failures.length === 0,
+    failures,
+    details,
+    policyVersion: POLICY_VERSION,
+    changedPaths: impact.changedPaths,
+    impactedGates: impact.impactedGates,
+    impactedSuites: impact.impactedSuites,
+    scriptsPassed: commands.passed,
+    readmePassed: readme.passed,
+  };
+}
+
+export function validateQualityGateImpact({ entries, rootDir = process.cwd() } = {}) {
+  let rootPackageJsonText;
+  let frontendPackageJsonText;
+  let readmeText;
+  const failures = [];
+
+  try {
+    rootPackageJsonText = readFileSync(resolve(rootDir, ROOT_PACKAGE_PATH), "utf8");
+  } catch (error) {
+    failures.push(`Quality gate impact cannot read ${ROOT_PACKAGE_PATH}: ${error.message}`);
+  }
+
+  try {
+    frontendPackageJsonText = readFileSync(resolve(rootDir, FRONTEND_PACKAGE_PATH), "utf8");
+  } catch (error) {
+    failures.push(`Quality gate impact cannot read ${FRONTEND_PACKAGE_PATH}: ${error.message}`);
+  }
+
+  try {
+    readmeText = readFileSync(resolve(rootDir, TEST_README_PATH), "utf8");
+  } catch (error) {
+    failures.push(`Quality gate impact cannot read ${TEST_README_PATH}: ${error.message}`);
+  }
+
+  if (failures.length > 0) {
+    return {
+      passed: false,
+      failures,
+      details: [],
+      policyVersion: POLICY_VERSION,
+      changedPaths: [],
+      impactedGates: [],
+      impactedSuites: [],
+      scriptsPassed: false,
+      readmePassed: false,
+    };
+  }
+
+  return evaluateQualityGateImpact({
+    entries,
+    rootPackageJsonText,
+    frontendPackageJsonText,
+    readmeText,
+  });
+}
+
+export function renderQualityGateImpactSummary(report) {
+  if (!report) return "";
+
+  const changedRows = report.changedPaths.map((entry) => {
+    const ruleId = entry.rule?.id ?? "UNCLASSIFIED";
+    const gates = entry.gates.map((gate) => `${gate.id} (${gate.execution})`).join(", ") || "(none)";
+    return `| \`${entry.display ?? entry.path}\` | \`${entry.status ?? ""}\` | \`${ruleId}\` | ${gates} |`;
+  });
+
+  const gateRows = report.impactedGates.map(
+    (gate) => `| \`${gate.id}\` | ${gate.workflow ?? "n/a"} | ${gate.check ?? "n/a"} | \`${gate.execution}\` | \`${gate.required ? "required" : "non-required"}\` |`,
+  );
+
+  const suiteRows = report.impactedSuites.map((suite) => {
+    const commands = (suite.commands ?? []).map((command) => `\`${command.command}\``).join("<br>") || "(none)";
+    return `| \`${suite.id}\` | \`${suite.gate ?? "unknown"}\` | ${commands} |`;
+  });
+
+  return normalizeMarkdown([
+    "## Quality gate impact",
+    "",
+    "| Field | Value |",
+    "| --- | --- |",
+    `| policy version | \`${report.policyVersion}\` |`,
+    `| result | \`${report.passed ? "PASS" : "FAIL"}\` |`,
+    `| changed paths | \`${report.changedPaths.length}\` |`,
+    `| script validation | \`${report.scriptsPassed ? "PASS" : "FAIL"}\` |`,
+    `| test/README.md taxonomy sync | \`${report.readmePassed ? "PASS" : "FAIL"}\` |`,
+    "",
+    "### Changed path routing",
+    "",
+    "| Path | Status | Rule | Gates |",
+    "| --- | --- | --- | --- |",
+    ...(changedRows.length > 0 ? changedRows : ["| n/a | n/a | n/a | n/a |"]),
+    "",
+    "### Impacted gates",
+    "",
+    "| Gate | Workflow | Check | Execution | Required |",
+    "| --- | --- | --- | --- | --- |",
+    ...(gateRows.length > 0 ? gateRows : ["| n/a | n/a | n/a | n/a | n/a |"]),
+    "",
+    "### Impacted normative suites",
+    "",
+    "| Suite | Gate | Commands |",
+    "| --- | --- | --- |",
+    ...(suiteRows.length > 0 ? suiteRows : ["| n/a | n/a | n/a |"]),
+    "",
+  ].join("\n"));
+}

--- a/test/README.md
+++ b/test/README.md
@@ -134,6 +134,25 @@ pnpm security:public-surface
 
 Para cambios de frontend o E2E, agregar lint, typecheck, build y la suite Playwright focal correspondiente.
 
+<!-- quality-gate-taxonomy:start -->
+_Generated from `scripts/governance/quality-gate-impact-policy.mjs`. Do not edit this block manually._
+
+| Suite ID | Purpose | Gate | Package scope | Commands | Representative paths | Requirement |
+| --- | --- | --- | --- | --- | --- | --- |
+| `backend-build` | Backend production bundle check. | `backend-ci` (conditional, non-required) | `root` | `pnpm build` | `server/**`<br>`package.json` | `mandatory` |
+| `backend-test-typecheck` | TypeScript contract for the Node test suite. | `backend-ci` (conditional, non-required) | `root` | `pnpm typecheck:test` | `test/**/*.test.ts`<br>`test/tsconfig.json` | `mandatory` |
+| `backend-tests` | Recursive Node test suite for backend, architecture, security, contracts and static frontend source contracts. | `backend-ci` (conditional, non-required) | `root` | `pnpm test` | `test/**/*.test.ts` | `mandatory` |
+| `backend-typecheck` | TypeScript contract for backend runtime and shared test-facing types. | `backend-ci` (conditional, non-required) | `root` | `pnpm typecheck` | `server/**`<br>`test/**/*.test.ts`<br>`tsconfig.json` | `mandatory` |
+| `frontend-build` | Next.js production build contract. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend build` | `frontend/**`<br>`frontend/package.json` | `conditional` |
+| `frontend-e2e-admin-mobile` | Playwright mobile admin app-shell and module operability contracts. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend e2e:admin-mobile` | `frontend/e2e/admin-*.spec.ts`<br>`frontend/e2e/dashboard-*.spec.ts` | `conditional` |
+| `frontend-e2e-public-clinic` | Playwright public and clinic-facing route contracts. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend e2e:public-clinic` | `frontend/e2e/public-*.spec.ts`<br>`frontend/e2e/dashboard-clinic-*.spec.ts` | `conditional` |
+| `frontend-e2e-smoke` | Fast Playwright smoke for auth, public routes, hydration, theme and dashboard foundation. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend e2e:smoke` | `frontend/e2e/**`<br>`frontend/src/**` | `conditional` |
+| `frontend-e2e-visual-contract` | Playwright visual and layout contracts for dashboard shells and responsive behavior. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend e2e:visual-contract` | `frontend/e2e/dashboard-*.spec.ts` | `conditional` |
+| `frontend-lint` | ESLint contract for the Next.js frontend workspace. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend lint` | `frontend/**` | `conditional` |
+| `frontend-typecheck` | TypeScript contract for the Next.js frontend workspace. | `frontend-ci` (conditional, non-required) | `frontend` | `pnpm --dir frontend typecheck` | `frontend/**` | `conditional` |
+| `public-surface-audit` | Audit of the built public surface for unintended devtools exposure. | `frontend-ci` (conditional, non-required) | `root` | `pnpm security:public-surface` | `frontend/**`<br>`scripts/security/**` | `conditional` |
+<!-- quality-gate-taxonomy:end -->
+
 ---
 
 ## 8. Estado post-migración

--- a/test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts
+++ b/test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts
@@ -1,0 +1,206 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  copyFileSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const repoRoot = process.cwd();
+
+function copyRepoFile(relativePath: string, targetRoot: string): void {
+  const target = join(targetRoot, relativePath);
+  mkdirSync(dirname(target), { recursive: true });
+  copyFileSync(resolve(repoRoot, relativePath), target);
+}
+
+function runGit(cwd: string, args: string[]): string {
+  const result = spawnSync("git", args, {
+    cwd,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+
+  assert.equal(
+    result.status,
+    0,
+    `git ${args.join(" ")} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`,
+  );
+  return result.stdout.trim();
+}
+
+function setupTempRepository(): { root: string; baseSha: string } {
+  const root = mkdtempSync(join(tmpdir(), "vetneb-qga-pr-"));
+
+  for (const relativePath of [
+    "package.json",
+    "frontend/package.json",
+    "test/README.md",
+    "scripts/governance/pr-governance-validator.mjs",
+    "scripts/governance/quality-gate-impact-policy.mjs",
+    "scripts/governance/quality-gate-impact-validator.mjs",
+  ]) {
+    copyRepoFile(relativePath, root);
+  }
+
+  runGit(root, ["init"]);
+  runGit(root, ["config", "user.email", "qga@example.com"]);
+  runGit(root, ["config", "user.name", "QGA Test"]);
+  runGit(root, ["checkout", "-b", "main"]);
+  runGit(root, ["add", "."]);
+  runGit(root, ["commit", "-m", "base"]);
+
+  return { root, baseSha: runGit(root, ["rev-parse", "HEAD"]) };
+}
+
+function commitFile(root: string, relativePath: string, content: string): string {
+  const target = join(root, relativePath);
+  mkdirSync(dirname(target), { recursive: true });
+  writeFileSync(target, content, "utf8");
+  runGit(root, ["add", relativePath]);
+  runGit(root, ["commit", "-m", `change ${relativePath}`]);
+  return runGit(root, ["rev-parse", "HEAD"]);
+}
+
+function writeEvent(root: string, baseSha: string, headSha: string, body: string): { eventPath: string; summaryPath: string } {
+  const eventPath = join(root, "event.json");
+  const summaryPath = join(root, "summary.md");
+  writeFileSync(
+    eventPath,
+    JSON.stringify({
+      pull_request: {
+        base: { sha: baseSha },
+        head: { sha: headSha },
+        body,
+      },
+    }),
+    "utf8",
+  );
+  writeFileSync(summaryPath, "", "utf8");
+  return { eventPath, summaryPath };
+}
+
+function scriptsToolingBody(): string {
+  return `## Summary
+Quality impact integration fixture.
+
+## Scope
+- [ ] Backend runtime
+- [ ] Frontend runtime
+- [ ] Tests
+- [ ] Workflows/CI
+- [ ] Migrations/Schema
+- [ ] Docs
+- [ ] Dependencies
+- [x] Scripts/Tooling
+- [ ] Repository configuration
+- [ ] Other
+- [ ] Mixed-Scope exception
+
+## Validation
+- Integration fixture.
+
+## Rollback
+Revert fixture.
+`;
+}
+
+function otherScopeBody(): string {
+  return `## Summary
+Quality impact failure fixture.
+
+## Scope
+- [ ] Backend runtime
+- [ ] Frontend runtime
+- [ ] Tests
+- [ ] Workflows/CI
+- [ ] Migrations/Schema
+- [ ] Docs
+- [ ] Dependencies
+- [ ] Scripts/Tooling
+- [ ] Repository configuration
+- [x] Other
+- [ ] Mixed-Scope exception
+
+## Other Scope Detail
+This fixture deliberately exercises an unclassified root asset to prove that quality impact routing fails closed.
+
+## Validation
+- Integration fixture.
+
+## Rollback
+Revert fixture.
+`;
+}
+
+function runValidator(root: string, eventPath: string, summaryPath: string) {
+  return spawnSync("node", ["scripts/governance/pr-governance-validator.mjs"], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+    },
+  });
+}
+
+function withTempRepository(assertion: (repo: { root: string; baseSha: string }) => void): void {
+  const repo = setupTempRepository();
+  try {
+    assertion(repo);
+  } finally {
+    rmSync(repo.root, { recursive: true, force: true });
+  }
+}
+
+test("PR governance invokes quality impact control and passes a valid scripts diff", () => {
+  withTempRepository(({ root, baseSha }) => {
+    const headSha = commitFile(root, "scripts/governance/example.mjs", "export const fixture = true;\n");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, scriptsToolingBody());
+    const result = runValidator(root, eventPath, summaryPath);
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Quality gate impact PASS\./);
+    assert.match(result.stdout, /PR Governance passed\./);
+    assert.match(summary, /## Quality gate impact/);
+    assert.match(summary, /governance-scripts/);
+  });
+});
+
+test("PR governance adds quality impact failures to the general failure path", () => {
+  withTempRepository(({ root, baseSha }) => {
+    const headSha = commitFile(root, "unclassified-root-asset.bin", "fixture\n");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, otherScopeBody());
+    const result = runValidator(root, eventPath, summaryPath);
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /PR Governance quality gate impact/);
+    assert.match(result.stderr, /Quality gate impact policy has no route for changed path: unclassified-root-asset\.bin/);
+    assert.match(summary, /quality gate impact/);
+    assert.match(summary, /`FAIL`/);
+  });
+});
+
+test("PR governance keeps preexisting metadata validation failures active", () => {
+  withTempRepository(({ root, baseSha }) => {
+    const headSha = commitFile(root, "scripts/governance/example.mjs", "export const fixture = true;\n");
+    const missingSummaryBody = scriptsToolingBody().replace(/## Summary[\s\S]*?\n\n## Scope/, "## Scope");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, missingSummaryBody);
+    const result = runValidator(root, eventPath, summaryPath);
+
+    assert.notEqual(result.status, 0);
+    assert.match(result.stderr, /PR Governance metadata/);
+    assert.match(result.stderr, /Missing required section\(s\): Summary/);
+  });
+});

--- a/test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts
+++ b/test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts
@@ -111,6 +111,31 @@ Revert fixture.
 `;
 }
 
+function repositoryConfigurationBody(): string {
+  return `## Summary
+Repository configuration routing fixture.
+
+## Scope
+- [ ] Backend runtime
+- [ ] Frontend runtime
+- [ ] Tests
+- [ ] Workflows/CI
+- [ ] Migrations/Schema
+- [ ] Docs
+- [ ] Dependencies
+- [ ] Scripts/Tooling
+- [x] Repository configuration
+- [ ] Other
+- [ ] Mixed-Scope exception
+
+## Validation
+- Integration fixture.
+
+## Rollback
+Revert fixture.
+`;
+}
+
 function otherScopeBody(): string {
   return `## Summary
 Quality impact failure fixture.
@@ -174,6 +199,20 @@ test("PR governance invokes quality impact control and passes a valid scripts di
     assert.match(result.stdout, /PR Governance passed\./);
     assert.match(summary, /## Quality gate impact/);
     assert.match(summary, /governance-scripts/);
+  });
+});
+
+test("PR governance invokes quality impact control and passes a valid repository config diff", () => {
+  withTempRepository(({ root, baseSha }) => {
+    const headSha = commitFile(root, ".gitignore", "node_modules/\n");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, repositoryConfigurationBody());
+    const result = runValidator(root, eventPath, summaryPath);
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Quality gate impact PASS\./);
+    assert.match(result.stdout, /PR Governance passed\./);
+    assert.match(summary, /repo-config-gitignore/);
   });
 });
 

--- a/test/unit/infrastructure/quality-gate-impact-contract.test.ts
+++ b/test/unit/infrastructure/quality-gate-impact-contract.test.ts
@@ -1,0 +1,317 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+import {
+  IMPACT_RULES,
+  QUALITY_GATES,
+  README_MARKERS,
+  TEST_TAXONOMY,
+} from "../../../scripts/governance/quality-gate-impact-policy.mjs";
+import type { QualityGateCommand } from "../../../scripts/governance/quality-gate-impact-policy.mjs";
+import {
+  evaluateChangedPathImpact,
+  renderTestTaxonomyProjection,
+  validateCommandReferences,
+  validateImpactPolicy,
+  validateReadmeTaxonomyProjection,
+  validateRulePrecedence,
+} from "../../../scripts/governance/quality-gate-impact-validator.mjs";
+
+const rootPackageJsonText = readFileSync(resolve(process.cwd(), "package.json"), "utf8");
+const frontendPackageJsonText = readFileSync(resolve(process.cwd(), "frontend/package.json"), "utf8");
+const readmeText = readFileSync(resolve(process.cwd(), "test/README.md"), "utf8");
+
+function packageScriptCommand(
+  packageScope: "root" | "frontend",
+  script: string,
+  command: string,
+): QualityGateCommand {
+  return {
+    id: `${packageScope}-${script}`,
+    type: "package-script",
+    packageScope,
+    script,
+    command,
+  };
+}
+
+function invalidPackageScriptCommand(packageScope: string, script: string, command: string): QualityGateCommand {
+  return {
+    id: `${packageScope}-${script}`,
+    type: "package-script",
+    packageScope,
+    script,
+    command,
+  } as QualityGateCommand;
+}
+
+test("quality gate policy keeps unique IDs and valid references", () => {
+  const gateIds = QUALITY_GATES.map((gate) => gate.id);
+  const ruleIds = IMPACT_RULES.map((rule) => rule.id);
+  const suiteIds = TEST_TAXONOMY.map((suite) => suite.id);
+  const validation = validateImpactPolicy();
+
+  assert.equal(new Set(gateIds).size, gateIds.length);
+  assert.equal(new Set(ruleIds).size, ruleIds.length);
+  assert.equal(new Set(suiteIds).size, suiteIds.length);
+  assert.deepEqual(validation.failures, []);
+});
+
+test("quality gate rules are non-empty and reference existing gates", () => {
+  const gateIds = new Set(QUALITY_GATES.map((gate) => gate.id));
+
+  for (const rule of IMPACT_RULES) {
+    assert.ok(rule.id);
+    assert.ok(rule.matcher.type);
+    assert.ok(rule.gates.length > 0, `${rule.id} must reference at least one gate`);
+    for (const gateId of rule.gates) assert.ok(gateIds.has(gateId), `${rule.id} -> ${gateId}`);
+  }
+});
+
+test("quality gate taxonomy suites reference existing gates and commands", () => {
+  const gateIds = new Set(QUALITY_GATES.map((gate) => gate.id));
+
+  for (const suite of TEST_TAXONOMY) {
+    assert.ok(gateIds.has(suite.gate), `${suite.id} references ${suite.gate}`);
+    assert.ok(suite.commands.length > 0, `${suite.id} must keep commands`);
+  }
+});
+
+test("impact rule precedence resolves specific routes before general routes", () => {
+  assert.deepEqual(
+    validateRulePrecedence({
+      specificPath: "test/README.md",
+      generalPath: "test/unit/example.test.ts",
+      expectedSpecificRuleId: "test-readme-taxonomy",
+      expectedGeneralRuleId: "node-tests",
+    }).failures,
+    [],
+  );
+  assert.deepEqual(
+    validateRulePrecedence({
+      specificPath: ".github/workflows/backend-ci.yml",
+      generalPath: ".github/CODEOWNERS",
+      expectedSpecificRuleId: "github-workflows",
+      expectedGeneralRuleId: "github-config",
+    }).failures,
+    [],
+  );
+});
+
+test("impact routing classifies representative paths", () => {
+  const expectations = new Map([
+    ["server/routes/clinics.ts", "server-runtime"],
+    ["frontend/src/app/page.tsx", "frontend-runtime"],
+    ["test/unit/example.test.ts", "node-tests"],
+    ["frontend/e2e/admin-mobile.spec.ts", "frontend-e2e"],
+    ["test/README.md", "test-readme-taxonomy"],
+    ["drizzle/schema.ts", "database-migrations"],
+    ["scripts/governance/example.mjs", "governance-scripts"],
+    [".github/workflows/backend-ci.yml", "github-workflows"],
+    [".github/CODEOWNERS", "github-config"],
+    ["docs/governance/example.md", "docs"],
+    ["package.json", "root-package"],
+    ["frontend/package.json", "frontend-package"],
+    ["pnpm-lock.yaml", "pnpm-lockfile"],
+    ["pnpm-workspace.yaml", "pnpm-workspace"],
+    ["drizzle.config.ts", "drizzle-config"],
+    ["AGENTS.md", "agents-protocol"],
+    ["tsconfig.json", "root-tsconfig"],
+    ["README.md", "root-markdown"],
+  ]);
+
+  const entries = [...expectations.keys()].map((path) => ({
+    status: "M",
+    path,
+    display: path,
+  }));
+  const result = evaluateChangedPathImpact({ entries });
+
+  assert.deepEqual(result.failures, []);
+  for (const routed of result.changedPaths) {
+    assert.equal(routed.rule?.id, expectations.get(routed.path), routed.path);
+    assert.ok(routed.gates.length > 0, `${routed.path} must have gates`);
+  }
+});
+
+test("impact routing rejects unclassified root assets", () => {
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "A",
+        path: "unclassified-root-asset.bin",
+        display: "unclassified-root-asset.bin",
+      },
+    ],
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(
+    result.failures.includes(
+      "Quality gate impact policy has no route for changed path: unclassified-root-asset.bin",
+    ),
+  );
+});
+
+test("impact routing blocks deletion of required sources", () => {
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "D",
+        path: "test/README.md",
+        display: "test/README.md",
+      },
+    ],
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(
+    result.failures.includes("Quality gate impact policy cannot delete required source: test/README.md"),
+  );
+});
+
+test("package script references pass for current root and frontend packages", () => {
+  const result = validateCommandReferences({
+    rootPackageJsonText,
+    frontendPackageJsonText,
+  });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("package script validation fails for missing root script", () => {
+  const result = validateCommandReferences({
+    rootPackageJsonText,
+    frontendPackageJsonText,
+    commands: [packageScriptCommand("root", "taxonomy-required", "pnpm taxonomy-required")],
+  });
+
+  assert.deepEqual(result.failures, [
+    "Quality gate taxonomy references missing root script: taxonomy-required",
+  ]);
+});
+
+test("package script validation fails for missing frontend script", () => {
+  const result = validateCommandReferences({
+    rootPackageJsonText,
+    frontendPackageJsonText,
+    commands: [
+      packageScriptCommand(
+        "frontend",
+        "e2e:taxonomy-required",
+        "pnpm --dir frontend e2e:taxonomy-required",
+      ),
+    ],
+  });
+
+  assert.deepEqual(result.failures, [
+    "Quality gate taxonomy references missing frontend script: e2e:taxonomy-required",
+  ]);
+});
+
+test("package script validation fails for invalid package scope", () => {
+  const result = validateCommandReferences({
+    rootPackageJsonText,
+    frontendPackageJsonText,
+    commands: [invalidPackageScriptCommand("workspace", "test", "pnpm --dir workspace test")],
+  });
+
+  assert.deepEqual(result.failures, [
+    "Quality gate taxonomy references invalid package scope: workspace",
+  ]);
+});
+
+test("test README contains the canonical generated taxonomy", () => {
+  const result = validateReadmeTaxonomyProjection({ readmeText });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("test README taxonomy drift is rejected", () => {
+  const drifted = readmeText.replace("Backend production bundle check.", "Backend bundle drift.");
+  const result = validateReadmeTaxonomyProjection({ readmeText: drifted });
+
+  assert.deepEqual(result.failures, [
+    "test/README.md quality gate taxonomy is out of sync with the executable policy.",
+  ]);
+});
+
+test("invented taxonomy commands fail script validation", () => {
+  const result = validateCommandReferences({
+    rootPackageJsonText,
+    frontendPackageJsonText,
+    commands: [
+      packageScriptCommand(
+        "frontend",
+        "e2e:taxonomy-required",
+        "pnpm --dir frontend e2e:taxonomy-required",
+      ),
+    ],
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(result.failures[0].includes("missing frontend script"));
+});
+
+test("test README taxonomy start marker is required", () => {
+  const result = validateReadmeTaxonomyProjection({
+    readmeText: readmeText.replace(README_MARKERS.start, ""),
+  });
+
+  assert.ok(result.failures.includes("test/README.md quality gate taxonomy start marker is missing."));
+});
+
+test("test README taxonomy end marker is required", () => {
+  const result = validateReadmeTaxonomyProjection({
+    readmeText: readmeText.replace(README_MARKERS.end, ""),
+  });
+
+  assert.ok(result.failures.includes("test/README.md quality gate taxonomy end marker is missing."));
+});
+
+test("test README taxonomy duplicate markers are rejected", () => {
+  const result = validateReadmeTaxonomyProjection({
+    readmeText: readmeText.replace(README_MARKERS.start, `${README_MARKERS.start}\n${README_MARKERS.start}`),
+  });
+
+  assert.ok(result.failures.includes("test/README.md quality gate taxonomy start marker is duplicated."));
+});
+
+test("test README taxonomy inverted markers are rejected", () => {
+  const projection = renderTestTaxonomyProjection().trimEnd();
+  const inverted = `${README_MARKERS.end}\n${projection}\n${README_MARKERS.start}\n`;
+  const result = validateReadmeTaxonomyProjection({ readmeText: inverted });
+
+  assert.deepEqual(result.failures, [
+    "test/README.md quality gate taxonomy markers are in an invalid order.",
+  ]);
+});
+
+test("test README taxonomy accepts CRLF and LF as equivalent", () => {
+  const crlf = readmeText.replace(/\n/g, "\r\n");
+  const result = validateReadmeTaxonomyProjection({ readmeText: crlf });
+
+  assert.deepEqual(result.failures, []);
+});
+
+test("test README taxonomy normalizes trailing spaces inside the generated block", () => {
+  const withTrailingSpaces = readmeText
+    .split("\n")
+    .map((line) => {
+      if (
+        line === README_MARKERS.start ||
+        line === README_MARKERS.end ||
+        line.startsWith("_Generated") ||
+        line.startsWith("|")
+      ) {
+        return `${line}   `;
+      }
+      return line;
+    })
+    .join("\n");
+  const result = validateReadmeTaxonomyProjection({ readmeText: withTrailingSpaces });
+
+  assert.deepEqual(result.failures, []);
+});

--- a/test/unit/infrastructure/quality-gate-impact-contract.test.ts
+++ b/test/unit/infrastructure/quality-gate-impact-contract.test.ts
@@ -10,6 +10,7 @@ import {
   TEST_TAXONOMY,
 } from "../../../scripts/governance/quality-gate-impact-policy.mjs";
 import type { QualityGateCommand } from "../../../scripts/governance/quality-gate-impact-policy.mjs";
+import { classifyPath } from "../../../scripts/governance/pr-governance-validator.mjs";
 import {
   evaluateChangedPathImpact,
   renderTestTaxonomyProjection,
@@ -22,6 +23,10 @@ import {
 const rootPackageJsonText = readFileSync(resolve(process.cwd(), "package.json"), "utf8");
 const frontendPackageJsonText = readFileSync(resolve(process.cwd(), "frontend/package.json"), "utf8");
 const readmeText = readFileSync(resolve(process.cwd(), "test/README.md"), "utf8");
+
+function ids(values: Array<{ id: string }>): string[] {
+  return values.map((value) => value.id);
+}
 
 function packageScriptCommand(
   packageScope: "root" | "frontend",
@@ -93,8 +98,17 @@ test("impact rule precedence resolves specific routes before general routes", ()
     validateRulePrecedence({
       specificPath: ".github/workflows/backend-ci.yml",
       generalPath: ".github/CODEOWNERS",
-      expectedSpecificRuleId: "github-workflows",
+      expectedSpecificRuleId: "backend-ci-workflow",
       expectedGeneralRuleId: "github-config",
+    }).failures,
+    [],
+  );
+  assert.deepEqual(
+    validateRulePrecedence({
+      specificPath: ".github/workflows/frontend-ci.yml",
+      generalPath: ".github/workflows/custom-ci.yml",
+      expectedSpecificRuleId: "frontend-ci-workflow",
+      expectedGeneralRuleId: "github-workflows",
     }).failures,
     [],
   );
@@ -109,8 +123,16 @@ test("impact routing classifies representative paths", () => {
     ["test/README.md", "test-readme-taxonomy"],
     ["drizzle/schema.ts", "database-migrations"],
     ["scripts/governance/example.mjs", "governance-scripts"],
-    [".github/workflows/backend-ci.yml", "github-workflows"],
+    [".github/workflows/backend-ci.yml", "backend-ci-workflow"],
+    [".github/workflows/frontend-ci.yml", "frontend-ci-workflow"],
+    [".github/workflows/pr-governance.yml", "pr-governance-workflow"],
     [".github/CODEOWNERS", "github-config"],
+    [".gitignore", "repo-config-gitignore"],
+    [".gitattributes", "repo-config-gitattributes"],
+    [".npmrc", "repo-config-npmrc"],
+    [".pnpmrc", "repo-config-pnpmrc"],
+    [".cursorignore", "repo-config-cursorignore"],
+    [".vscode/settings.json", "repo-config-vscode"],
     ["docs/governance/example.md", "docs"],
     ["package.json", "root-package"],
     ["frontend/package.json", "frontend-package"],
@@ -136,6 +158,58 @@ test("impact routing classifies representative paths", () => {
   }
 });
 
+test("PR governance classifyPath maps cursorignore to repository configuration", () => {
+  assert.equal(classifyPath(".cursorignore"), "repository configuration");
+});
+
+test("repository configuration routes use governance and manual review gates", () => {
+  const entries = [
+    ".gitignore",
+    ".gitattributes",
+    ".npmrc",
+    ".pnpmrc",
+    ".cursorignore",
+    ".vscode/settings.json",
+  ].map((path) => ({
+    status: "M",
+    path,
+    display: path,
+  }));
+
+  const result = evaluateChangedPathImpact({ entries });
+
+  assert.deepEqual(result.failures, []);
+  for (const routed of result.changedPaths) {
+    assert.ok(ids(routed.gates).includes("pr-governance"), routed.path);
+    assert.ok(ids(routed.gates).includes("manual-review"), routed.path);
+    assert.ok(routed.impacts.includes("repository-configuration"), routed.path);
+  }
+});
+
+test("frontend workflow exact route includes frontend CI and normative frontend suites", () => {
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "M",
+        path: ".github/workflows/frontend-ci.yml",
+        display: ".github/workflows/frontend-ci.yml",
+      },
+    ],
+  });
+  const routed = result.changedPaths[0];
+  const gateIds = ids(routed.gates);
+  const suiteIds = ids(routed.suites);
+  const frontendSuiteIds = TEST_TAXONOMY.filter((suite) => suite.gate === "frontend-ci").map((suite) => suite.id);
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(routed.rule?.id, "frontend-ci-workflow");
+  assert.ok(gateIds.includes("pr-governance"));
+  assert.ok(gateIds.includes("backend-ci"));
+  assert.ok(gateIds.includes("frontend-ci"));
+  assert.ok(gateIds.includes("manual-review"));
+  for (const suiteId of frontendSuiteIds) assert.ok(suiteIds.includes(suiteId), suiteId);
+});
+
 test("impact routing rejects unclassified root assets", () => {
   const result = evaluateChangedPathImpact({
     entries: [
@@ -153,6 +227,75 @@ test("impact routing rejects unclassified root assets", () => {
       "Quality gate impact policy has no route for changed path: unclassified-root-asset.bin",
     ),
   );
+});
+
+test("impact routing combines old and new paths for server to docs renames", () => {
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "R100",
+        path: "docs/foo.md",
+        oldPath: "server/routes/foo.ts",
+        newPath: "docs/foo.md",
+        display: "server/routes/foo.ts -> docs/foo.md",
+      },
+    ],
+  });
+  const routed = result.changedPaths[0];
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(routed.oldPath, "server/routes/foo.ts");
+  assert.equal(routed.newPath, "docs/foo.md");
+  assert.deepEqual(ids(routed.rules), ["server-runtime", "docs"]);
+  assert.ok(routed.impacts.includes("backend-runtime"));
+  assert.ok(routed.impacts.includes("documentation"));
+  assert.ok(ids(routed.gates).includes("backend-ci"));
+  assert.ok(ids(routed.gates).includes("manual-review"));
+});
+
+test("impact routing combines old and new paths for docs to frontend renames", () => {
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "R100",
+        path: "frontend/src/app/page.tsx",
+        oldPath: "docs/foo.md",
+        newPath: "frontend/src/app/page.tsx",
+        display: "docs/foo.md -> frontend/src/app/page.tsx",
+      },
+    ],
+  });
+  const routed = result.changedPaths[0];
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(ids(routed.rules), ["docs", "frontend-runtime"]);
+  assert.ok(routed.impacts.includes("documentation"));
+  assert.ok(routed.impacts.includes("frontend-runtime"));
+  assert.ok(ids(routed.gates).includes("frontend-ci"));
+  assert.ok(ids(routed.gates).includes("manual-review"));
+});
+
+test("impact routing deduplicates gates and suites for same-domain renames", () => {
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "R100",
+        path: "server/routes/bar.ts",
+        oldPath: "server/routes/foo.ts",
+        newPath: "server/routes/bar.ts",
+        display: "server/routes/foo.ts -> server/routes/bar.ts",
+      },
+    ],
+  });
+  const routed = result.changedPaths[0];
+  const gateIds = ids(routed.gates);
+  const suiteIds = ids(routed.suites);
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(ids(routed.rules), ["server-runtime"]);
+  assert.deepEqual(gateIds, [...new Set(gateIds)]);
+  assert.deepEqual(suiteIds, [...new Set(suiteIds)]);
+  assert.deepEqual(routed.impacts, [...new Set(routed.impacts)]);
 });
 
 test("impact routing blocks deletion of required sources", () => {


### PR DESCRIPTION
## Summary

Implement machine-checkable quality gate impact routing inside the existing required `validate-pr-governance` context.

The change introduces a structured impact policy, rejects unclassified paths, validates referenced root/frontend package scripts, and keeps the canonical test taxonomy in `test/README.md` synchronized with executable policy.

This PR does not close `ERM-CTRL-014`, `ERM-FE-001`, or `ERM-CI-002`. A real negative canary remains mandatory after this implementation is merged.

## Scope

- [ ] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/Schema
- [ ] Docs
- [ ] Dependencies
- [x] Scripts/Tooling
- [ ] Repository configuration
- [ ] Other
- [ ] Mixed-Scope exception

## Validation

- `node --check` passed for all changed governance modules.
- Targeted quality-impact and PR-governance contract tests passed.
- `pnpm typecheck` passed.
- `pnpm typecheck:test` passed.
- `pnpm test` passed.
- `pnpm build` passed.
- `pnpm security:public-surface` passed.
- A synthetic positive PR event passed the complete `pr-governance-validator.mjs` integration path.

## Rollback

Revert this commit. The existing workflow, required check name, branch protection and product runtime remain unchanged.