### PR TITLE
ci(governance): enforce workflow security in pr governance

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,6 +1,9 @@
 name: PR Governance
 
 on:
+  pull_request:
+    branches:
+      - main
   pull_request_target:
     branches:
       - main
@@ -31,7 +34,7 @@ jobs:
       - name: Checkout candidate tree
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
-          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
           path: candidate
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -1,7 +1,7 @@
 name: PR Governance
 
 on:
-  pull_request:
+  pull_request_target:
     branches:
       - main
   workflow_dispatch:
@@ -20,15 +20,37 @@ jobs:
     timeout-minutes: 10
 
     steps:
-      - name: Checkout repository
+      - name: Checkout trusted governance code
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
         with:
+          ref: ${{ github.event.pull_request.base.sha || github.sha }}
+          path: trusted
+          persist-credentials: false
           fetch-depth: 0
+
+      - name: Checkout candidate tree
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+          path: candidate
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.8.1
 
       - name: Setup Node.js
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
           node-version: 24
+          cache: pnpm
+          cache-dependency-path: trusted/pnpm-lock.yaml
+
+      - name: Install trusted dependencies
+        run: pnpm --dir trusted install --frozen-lockfile --ignore-scripts
 
       - name: Validate pull request governance
-        run: node scripts/governance/pr-governance-validator.mjs
+        working-directory: candidate
+        run: node ../trusted/scripts/governance/pr-governance-validator.mjs

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -13,7 +13,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: pr-governance-${{ github.workflow }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
+  group: pr-governance-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/docs/audit/workflow-security-required-enforcement-audit.md
+++ b/docs/audit/workflow-security-required-enforcement-audit.md
@@ -1,0 +1,176 @@
+# Workflow Security Required Enforcement Audit
+
+| Campo | Valor |
+| --- | --- |
+| Fecha | 2026-07-13 |
+| Rama | `ci/workflow-security-required-enforcement` |
+| Base | `main@d004bfb4035886535fe13a7f244ccb2dd60ec306` |
+| Dictamen | Implementacion conforme al scope con suite completa local fail 0 |
+
+## Alcance auditado
+
+Incluido:
+
+- workflow requerido `PR Governance / validate-pr-governance`;
+- trust boundary `trusted` / `candidate`;
+- bootstrap compatibility para la unica transicion desde `pull_request` legacy;
+- permisos read-only;
+- parser-backed enforcement obligatorio;
+- contratos de PR Governance y workflow security;
+- freeze SHA-256 temporal.
+
+Excluido:
+
+- branch protection, settings y rulesets;
+- backend, frontend runtime, DB, migraciones, Supabase, auth y sesiones;
+- dependencias y lockfiles;
+- secrets y permisos write;
+- QGA-N2.
+
+## Hallazgos
+
+### Evento requerido
+
+`.github/workflows/pr-governance.yml` reemplaza `pull_request` por `pull_request_target` y conserva `workflow_dispatch`.
+
+Resultado: PASS.
+
+### Permisos
+
+El workflow mantiene permisos top-level exactos:
+
+```yaml
+permissions:
+  contents: read
+```
+
+No se agregaron permisos write, secrets ni job-level permissions.
+
+Resultado: PASS.
+
+### Codigo confiable
+
+El checkout `trusted` usa la version de base para PRs:
+
+```yaml
+ref: ${{ github.event.pull_request.base.sha || github.sha }}
+path: trusted
+```
+
+Para `workflow_dispatch`, la misma expresion cae en `github.sha`.
+
+Resultado: PASS.
+
+### Candidate estatico
+
+El checkout `candidate` usa merge ref para PRs:
+
+```yaml
+ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+path: candidate
+```
+
+El candidate se usa como arbol estatico de inspeccion. No se instalan dependencias ahi y no se ejecutan scripts del candidate.
+
+Resultado: PASS.
+
+### Dependencias
+
+`pnpm/action-setup` usa el SHA ya aprobado. La instalacion se limita a:
+
+```powershell
+pnpm --dir trusted install --frozen-lockfile --ignore-scripts
+```
+
+Resultado: PASS.
+
+### Ejecucion
+
+El step requerido corre con:
+
+```yaml
+working-directory: candidate
+run: node ../trusted/scripts/governance/pr-governance-validator.mjs
+```
+
+El script importado pertenece a `trusted`; `ROOT` sigue siendo `candidate`, por lo que los workflows inspeccionados son los de la PR.
+
+Resultado: PASS.
+
+### Enforcement parser-backed
+
+`pr-governance-validator.mjs` no importa estaticamente `workflow-security-validator.mjs`.
+
+Para `pull_request_target` y `workflow_dispatch`, carga dinamicamente desde codigo confiable:
+
+```js
+await import("./workflow-security-validator.mjs")
+```
+
+Luego ejecuta `evaluateWorkflowSecurity({ rootDir: ROOT })`, aun cuando la PR no modifica `.github/workflows`.
+
+Resultado: PASS.
+
+### Bootstrap pull_request
+
+El evento legacy `pull_request` conserva las validaciones existentes de governance, pero marca `workflow security` como `N/A` con el detalle deterministico:
+
+```text
+Bootstrap pull_request compatibility path; parser-backed enforcement becomes mandatory after the pull_request_target workflow is merged.
+```
+
+En ese camino no se carga `workflow-security-validator.mjs` ni `js-yaml`. Despues del merge, `.github/workflows/pr-governance.yml` ya no escucha `pull_request`, por lo que este camino queda inalcanzable en operacion normal.
+
+Resultado: PASS.
+
+### Fallo cerrado
+
+Los fallos de workflow security se agregan a `failures`; por lo tanto, el required check termina con exit code `1` si el candidate contiene acciones mutables, permisos write, imagenes inseguras o aliases YAML.
+
+Resultado: PASS.
+
+### Summary
+
+El GitHub Step Summary conserva PR Governance y quality impact, y agrega:
+
+```md
+## Workflow security
+```
+
+Resultado: PASS.
+
+### Freeze
+
+El freeze SHA-256 se conserva. Solo se actualizo el digest revisado de `.github/workflows/pr-governance.yml`.
+
+Resultado: PASS.
+
+## Validaciones observadas
+
+| Comando | Resultado |
+| --- | --- |
+| `node --check scripts/governance/pr-governance-validator.mjs` | PASS |
+| `node --check scripts/governance/workflow-security-validator.mjs` | PASS |
+| `node scripts/governance/workflow-security-validator.mjs` | PASS: 5 workflows, 15 acciones externas, 1 excepcion |
+| `node scripts/governance/workflow-security-validator.mjs --json` | PASS |
+| `pnpm exec tsx --test test/unit/infrastructure/pr-governance-single-scope-contract.test.ts test/unit/infrastructure/quality-gate-impact-contract.test.ts test/unit/infrastructure/workflow-security-policy-contract.test.ts test/unit/infrastructure/workflow-security-validator-contract.test.ts test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts` | PASS: 98 tests, fail 0 |
+| `pnpm typecheck` | PASS |
+| `pnpm typecheck:test` | PASS |
+| `pnpm test` | PASS: 3101 tests, fail 0 |
+| `pnpm build` | PASS |
+| `pnpm security:public-surface` | PASS; hallazgos existentes `server-only` |
+| `pnpm --dir frontend lint` | PASS |
+| `pnpm --dir frontend typecheck` | PASS |
+| `pnpm --dir frontend build` | PASS |
+| `git diff --check` | PASS |
+
+## Riesgo residual
+
+- `pull_request_target` debe permanecer sin secrets, sin permisos write y sin ejecucion candidate.
+- Si GitHub no puede crear `refs/pull/<number>/merge`, el checkout candidate fallara antes de ejecutar governance.
+- El camino bootstrap legacy existe solo durante esta transicion y depende de mantener `workflow security` como `N/A` exclusivamente en `pull_request`.
+- QGA-N2 no fue iniciado por scope explicito.
+
+## Dictamen
+
+QGA-4B queda completado: el workflow security parser-backed queda convertido en enforcement obligatorio dentro del check requerido `PR Governance / validate-pr-governance`, con separacion explicita entre codigo confiable y arbol candidate.

--- a/docs/audit/workflow-security-required-enforcement-audit.md
+++ b/docs/audit/workflow-security-required-enforcement-audit.md
@@ -5,7 +5,7 @@
 | Fecha | 2026-07-13 |
 | Rama | `ci/workflow-security-required-enforcement` |
 | Base | `main@d004bfb4035886535fe13a7f244ccb2dd60ec306` |
-| Dictamen | Implementacion conforme al scope con suite completa local fail 0 |
+| Dictamen | Fase transitoria #1459 conforme al scope; QGA-4B pendiente de cierre definitivo |
 
 ## Alcance auditado
 
@@ -13,7 +13,8 @@ Incluido:
 
 - workflow requerido `PR Governance / validate-pr-governance`;
 - trust boundary `trusted` / `candidate`;
-- bootstrap compatibility para la unica transicion desde `pull_request` legacy;
+- activacion dual transitoria `pull_request` + `pull_request_target`;
+- bootstrap compatibility para `pull_request`;
 - permisos read-only;
 - parser-backed enforcement obligatorio;
 - contratos de PR Governance y workflow security;
@@ -29,9 +30,22 @@ Excluido:
 
 ## Hallazgos
 
-### Evento requerido
+### Evento requerido transitorio
 
-`.github/workflows/pr-governance.yml` reemplaza `pull_request` por `pull_request_target` y conserva `workflow_dispatch`.
+`.github/workflows/pr-governance.yml` declara durante #1459:
+
+```yaml
+on:
+  pull_request:
+    branches:
+      - main
+  pull_request_target:
+    branches:
+      - main
+  workflow_dispatch:
+```
+
+`pull_request` existe unicamente para obtener el required check durante la transicion. `pull_request_target` queda instalado en `main` al fusionar #1459.
 
 Resultado: PASS.
 
@@ -66,9 +80,11 @@ Resultado: PASS.
 El checkout `candidate` usa merge ref para PRs:
 
 ```yaml
-ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
+ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}
 path: candidate
 ```
+
+`pull_request` y `pull_request_target` inspeccionan `refs/pull/<number>/merge`; `workflow_dispatch` usa `github.sha`.
 
 El candidate se usa como arbol estatico de inspeccion. No se instalan dependencias ahi y no se ejecutan scripts del candidate.
 
@@ -113,13 +129,13 @@ Resultado: PASS.
 
 ### Bootstrap pull_request
 
-El evento legacy `pull_request` conserva las validaciones existentes de governance, pero marca `workflow security` como `N/A` con el detalle deterministico:
+El evento `pull_request` transitorio conserva las validaciones existentes de governance, pero marca `workflow security` como `N/A` con el detalle deterministico:
 
 ```text
 Bootstrap pull_request compatibility path; parser-backed enforcement becomes mandatory after the pull_request_target workflow is merged.
 ```
 
-En ese camino no se carga `workflow-security-validator.mjs` ni `js-yaml`. Despues del merge, `.github/workflows/pr-governance.yml` ya no escucha `pull_request`, por lo que este camino queda inalcanzable en operacion normal.
+En ese camino no se carga `workflow-security-validator.mjs` ni `js-yaml`. El cierre definitivo de QGA-4B requiere una segunda PR que elimine `pull_request` despues de que `pull_request_target` ya exista en `main`.
 
 Resultado: PASS.
 
@@ -173,4 +189,4 @@ Resultado: PASS.
 
 ## Dictamen
 
-QGA-4B queda completado: el workflow security parser-backed queda convertido en enforcement obligatorio dentro del check requerido `PR Governance / validate-pr-governance`, con separacion explicita entre codigo confiable y arbol candidate.
+#1459 queda como fase transitoria segura: activa el required check con `pull_request`, instala `pull_request_target` en `main`, preserva la separacion `trusted`/`candidate` y mantiene QGA-N2 bloqueado. QGA-4B no queda cerrado hasta una segunda PR que elimine `pull_request`.

--- a/docs/audit/workflow-security-required-enforcement-audit.md
+++ b/docs/audit/workflow-security-required-enforcement-audit.md
@@ -14,6 +14,7 @@ Incluido:
 - workflow requerido `PR Governance / validate-pr-governance`;
 - trust boundary `trusted` / `candidate`;
 - activacion dual transitoria `pull_request` + `pull_request_target`;
+- aislamiento de concurrencia por evento para la transicion dual;
 - bootstrap compatibility para `pull_request`;
 - permisos read-only;
 - parser-backed enforcement obligatorio;
@@ -46,6 +47,19 @@ on:
 ```
 
 `pull_request` existe unicamente para obtener el required check durante la transicion. `pull_request_target` queda instalado en `main` al fusionar #1459.
+
+Resultado: PASS.
+
+### Concurrencia
+
+El concurrency group incluye `github.event_name` y conserva `cancel-in-progress: true`:
+
+```yaml
+group: pr-governance-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}
+cancel-in-progress: true
+```
+
+Esto evita que las ejecuciones `pull_request` y `pull_request_target` del mismo PR se cancelen entre si durante #1459.
 
 Resultado: PASS.
 

--- a/docs/implementation/workflow-security-required-enforcement.md
+++ b/docs/implementation/workflow-security-required-enforcement.md
@@ -5,7 +5,7 @@
 | Fecha | 2026-07-13 |
 | Rama | `ci/workflow-security-required-enforcement` |
 | Base | `main@d004bfb4035886535fe13a7f244ccb2dd60ec306` |
-| Estado | Implementado y validado localmente con fail 0 |
+| Estado | Fase transitoria #1459 implementada; QGA-4B pendiente de cierre definitivo |
 | Owner | CI owner / Engineering governance |
 
 ## Estado base
@@ -19,15 +19,15 @@
 
 ## Scope incluido
 
-- Convertir `.github/workflows/pr-governance.yml` a `pull_request_target` conservando `workflow_dispatch`.
+- Convertir `.github/workflows/pr-governance.yml` en fase transitoria de activacion dual para #1459: `pull_request`, `pull_request_target` y `workflow_dispatch`.
 - Mantener el workflow `PR Governance` y el job/check `validate-pr-governance`.
 - Separar checkout confiable `trusted` desde base SHA/current SHA y checkout `candidate` desde `refs/pull/<number>/merge`/current SHA.
 - Instalar dependencias solo en `trusted` con `pnpm --dir trusted install --frozen-lockfile --ignore-scripts`.
 - Ejecutar desde `candidate` solo `node ../trusted/scripts/governance/pr-governance-validator.mjs`.
 - Tratar `pull_request_target` como evento PR valido en `pr-governance-validator.mjs`.
 - Cargar dinamicamente el workflow security validator solo en `pull_request_target` y `workflow_dispatch`.
-- Integrar `evaluateWorkflowSecurity({ rootDir: ROOT })` dentro del check requerido para la operacion normal post-merge.
-- Conservar compatibilidad bootstrap para el unico camino legacy `pull_request` que evalua esta PR antes del merge.
+- Integrar `evaluateWorkflowSecurity({ rootDir: ROOT })` dentro del check requerido para `pull_request_target` y `workflow_dispatch`.
+- Conservar compatibilidad bootstrap para `pull_request` durante esta PR transitoria.
 - Agregar `workflow security` a `results`, `details`, `failures` y GitHub Step Summary.
 - Validar siempre todos los workflows del candidate aunque la PR no toque `.github/workflows`.
 - Actualizar contratos de seguridad y PR Governance.
@@ -59,9 +59,11 @@
 
 ## Cambios
 
-- `PR Governance` ahora usa `pull_request_target` con `permissions: contents: read`.
+- `PR Governance` ahora usa activacion dual transitoria con `pull_request`, `pull_request_target` y `workflow_dispatch`.
+- `pull_request` existe unicamente para obtener el required check durante la transicion #1459.
 - El checkout `trusted` usa `${{ github.event.pull_request.base.sha || github.sha }}`.
-- El checkout `candidate` usa `${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}`.
+- El checkout `candidate` usa `${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}`.
+- `pull_request` y `pull_request_target` inspeccionan `refs/pull/<number>/merge`; `workflow_dispatch` inspecciona `github.sha`.
 - Ambos checkouts usan `persist-credentials: false` y `fetch-depth: 0`.
 - Se agrego `pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1`.
 - `actions/setup-node` cachea contra `trusted/pnpm-lock.yaml`.
@@ -69,14 +71,14 @@
 - El validador requerido corre desde `candidate` pero importa y ejecuta codigo confiable desde `trusted`.
 - `pr-governance-validator.mjs` acepta `pull_request_target` para rango, metadata y scope.
 - `pr-governance-validator.mjs` no importa estaticamente `workflow-security-validator.mjs`.
-- `pull_request_target` y `workflow_dispatch` cargan el parser-backed validator mediante `import()`.
+- `pull_request_target` y `workflow_dispatch` cargan el parser-backed validator mediante `import()` y fallan cerrado.
 - El evento legacy `pull_request` conserva diff, secretos, Markdown, metadata, scope y quality impact, pero marca `workflow security` como `N/A` con detalle deterministico:
   - `Bootstrap pull_request compatibility path; parser-backed enforcement becomes mandatory after the pull_request_target workflow is merged.`
 - El workflow security report se registra en el flujo general de fallos; si falla, el proceso termina con exit code `1`.
 - El GitHub Step Summary incluye seccion `## Workflow security`.
 - Los tests cubren:
   - trigger `pull_request_target`;
-  - ausencia de trigger `pull_request` directo;
+  - trigger transitorio `pull_request`;
   - permisos `contents: read`;
   - checkouts `trusted` / `candidate`;
   - base SHA confiable y merge ref candidate;
@@ -118,9 +120,9 @@
 
 ## Resultado
 
-QGA-4B queda completado: el validador parser-backed pasa de control disponible a enforcement obligatorio dentro del check requerido `PR Governance / validate-pr-governance`.
+#1459 queda como fase transitoria segura de activacion dual. No se declara QGA-4B como cerrado en esta PR.
 
-La PR conserva un bootstrap de una sola transicion: mientras `main` todavia ejecute el workflow legacy `pull_request`, `workflow security` queda `N/A` y no intenta cargar `js-yaml`. Despues del merge, el workflow nuevo ya no escucha `pull_request`, por lo que ese camino queda inalcanzable en operacion normal.
+Durante esta fase, `pull_request` activa el required check y mantiene `workflow security` en `N/A` sin cargar `js-yaml`. `pull_request_target` queda instalado en `main` cuando #1459 se fusione. El cierre definitivo de QGA-4B corresponde a una segunda PR que elimine `pull_request` y deje solo `pull_request_target`/`workflow_dispatch`.
 
 El boundary confiable queda definido asi:
 
@@ -134,11 +136,11 @@ El boundary confiable queda definido asi:
 - El evento `pull_request_target` exige disciplina permanente: no agregar secrets, permisos write ni ejecucion candidate en este workflow.
 - `refs/pull/<number>/merge` depende de que GitHub pueda materializar el merge ref de la PR.
 - El freeze temporal sigue activo; cualquier cambio futuro de workflows debe actualizar digest solo tras revision explicita.
-- El camino bootstrap legacy existe solo para que esta PR pueda ser evaluada por el workflow `pull_request` aun no migrado en `main`.
+- El camino `pull_request` debe eliminarse en la segunda PR de cierre para completar QGA-4B.
 
 ## Estado final
 
-- QGA-4B: completado.
+- QGA-4B: fase transitoria #1459; cierre definitivo pendiente en segunda PR.
 - QGA-N2: no iniciado.
 - Backend/frontend/DB/auth/dependencias/branch protection: sin cambios.
 - Stage, commit, push y PR: no ejecutados.

--- a/docs/implementation/workflow-security-required-enforcement.md
+++ b/docs/implementation/workflow-security-required-enforcement.md
@@ -28,6 +28,7 @@
 - Cargar dinamicamente el workflow security validator solo en `pull_request_target` y `workflow_dispatch`.
 - Integrar `evaluateWorkflowSecurity({ rootDir: ROOT })` dentro del check requerido para `pull_request_target` y `workflow_dispatch`.
 - Conservar compatibilidad bootstrap para `pull_request` durante esta PR transitoria.
+- Aislar la concurrencia por `github.event_name` para que `pull_request` y `pull_request_target` no se cancelen entre si.
 - Agregar `workflow security` a `results`, `details`, `failures` y GitHub Step Summary.
 - Validar siempre todos los workflows del candidate aunque la PR no toque `.github/workflows`.
 - Actualizar contratos de seguridad y PR Governance.
@@ -61,6 +62,7 @@
 
 - `PR Governance` ahora usa activacion dual transitoria con `pull_request`, `pull_request_target` y `workflow_dispatch`.
 - `pull_request` existe unicamente para obtener el required check durante la transicion #1459.
+- El concurrency group incluye `${{ github.event_name }}` y conserva `cancel-in-progress: true`, aislando los dos eventos PR de transicion.
 - El checkout `trusted` usa `${{ github.event.pull_request.base.sha || github.sha }}`.
 - El checkout `candidate` usa `${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}`.
 - `pull_request` y `pull_request_target` inspeccionan `refs/pull/<number>/merge`; `workflow_dispatch` inspecciona `github.sha`.

--- a/docs/implementation/workflow-security-required-enforcement.md
+++ b/docs/implementation/workflow-security-required-enforcement.md
@@ -1,0 +1,144 @@
+# Workflow Security Required Enforcement
+
+| Campo | Valor |
+| --- | --- |
+| Fecha | 2026-07-13 |
+| Rama | `ci/workflow-security-required-enforcement` |
+| Base | `main@d004bfb4035886535fe13a7f244ccb2dd60ec306` |
+| Estado | Implementado y validado localmente con fail 0 |
+| Owner | CI owner / Engineering governance |
+
+## Estado base
+
+- Worktree inicial limpio.
+- Rama inicial: `ci/workflow-security-required-enforcement`.
+- HEAD inicial: `d004bfb ci(governance): add parser-backed workflow security validator (#1458)`.
+- `PR Governance / validate-pr-governance` existia con trigger `pull_request`, checkout unico y ejecucion directa de `scripts/governance/pr-governance-validator.mjs`.
+- El parser-backed workflow security validator ya existia como CLI independiente y pasaba sobre los cinco workflows canonicos.
+- El freeze SHA-256 de workflows estaba activo en `workflow-security-policy-contract.test.ts`.
+
+## Scope incluido
+
+- Convertir `.github/workflows/pr-governance.yml` a `pull_request_target` conservando `workflow_dispatch`.
+- Mantener el workflow `PR Governance` y el job/check `validate-pr-governance`.
+- Separar checkout confiable `trusted` desde base SHA/current SHA y checkout `candidate` desde `refs/pull/<number>/merge`/current SHA.
+- Instalar dependencias solo en `trusted` con `pnpm --dir trusted install --frozen-lockfile --ignore-scripts`.
+- Ejecutar desde `candidate` solo `node ../trusted/scripts/governance/pr-governance-validator.mjs`.
+- Tratar `pull_request_target` como evento PR valido en `pr-governance-validator.mjs`.
+- Cargar dinamicamente el workflow security validator solo en `pull_request_target` y `workflow_dispatch`.
+- Integrar `evaluateWorkflowSecurity({ rootDir: ROOT })` dentro del check requerido para la operacion normal post-merge.
+- Conservar compatibilidad bootstrap para el unico camino legacy `pull_request` que evalua esta PR antes del merge.
+- Agregar `workflow security` a `results`, `details`, `failures` y GitHub Step Summary.
+- Validar siempre todos los workflows del candidate aunque la PR no toque `.github/workflows`.
+- Actualizar contratos de seguridad y PR Governance.
+- Mantener el freeze temporal y actualizar solo el digest revisado de `.github/workflows/pr-governance.yml`.
+
+## Scope excluido
+
+- Backend, frontend runtime, DB, Drizzle, migraciones, Supabase, auth, cookies, CSRF, CSP y rate limits.
+- Branch protection, settings, rulesets y required-check configuration.
+- Dependencias, `package.json`, `pnpm-lock.yaml` y lockfiles.
+- Secrets, permisos write y cualquier ejecucion de scripts/binarios procedentes de candidate.
+- Eliminacion del freeze temporal.
+- Inicio de QGA-N2.
+- Stage, commit, push o PR.
+
+## Auditoria previa
+
+- Base local limpia: `git status --short --untracked-files=all` sin salida.
+- Rama local: `ci/workflow-security-required-enforcement`.
+- HEAD local: `d004bfb`.
+- Archivos reales identificados:
+  - `.github/workflows/pr-governance.yml`
+  - `scripts/governance/pr-governance-validator.mjs`
+  - `scripts/governance/workflow-security-validator.mjs`
+  - `test/unit/infrastructure/workflow-security-policy-contract.test.ts`
+  - `test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts`
+- Tests nativos confirmados en `package.json` y `frontend/package.json`.
+- Referencias legacy revisadas: docs de governance, parser-backed validator, QGA y branch protection.
+
+## Cambios
+
+- `PR Governance` ahora usa `pull_request_target` con `permissions: contents: read`.
+- El checkout `trusted` usa `${{ github.event.pull_request.base.sha || github.sha }}`.
+- El checkout `candidate` usa `${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}`.
+- Ambos checkouts usan `persist-credentials: false` y `fetch-depth: 0`.
+- Se agrego `pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1`.
+- `actions/setup-node` cachea contra `trusted/pnpm-lock.yaml`.
+- Dependencias se instalan solo en `trusted` con `--ignore-scripts`.
+- El validador requerido corre desde `candidate` pero importa y ejecuta codigo confiable desde `trusted`.
+- `pr-governance-validator.mjs` acepta `pull_request_target` para rango, metadata y scope.
+- `pr-governance-validator.mjs` no importa estaticamente `workflow-security-validator.mjs`.
+- `pull_request_target` y `workflow_dispatch` cargan el parser-backed validator mediante `import()`.
+- El evento legacy `pull_request` conserva diff, secretos, Markdown, metadata, scope y quality impact, pero marca `workflow security` como `N/A` con detalle deterministico:
+  - `Bootstrap pull_request compatibility path; parser-backed enforcement becomes mandatory after the pull_request_target workflow is merged.`
+- El workflow security report se registra en el flujo general de fallos; si falla, el proceso termina con exit code `1`.
+- El GitHub Step Summary incluye seccion `## Workflow security`.
+- Los tests cubren:
+  - trigger `pull_request_target`;
+  - ausencia de trigger `pull_request` directo;
+  - permisos `contents: read`;
+  - checkouts `trusted` / `candidate`;
+  - base SHA confiable y merge ref candidate;
+  - install solo en `trusted`;
+  - comando `../trusted/scripts/governance`;
+  - no ejecucion propia del candidate;
+  - `pull_request_target` como evento PR valido;
+  - `workflow_dispatch`;
+  - fallos por tag mutable, permisos write, imagen insegura y alias YAML.
+
+## Archivos modificados
+
+- `.github/workflows/pr-governance.yml`
+- `scripts/governance/pr-governance-validator.mjs`
+- `scripts/governance/pr-governance-validator.d.mts`
+- `test/unit/infrastructure/workflow-security-policy-contract.test.ts`
+- `test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts`
+- `docs/implementation/workflow-security-required-enforcement.md`
+- `docs/audit/workflow-security-required-enforcement-audit.md`
+
+## Validaciones
+
+| Comando | Resultado |
+| --- | --- |
+| `node --check scripts/governance/pr-governance-validator.mjs` | Paso |
+| `node --check scripts/governance/workflow-security-validator.mjs` | Paso |
+| `node scripts/governance/workflow-security-validator.mjs` | Paso: 5 workflows, 15 acciones externas, 1 excepcion |
+| `node scripts/governance/workflow-security-validator.mjs --json` | Paso |
+| `pnpm exec tsx --test test/unit/infrastructure/pr-governance-single-scope-contract.test.ts test/unit/infrastructure/quality-gate-impact-contract.test.ts test/unit/infrastructure/workflow-security-policy-contract.test.ts test/unit/infrastructure/workflow-security-validator-contract.test.ts test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts` | Paso: 98 tests, fail 0 |
+| `pnpm typecheck` | Paso |
+| `pnpm typecheck:test` | Paso |
+| `pnpm test` | Paso: 3101 tests, fail 0 |
+| `pnpm build` | Paso |
+| `pnpm security:public-surface` | Paso; hallazgos existentes clasificados como `server-only` |
+| `pnpm --dir frontend lint` | Paso |
+| `pnpm --dir frontend typecheck` | Paso |
+| `pnpm --dir frontend build` | Paso |
+| `git diff --check` | Paso |
+
+## Resultado
+
+QGA-4B queda completado: el validador parser-backed pasa de control disponible a enforcement obligatorio dentro del check requerido `PR Governance / validate-pr-governance`.
+
+La PR conserva un bootstrap de una sola transicion: mientras `main` todavia ejecute el workflow legacy `pull_request`, `workflow security` queda `N/A` y no intenta cargar `js-yaml`. Despues del merge, el workflow nuevo ya no escucha `pull_request`, por lo que ese camino queda inalcanzable en operacion normal.
+
+El boundary confiable queda definido asi:
+
+- codigo ejecutable: `trusted`, proveniente de la base confiable;
+- arbol inspeccionado: `candidate`, proveniente del merge ref de PR;
+- dependencia instalada: solo `trusted`;
+- scripts/binarios candidate: no ejecutados.
+
+## Riesgo residual
+
+- El evento `pull_request_target` exige disciplina permanente: no agregar secrets, permisos write ni ejecucion candidate en este workflow.
+- `refs/pull/<number>/merge` depende de que GitHub pueda materializar el merge ref de la PR.
+- El freeze temporal sigue activo; cualquier cambio futuro de workflows debe actualizar digest solo tras revision explicita.
+- El camino bootstrap legacy existe solo para que esta PR pueda ser evaluada por el workflow `pull_request` aun no migrado en `main`.
+
+## Estado final
+
+- QGA-4B: completado.
+- QGA-N2: no iniciado.
+- Backend/frontend/DB/auth/dependencias/branch protection: sin cambios.
+- Stage, commit, push y PR: no ejecutados.

--- a/scripts/governance/pr-governance-validator.d.mts
+++ b/scripts/governance/pr-governance-validator.d.mts
@@ -21,4 +21,4 @@ export function derivePrimaryCategories(inputCategories: string[]): string[];
 
 export function evaluateScopeContract(input: ScopeContractInput): ScopeContractResult;
 
-export function main(): number;
+export function main(): Promise<number>;

--- a/scripts/governance/pr-governance-validator.mjs
+++ b/scripts/governance/pr-governance-validator.mjs
@@ -13,6 +13,8 @@ const ROOT = resolve(process.cwd());
 const EVENT_NAME = process.env.GITHUB_EVENT_NAME ?? "";
 const EVENT_PATH = process.env.GITHUB_EVENT_PATH ?? "";
 const SUMMARY_PATH = process.env.GITHUB_STEP_SUMMARY ?? "";
+const WORKFLOW_SECURITY_BOOTSTRAP_DETAIL =
+  "Bootstrap pull_request compatibility path; parser-backed enforcement becomes mandatory after the pull_request_target workflow is merged.";
 
 export const CATEGORY_ORDER = [
   "backend",
@@ -93,6 +95,14 @@ function ensureCommit(sha) {
 
 function shortSha(sha) {
   return sha ? sha.slice(0, 12) : "(missing)";
+}
+
+function isPullRequestEvent() {
+  return EVENT_NAME === "pull_request" || EVENT_NAME === "pull_request_target";
+}
+
+function shouldRunWorkflowSecurity() {
+  return EVENT_NAME === "pull_request_target" || EVENT_NAME === "workflow_dispatch";
 }
 
 function normalizePath(value) {
@@ -278,10 +288,10 @@ function readEvent() {
 }
 
 function determineRange(event, fail, detail) {
-  if (EVENT_NAME === "pull_request") {
+  if (isPullRequestEvent()) {
     const baseSha = event.pull_request?.base?.sha?.trim?.() ?? "";
     const headSha = event.pull_request?.head?.sha?.trim?.() ?? "";
-    if (!baseSha || !headSha) fail("scope", "Cannot determine pull_request base/head SHA.");
+    if (!baseSha || !headSha) fail("scope", `Cannot determine ${EVENT_NAME} base/head SHA.`);
     if (baseSha && !ensureCommit(baseSha)) fail("scope", `Base SHA ${shortSha(baseSha)} is unavailable.`);
     if (headSha && !ensureCommit(headSha)) fail("scope", `Head SHA ${shortSha(headSha)} is unavailable.`);
     return [baseSha, headSha];
@@ -300,6 +310,41 @@ function determineRange(event, fail, detail) {
 
   fail("scope", `Unsupported event: ${EVENT_NAME || "(empty)"}.`);
   return ["", ""];
+}
+
+async function validateWorkflowSecurity({ pass, fail, detail, notApplicable }) {
+  if (EVENT_NAME === "pull_request") {
+    notApplicable("workflow security", WORKFLOW_SECURITY_BOOTSTRAP_DETAIL);
+    return `Workflow security N/A.\n${WORKFLOW_SECURITY_BOOTSTRAP_DETAIL}\n`;
+  }
+
+  if (!shouldRunWorkflowSecurity()) {
+    detail("workflow security", `Skipped for unsupported event: ${EVENT_NAME || "(empty)"}.`);
+    return "Workflow security NOT RUN.\n";
+  }
+
+  try {
+    const {
+      evaluateWorkflowSecurity,
+      renderWorkflowSecuritySummary,
+    } = await import("./workflow-security-validator.mjs");
+    const report = evaluateWorkflowSecurity({ rootDir: ROOT });
+    report.details.forEach((message) => detail("workflow security", message));
+    detail("workflow security", `Candidate workflows parsed: ${report.workflows.length}.`);
+
+    if (report.passed) {
+      pass("workflow security", "Parser-backed workflow security validation passed.");
+    } else {
+      report.failures.forEach((failure) => {
+        fail("workflow security", `${failure.workflow} ${failure.path}: ${failure.cause}`);
+      });
+    }
+
+    return renderWorkflowSecuritySummary(report);
+  } catch (error) {
+    fail("workflow security", `Workflow security validation crashed: ${error.message}`);
+    return "Workflow security validation crashed.\n";
+  }
 }
 
 function changedFiles(baseSha, headSha) {
@@ -465,7 +510,7 @@ function validateMarkdown(entries, pass, fail) {
   }
 }
 
-function writeSummary({ baseSha, headSha, entries, categories, results, details, failures, qualityImpact }) {
+function writeSummary({ baseSha, headSha, entries, categories, results, details, failures, qualityImpact, workflowSecuritySummary }) {
   if (!SUMMARY_PATH) return;
   const escape = (value) => String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
   const rows = Object.keys(results).map(
@@ -505,18 +550,23 @@ function writeSummary({ baseSha, headSha, entries, categories, results, details,
       "",
       renderQualityGateImpactSummary(qualityImpact).trimEnd(),
       "",
+      "## Workflow security",
+      "",
+      workflowSecuritySummary.trimEnd(),
+      "",
     ].join("\n"),
     "utf8",
   );
 }
 
-export function main() {
+export async function main() {
   const failures = [];
   const results = {
     "diff integrity": "NOT RUN",
     "sensitive-file policy": "NOT RUN",
     "secret scan": "NOT RUN",
     Markdown: "NOT RUN",
+    "workflow security": "NOT RUN",
     "quality gate impact": "NOT RUN",
     metadata: "NOT RUN",
     scope: "NOT RUN",
@@ -532,11 +582,16 @@ export function main() {
     details[section].push(message);
   };
   const detail = (section, message) => details[section].push(message);
+  const notApplicable = (section, message) => {
+    if (results[section] !== "FAIL") results[section] = "N/A";
+    details[section].push(message);
+  };
 
   const event = readEvent();
   const [baseSha, headSha] = determineRange(event, fail, detail);
   let entries = [];
   let qualityImpact = null;
+  const workflowSecuritySummary = await validateWorkflowSecurity({ pass, fail, detail, notApplicable });
   const categories = new Map(CATEGORY_ORDER.map((category) => [category, []]));
 
   if (baseSha && headSha && ensureCommit(baseSha) && ensureCommit(headSha)) {
@@ -566,7 +621,7 @@ export function main() {
         fail("quality gate impact", `Quality gate impact validation crashed: ${error.message}`);
       }
 
-      if (EVENT_NAME === "pull_request") {
+      if (isPullRequestEvent()) {
         const body = event.pull_request?.body ?? "";
         const missing = REQUIRED_SECTIONS.filter((section) => !sectionPresent(body, section));
         if (!body.trim()) fail("metadata", "PR body is required and cannot be empty.");
@@ -588,7 +643,7 @@ export function main() {
     }
   }
 
-  writeSummary({ baseSha, headSha, entries, categories, results, details, failures, qualityImpact });
+  writeSummary({ baseSha, headSha, entries, categories, results, details, failures, qualityImpact, workflowSecuritySummary });
 
   if (failures.length > 0) {
     failures.forEach(({ section, message }) =>
@@ -605,5 +660,5 @@ export function main() {
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(resolve(process.argv[1])).href) {
-  process.exit(main());
+  process.exit(await main());
 }

--- a/test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts
+++ b/test/unit/infrastructure/pr-governance-quality-impact-integration.test.ts
@@ -2,9 +2,11 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   copyFileSync,
+  existsSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
+  readdirSync,
   rmSync,
   writeFileSync,
 } from "node:fs";
@@ -37,6 +39,32 @@ function runGit(cwd: string, args: string[]): string {
 
 function setupTempRepository(): { root: string; baseSha: string } {
   const root = mkdtempSync(join(tmpdir(), "vetneb-qga-pr-"));
+
+  for (const relativePath of [
+    "package.json",
+    "frontend/package.json",
+    "test/README.md",
+  ]) {
+    copyRepoFile(relativePath, root);
+  }
+
+  for (const workflowName of readdirSync(resolve(repoRoot, ".github/workflows"))) {
+    if (!workflowName.endsWith(".yml") && !workflowName.endsWith(".yaml")) continue;
+    copyRepoFile(`.github/workflows/${workflowName}`, root);
+  }
+
+  runGit(root, ["init"]);
+  runGit(root, ["config", "user.email", "qga@example.com"]);
+  runGit(root, ["config", "user.name", "QGA Test"]);
+  runGit(root, ["checkout", "-b", "main"]);
+  runGit(root, ["add", "."]);
+  runGit(root, ["commit", "-m", "base"]);
+
+  return { root, baseSha: runGit(root, ["rev-parse", "HEAD"]) };
+}
+
+function setupBootstrapCompatibilityRepository(): { root: string; baseSha: string } {
+  const root = mkdtempSync(join(tmpdir(), "vetneb-qga-bootstrap-"));
 
   for (const relativePath of [
     "package.json",
@@ -136,6 +164,31 @@ Revert fixture.
 `;
 }
 
+function workflowsCiBody(): string {
+  return `## Summary
+Workflow governance routing fixture.
+
+## Scope
+- [ ] Backend runtime
+- [ ] Frontend runtime
+- [ ] Tests
+- [x] Workflows/CI
+- [ ] Migrations/Schema
+- [ ] Docs
+- [ ] Dependencies
+- [ ] Scripts/Tooling
+- [ ] Repository configuration
+- [ ] Other
+- [ ] Mixed-Scope exception
+
+## Validation
+- Integration fixture.
+
+## Rollback
+Revert fixture.
+`;
+}
+
 function otherScopeBody(): string {
   return `## Summary
 Quality impact failure fixture.
@@ -164,14 +217,28 @@ Revert fixture.
 `;
 }
 
-function runValidator(root: string, eventPath: string, summaryPath: string) {
+function runValidator(root: string, eventPath: string, summaryPath: string, eventName = "pull_request") {
+  return spawnSync("node", [resolve(repoRoot, "scripts/governance/pr-governance-validator.mjs")], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+    env: {
+      ...process.env,
+      GITHUB_EVENT_NAME: eventName,
+      GITHUB_EVENT_PATH: eventPath,
+      GITHUB_STEP_SUMMARY: summaryPath,
+    },
+  });
+}
+
+function runLocalValidator(root: string, eventPath: string, summaryPath: string, eventName = "pull_request") {
   return spawnSync("node", ["scripts/governance/pr-governance-validator.mjs"], {
     cwd: root,
     encoding: "utf8",
     stdio: ["ignore", "pipe", "pipe"],
     env: {
       ...process.env,
-      GITHUB_EVENT_NAME: "pull_request",
+      GITHUB_EVENT_NAME: eventName,
       GITHUB_EVENT_PATH: eventPath,
       GITHUB_STEP_SUMMARY: summaryPath,
     },
@@ -180,6 +247,15 @@ function runValidator(root: string, eventPath: string, summaryPath: string) {
 
 function withTempRepository(assertion: (repo: { root: string; baseSha: string }) => void): void {
   const repo = setupTempRepository();
+  try {
+    assertion(repo);
+  } finally {
+    rmSync(repo.root, { recursive: true, force: true });
+  }
+}
+
+function withBootstrapCompatibilityRepository(assertion: (repo: { root: string; baseSha: string }) => void): void {
+  const repo = setupBootstrapCompatibilityRepository();
   try {
     assertion(repo);
   } finally {
@@ -198,7 +274,76 @@ test("PR governance invokes quality impact control and passes a valid scripts di
     assert.match(result.stdout, /Quality gate impact PASS\./);
     assert.match(result.stdout, /PR Governance passed\./);
     assert.match(summary, /## Quality gate impact/);
+    assert.match(summary, /## Workflow security/);
+    assert.match(summary, /\| workflow security \| `N\/A` \| Bootstrap pull_request compatibility path/);
+    assert.match(
+      summary,
+      /Workflow security N\/A\.\nBootstrap pull_request compatibility path; parser-backed enforcement becomes mandatory after the pull_request_target workflow is merged\./,
+    );
     assert.match(summary, /governance-scripts/);
+  });
+});
+
+test("PR governance legacy pull_request runs without workflow-security validator or js-yaml", () => {
+  withBootstrapCompatibilityRepository(({ root, baseSha }) => {
+    assert.equal(existsSync(join(root, "scripts/governance/workflow-security-validator.mjs")), false);
+    assert.equal(existsSync(join(root, "node_modules/js-yaml")), false);
+
+    const headSha = commitFile(root, "scripts/governance/example.mjs", "export const fixture = true;\n");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, scriptsToolingBody());
+    const result = runLocalValidator(root, eventPath, summaryPath);
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Quality gate impact PASS\./);
+    assert.match(result.stdout, /PR Governance passed\./);
+    assert.match(summary, /\| workflow security \| `N\/A` \| Bootstrap pull_request compatibility path/);
+    assert.match(summary, /Workflow security N\/A\./);
+  });
+});
+
+test("PR governance validator has no static workflow security import", () => {
+  const source = readFileSync(resolve(repoRoot, "scripts/governance/pr-governance-validator.mjs"), "utf8");
+
+  assert.doesNotMatch(
+    source,
+    /import\s+(?:[\s\S]*?\s+from\s+)?["']\.\/workflow-security-validator\.mjs["']/,
+  );
+  assert.match(source, /import\("\.\/workflow-security-validator\.mjs"\)/);
+});
+
+test("PR governance treats pull_request_target as a pull request governance event", () => {
+  withTempRepository(({ root, baseSha }) => {
+    const headSha = commitFile(root, "scripts/governance/example.mjs", "export const fixture = true;\n");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, scriptsToolingBody());
+    const result = runValidator(root, eventPath, summaryPath, "pull_request_target");
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /PR Governance passed\./);
+    assert.match(summary, /\| event \| `pull_request_target` \|/);
+    assert.match(summary, /Required PR body sections are present/);
+    assert.doesNotMatch(summary, /\| workflow security \| `N\/A` \|/);
+    assert.match(summary, /\| workflow security \| `PASS` \|/);
+    assert.match(summary, /Workflow security validator PASS\./);
+  });
+});
+
+test("PR governance keeps workflow_dispatch diagnostic execution working", () => {
+  withTempRepository(({ root, baseSha }) => {
+    const headSha = commitFile(root, "scripts/governance/example.mjs", "export const fixture = true;\n");
+    const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, scriptsToolingBody());
+    const result = runValidator(root, eventPath, summaryPath, "workflow_dispatch");
+    const summary = readFileSync(summaryPath, "utf8");
+
+    assert.equal(result.status, 0, result.stderr);
+    assert.match(result.stdout, /Quality gate impact PASS\./);
+    assert.match(result.stdout, /PR Governance passed\./);
+    assert.match(summary, /\| event \| `workflow_dispatch` \|/);
+    assert.match(summary, /Skipped for workflow_dispatch/);
+    assert.doesNotMatch(summary, /\| workflow security \| `N\/A` \|/);
+    assert.match(summary, /\| workflow security \| `PASS` \|/);
+    assert.match(summary, /Workflow security validator PASS\./);
   });
 });
 
@@ -215,6 +360,88 @@ test("PR governance invokes quality impact control and passes a valid repository
     assert.match(summary, /repo-config-gitignore/);
   });
 });
+
+const unsafeWorkflowFixtures = [
+  {
+    name: "action with a mutable tag",
+    source: `name: Candidate
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+`,
+    expected: /not a tag, branch or expression/,
+  },
+  {
+    name: "write permissions",
+    source: `name: Candidate
+on:
+  pull_request:
+permissions: write-all
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo ok
+`,
+    expected: /Top-level permissions cannot be write-all/,
+  },
+  {
+    name: "unsafe image",
+    source: `name: Candidate
+on:
+  pull_request:
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    container: node:latest
+    steps:
+      - run: echo ok
+`,
+    expected: /latest tag is not allowed/,
+  },
+  {
+    name: "YAML alias",
+    source: `name: Candidate
+on:
+  pull_request:
+permissions:
+  contents: read
+x-step: &safeStep
+  run: echo ok
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - *safeStep
+`,
+    expected: /YAML aliases are not allowed/,
+  },
+] as const;
+
+for (const fixture of unsafeWorkflowFixtures) {
+  test(`PR governance fails when candidate workflow contains ${fixture.name}`, () => {
+    withTempRepository(({ root, baseSha }) => {
+      const headSha = commitFile(root, ".github/workflows/app-version-force-update.yml", fixture.source);
+      const { eventPath, summaryPath } = writeEvent(root, baseSha, headSha, workflowsCiBody());
+      const result = runValidator(root, eventPath, summaryPath, "pull_request_target");
+      const summary = readFileSync(summaryPath, "utf8");
+
+      assert.notEqual(result.status, 0);
+      assert.match(result.stderr, /PR Governance workflow security/);
+      assert.match(result.stderr, fixture.expected);
+      assert.match(summary, /Workflow security validator FAIL\./);
+      assert.match(summary, fixture.expected);
+    });
+  });
+}
 
 test("PR governance adds quality impact failures to the general failure path", () => {
   withTempRepository(({ root, baseSha }) => {

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -44,6 +44,7 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
     ".github/workflows/pr-governance.yml",
     [
       "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1",
       "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
     ],
   ],
@@ -69,7 +70,7 @@ const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "1c46f2ef4291dd893ea3683a62d200d9d0623b5a896b68567fed497d76abf07f"],
   [".github/workflows/frontend-ci.yml", "7567b16a6c3b518d0a7e710838f6b2b05c9aa7f8402d561b39f8888d4a7b0944"],
-  [".github/workflows/pr-governance.yml", "508d46915bb8f6b303a20eacdf31c47c6aa9e158e0041e7c240c0144b0313cac"],
+  [".github/workflows/pr-governance.yml", "9c848f3ff4c7154e0054bb1959d32f337e8b5c181f61505c67ecde4c9069740e"],
   [".github/workflows/visual-regression-manual.yml", "48d6f8c4c2c04a2cb744b410a6114ac3aa1fbe9b6097ac405d2a56bc43d2bb0a"],
 ]);
 
@@ -170,6 +171,43 @@ test("canonical workflows declare top-level contents read permissions", () => {
   for (const workflowPath of canonicalWorkflowPaths) {
     assertContains(readWorkflow(workflowPath), "permissions:\n  contents: read", workflowPath);
   }
+});
+
+test("PR Governance workflow enforces trusted pull_request_target boundary", () => {
+  const workflowPath = ".github/workflows/pr-governance.yml";
+  const source = readWorkflow(workflowPath);
+
+  assertContains(source, "name: PR Governance", workflowPath);
+  assertContains(source, "  pull_request_target:\n    branches:\n      - main", workflowPath);
+  assertNotContains(source, "  pull_request:\n", workflowPath);
+  assertContains(source, "  workflow_dispatch:", workflowPath);
+  assertContains(source, "permissions:\n  contents: read", workflowPath);
+  assertContains(source, "  validate-pr-governance:\n    name: validate-pr-governance", workflowPath);
+
+  assertContains(source, "      - name: Checkout trusted governance code", workflowPath);
+  assertContains(source, "          ref: ${{ github.event.pull_request.base.sha || github.sha }}", workflowPath);
+  assertContains(source, "          path: trusted", workflowPath);
+  assertContains(source, "          persist-credentials: false", workflowPath);
+  assertContains(source, "          fetch-depth: 0", workflowPath);
+
+  assertContains(source, "      - name: Checkout candidate tree", workflowPath);
+  assertContains(
+    source,
+    "          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}",
+    workflowPath,
+  );
+  assertContains(source, "          path: candidate", workflowPath);
+
+  assertContains(source, "uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1", workflowPath);
+  assertContains(source, "run: pnpm --dir trusted install --frozen-lockfile --ignore-scripts", workflowPath);
+  assertContains(source, "working-directory: candidate", workflowPath);
+  assertContains(source, "run: node ../trusted/scripts/governance/pr-governance-validator.mjs", workflowPath);
+
+  assertNotContains(source, "pnpm --dir candidate", workflowPath);
+  assertNotContains(source, "run: node scripts/governance/pr-governance-validator.mjs", workflowPath);
+  assertNotContains(source, "secrets.", workflowPath);
+  assertNotContains(source, "contents: write", workflowPath);
+  assertNotContains(source, "write-all", workflowPath);
 });
 
 test("canonical workflows pin only allowlisted external action references", () => {

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -70,7 +70,7 @@ const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "1c46f2ef4291dd893ea3683a62d200d9d0623b5a896b68567fed497d76abf07f"],
   [".github/workflows/frontend-ci.yml", "7567b16a6c3b518d0a7e710838f6b2b05c9aa7f8402d561b39f8888d4a7b0944"],
-  [".github/workflows/pr-governance.yml", "40d46f3973744aa4df4d857e009dbc2582f6ed050724e34b93e0da9473a35285"],
+  [".github/workflows/pr-governance.yml", "d8c8c6327af818e2d5dfb61736e143bf8ffc4493ddbf7c74ecf358b9ac04d1aa"],
   [".github/workflows/visual-regression-manual.yml", "48d6f8c4c2c04a2cb744b410a6114ac3aa1fbe9b6097ac405d2a56bc43d2bb0a"],
 ]);
 
@@ -182,6 +182,18 @@ test("PR Governance workflow enforces trusted dual-event transition boundary", (
   assertContains(source, "  pull_request_target:\n    branches:\n      - main", workflowPath);
   assertContains(source, "  workflow_dispatch:", workflowPath);
   assertContains(source, "permissions:\n  contents: read", workflowPath);
+  assertContains(
+    source,
+    "  group: pr-governance-${{ github.workflow }}-${{ github.event_name }}-${{ github.event.pull_request.number || github.ref_name || github.run_id }}",
+    workflowPath,
+  );
+  assertContains(source, "  cancel-in-progress: true", workflowPath);
+  const transitionConcurrencyGroup = (eventName: string) =>
+    `pr-governance-PR Governance-${eventName}-1459`;
+  assert.notEqual(
+    transitionConcurrencyGroup("pull_request"),
+    transitionConcurrencyGroup("pull_request_target"),
+  );
   assertContains(source, "  validate-pr-governance:\n    name: validate-pr-governance", workflowPath);
 
   assertContains(source, "      - name: Checkout trusted governance code", workflowPath);

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -70,7 +70,7 @@ const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "1c46f2ef4291dd893ea3683a62d200d9d0623b5a896b68567fed497d76abf07f"],
   [".github/workflows/frontend-ci.yml", "7567b16a6c3b518d0a7e710838f6b2b05c9aa7f8402d561b39f8888d4a7b0944"],
-  [".github/workflows/pr-governance.yml", "9c848f3ff4c7154e0054bb1959d32f337e8b5c181f61505c67ecde4c9069740e"],
+  [".github/workflows/pr-governance.yml", "40d46f3973744aa4df4d857e009dbc2582f6ed050724e34b93e0da9473a35285"],
   [".github/workflows/visual-regression-manual.yml", "48d6f8c4c2c04a2cb744b410a6114ac3aa1fbe9b6097ac405d2a56bc43d2bb0a"],
 ]);
 
@@ -173,13 +173,13 @@ test("canonical workflows declare top-level contents read permissions", () => {
   }
 });
 
-test("PR Governance workflow enforces trusted pull_request_target boundary", () => {
+test("PR Governance workflow enforces trusted dual-event transition boundary", () => {
   const workflowPath = ".github/workflows/pr-governance.yml";
   const source = readWorkflow(workflowPath);
 
   assertContains(source, "name: PR Governance", workflowPath);
+  assertContains(source, "  pull_request:\n    branches:\n      - main", workflowPath);
   assertContains(source, "  pull_request_target:\n    branches:\n      - main", workflowPath);
-  assertNotContains(source, "  pull_request:\n", workflowPath);
   assertContains(source, "  workflow_dispatch:", workflowPath);
   assertContains(source, "permissions:\n  contents: read", workflowPath);
   assertContains(source, "  validate-pr-governance:\n    name: validate-pr-governance", workflowPath);
@@ -193,7 +193,7 @@ test("PR Governance workflow enforces trusted pull_request_target boundary", () 
   assertContains(source, "      - name: Checkout candidate tree", workflowPath);
   assertContains(
     source,
-    "          ref: ${{ github.event_name == 'pull_request_target' && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}",
+    "          ref: ${{ github.event.pull_request.number && format('refs/pull/{0}/merge', github.event.pull_request.number) || github.sha }}",
     workflowPath,
   );
   assertContains(source, "          path: candidate", workflowPath);


### PR DESCRIPTION
## Summary

Introduces the transitional dual-event phase for required workflow-security enforcement.

PR Governance now listens to both `pull_request` and `pull_request_target` during this migration. The legacy `pull_request` path preserves the required check and reports workflow security as `N/A`; the trusted `pull_request_target` path becomes available after this PR is merged into `main`.

The candidate tree is treated only as static data. Candidate scripts, package scripts and binaries are never executed.

## Scope

- [x] Workflows/CI
- [x] Scripts/Tooling
- [x] Mixed-Scope Exception

Tests and documentation are supporting scope.

## Mixed-Scope Justification

The workflow trigger transition and the trusted PR governance validator must be delivered together because the workflow delegates required enforcement to that validator. Reviewing or rolling back either part independently would leave the required check incomplete or inconsistent during the migration.

## Validation

- Targeted infrastructure contracts: 98 passed, 0 failed
- `pnpm test`: 3101 passed, 0 failed
- `pnpm typecheck`
- `pnpm typecheck:test`
- `pnpm build`
- `pnpm security:public-surface`
- Frontend lint, typecheck and build
- Workflow security CLI normal and JSON modes
- `git diff --check`

The temporary workflow SHA-256 freeze remains active.

This PR is phase 1 of QGA-4B. A second PR will remove the legacy `pull_request` trigger after `pull_request_target` is present on `main`.

QGA-N2 is not included.

## Security / Regression Checklist

- permissions remain exactly `contents: read`
- no secrets are exposed
- dependencies are installed only from trusted base code with `--ignore-scripts`
- candidate code is never executed
- trusted and candidate checkouts remain separated
- the required job name remains `validate-pr-governance`
- existing diff, secret, Markdown, metadata, scope and quality-impact checks remain active

## Rollback

Revert this PR to restore the previous single-event PR Governance workflow. The SHA-256 workflow freeze remains available as fallback protection.