### PR TITLE
ci(governance): add app-published qga-workflow-security check workflow

### DIFF
--- a/.github/workflows/qga-governance.yml
+++ b/.github/workflows/qga-governance.yml
@@ -1,0 +1,93 @@
+name: QGA Governance
+
+on:
+  pull_request_target:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: qga-governance-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  qga-workflow-security:
+    name: qga-workflow-security
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    env:
+      CANDIDATE_HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+
+    steps:
+      - name: Checkout trusted base branch
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+
+      - name: Checkout candidate head as inert data
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          path: qga-candidate-head
+          persist-credentials: false
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
+        with:
+          version: 10.8.1
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Install trusted dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate candidate workflows with the trusted base validator
+        id: validate
+        working-directory: qga-candidate-head
+        run: |
+          set -u
+          if node "$GITHUB_WORKSPACE/scripts/governance/workflow-security-validator.mjs" > "$GITHUB_WORKSPACE/qga-validator-output.txt" 2>&1; then
+            echo "conclusion=success" >> "$GITHUB_OUTPUT"
+          else
+            echo "conclusion=failure" >> "$GITHUB_OUTPUT"
+          fi
+          cat "$GITHUB_WORKSPACE/qga-validator-output.txt"
+
+      - name: Mint installation token for the governance App
+        id: governance-app
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          client-id: ${{ vars.QGA_GOVERNANCE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.QGA_GOVERNANCE_APP_PRIVATE_KEY }}
+
+      - name: Publish qga-workflow-security check run on the candidate head SHA
+        env:
+          GH_TOKEN: ${{ steps.governance-app.outputs.token }}
+          CHECK_CONCLUSION: ${{ steps.validate.outputs.conclusion }}
+        run: |
+          set -u
+          summary="$(head -c 60000 "$GITHUB_WORKSPACE/qga-validator-output.txt")"
+          gh api "repos/${GITHUB_REPOSITORY}/check-runs" \
+            --method POST \
+            -f "name=qga-workflow-security" \
+            -f "head_sha=${CANDIDATE_HEAD_SHA}" \
+            -f "status=completed" \
+            -f "conclusion=${CHECK_CONCLUSION}" \
+            -f "output[title]=Trusted base validator over candidate workflows" \
+            -f "output[summary]=${summary}" \
+            --jq ".id"
+
+      - name: Enforce validator conclusion on this job
+        env:
+          CHECK_CONCLUSION: ${{ steps.validate.outputs.conclusion }}
+        run: |
+          set -u
+          test "$CHECK_CONCLUSION" = "success"

--- a/docs/audit/qga-governance-app-check-workflow-audit.md
+++ b/docs/audit/qga-governance-app-check-workflow-audit.md
@@ -1,0 +1,64 @@
+# Auditoria: QGA Governance App-Published Check Workflow (QGA-4B)
+
+| Campo | Valor |
+| --- | --- |
+| Fecha | 2026-07-13 |
+| Rama | `ci/workflow-security-required-enforcement-finalize` |
+| Base | `main@d004bfb4035886535fe13a7f244ccb2dd60ec306` |
+| Alcance | Workflow confiable + politica QGA-4.2 + tests contractuales |
+
+## Verificaciones de identidad previas (fase QGA-4B identidad)
+
+| Verificacion | Metodo | Resultado |
+| --- | --- | --- |
+| App autenticada | JWT RS256 (`iss` = Client ID) contra `GET /app` | Paso; App ID `4291335`, slug `labvetneb-portal-qga-governance` |
+| Permisos exactos | `GET /app` permissions | `checks: write`, `metadata: read`, sin extras |
+| Instalacion | `GET /repos/LABVETNEB/PORTAL-VETNEB/installation` | Installation ID `146398242`, `selected`, no suspendida |
+| Alcance del token | `GET /installation/repositories` con token temporal | Exactamente 1 repositorio: `LABVETNEB/PORTAL-VETNEB` |
+| Revocacion | `DELETE /installation/token` | 204, token revocado |
+| Secret | `gh secret list` | `QGA_GOVERNANCE_APP_PRIVATE_KEY` presente |
+| Variables | `gh variable list` | `QGA_GOVERNANCE_APP_ID`, `QGA_GOVERNANCE_APP_INSTALLATION_ID`, `QGA_GOVERNANCE_APP_CLIENT_ID` presentes |
+
+## Fuentes oficiales verificadas
+
+| Tema | Fuente | Conclusion aplicada |
+| --- | --- | --- |
+| `pull_request_target` | GitHub Docs, events that trigger workflows | Definicion del workflow tomada de la rama base; contexto del repositorio base; advertencia de no ejecutar codigo del PR respetada |
+| Autenticacion App en Actions | GitHub Docs, making authenticated API requests with a GitHub App in a GitHub Actions workflow | `actions/create-github-app-token` con `client-id` en variable y `private-key` en secret |
+| Inputs de la action | `action.yml` de `actions/create-github-app-token@v3.2.0` | `client-id` oficial, `app-id` deprecado, revocacion automatica del token al finalizar el job |
+| Check runs | GitHub Docs, REST checks/runs | `POST /repos/{owner}/{repo}/check-runs` exclusivo de GitHub Apps; `name` y `head_sha` obligatorios |
+| Pin de la action | API oficial del repo `actions/create-github-app-token` | `v3.2.0 = bcd2ba49218906704ab6c1aa796996da409d3eb1` |
+
+## Controles de seguridad del workflow
+
+| Control | Estado |
+| --- | --- |
+| Permisos top-level exactos `contents: read` | Cumplido |
+| Sin permisos a nivel job | Cumplido |
+| Todas las actions allowlisted y pinneadas por SHA de 40 caracteres | Cumplido |
+| Checkout del candidato con `persist-credentials: false` | Cumplido |
+| Codigo candidato nunca ejecutado (solo parseado por el validador confiable) | Cumplido |
+| Secrets solo en el paso de minting y publicacion, nunca expuestos al candidato | Cumplido |
+| Check emitido por la App dedicada sobre `pull_request.head.sha` | Cumplido |
+| Fail-closed: sin token o sin publicacion no hay check | Cumplido |
+
+## Validaciones ejecutadas
+
+| Comando | Resultado |
+| --- | --- |
+| `node --check scripts/governance/workflow-security-policy.mjs` | Paso |
+| `node scripts/governance/workflow-security-validator.mjs` | Paso: 6 workflows, 18 acciones externas pinneadas, 1 excepcion |
+| `pnpm exec tsx --test test/unit/infrastructure/workflow-security-policy-contract.test.ts test/unit/infrastructure/workflow-security-validator-contract.test.ts` | Paso |
+| `pnpm typecheck` | Paso |
+| `pnpm typecheck:test` | Paso |
+| `pnpm test` | Paso |
+| `git diff --check` | Paso |
+
+## Riesgo residual
+
+- El required check y los canarios quedan explicitamente fuera de este cambio.
+- El digest congelado del nuevo workflow debera actualizarse solo tras revision explicita de workflow-security, igual que los cinco preexistentes.
+
+## Estado final
+
+Working tree limpio tras commit; rama `ci/workflow-security-required-enforcement-finalize`; sin cambios en branch protection, backend, frontend, DB, dependencias npm ni lockfiles.

--- a/docs/implementation/qga-governance-app-check-workflow.md
+++ b/docs/implementation/qga-governance-app-check-workflow.md
@@ -1,0 +1,91 @@
+# QGA Governance App-Published Check Workflow (QGA-4B)
+
+| Campo | Valor |
+| --- | --- |
+| Fecha | 2026-07-13 |
+| Rama | `ci/workflow-security-required-enforcement-finalize` |
+| Base | `main@d004bfb4035886535fe13a7f244ccb2dd60ec306` |
+| Estado | Implementado y validado localmente |
+| Owner | CI owner / Engineering governance |
+
+## Estado base
+
+- Worktree inicial limpio.
+- HEAD inicial: `d004bfb ci(governance): add parser-backed workflow security validator (#1458)`.
+- GitHub App dedicada `LABVETNEB-PORTAL-QGA-Governance` verificada en fase previa de identidad:
+  - App ID `4291335`, Installation ID `146398242`.
+  - Permisos exactos: `checks: write` y `metadata: read`, sin extras.
+  - Instalada solo sobre `LABVETNEB/PORTAL-VETNEB` (`repository_selection = selected`, no suspendida).
+  - Sin OAuth, sin Device Flow, sin webhook, sin Client Secret.
+- Secret `QGA_GOVERNANCE_APP_PRIVATE_KEY` y variables `QGA_GOVERNANCE_APP_ID`, `QGA_GOVERNANCE_APP_INSTALLATION_ID`, `QGA_GOVERNANCE_APP_CLIENT_ID` presentes en el repositorio.
+
+## Scope incluido
+
+- Nuevo workflow confiable `.github/workflows/qga-governance.yml` sobre `pull_request_target` hacia `main`.
+- Publicacion del check run `qga-workflow-security` sobre `pull_request.head.sha` mediante la GitHub App dedicada, no mediante `github-actions`.
+- Allowlist de `actions/create-github-app-token` pinneada por SHA en `workflow-security-policy.mjs`.
+- Bump de `POLICY_VERSION` a `QGA-4.2`.
+- Actualizacion coordinada de los tests contractuales de politica y validador (sexto workflow canonico, digest congelado, referencias pinneadas, allowlist).
+
+## Scope excluido
+
+- Branch protection y required checks (fase posterior con canarios).
+- QGA-N2.
+- Backend, frontend, DB, migraciones, auth, dependencias de runtime y lockfiles (el lockfile no cambia; `actions/create-github-app-token` es una action de CI, no una dependencia npm).
+- Worktree protegido `C:\PORTAL-VETNEB-e2e-extended-fixes` y rama `test/e2e-extended-contract-fixes`.
+- Merge del PR.
+
+## Auditoria previa
+
+- Se confirmo que el validador parser-backed acepta `rootDir` implicito via `process.cwd()`, lo que permite ejecutar el validador confiable de `main` sobre los archivos del head candidato sin ejecutar codigo del candidato.
+- Se confirmo en documentacion oficial de GitHub que:
+  - `pull_request_target` ejecuta la definicion del workflow de la rama base y corre en el contexto del repositorio base con acceso a secrets; la guia oficial advierte contra construir o ejecutar codigo del PR, cosa que este workflow no hace.
+  - `POST /repos/{owner}/{repo}/check-runs` es exclusivo de GitHub Apps y requiere `checks: write`; `name` y `head_sha` son obligatorios y `output.title`/`output.summary` acompañan la conclusion.
+  - `actions/create-github-app-token` es la via oficialmente documentada para autenticar como App en Actions; en v3 el input oficial es `client-id` (con `app-id` deprecado) y el token se revoca automaticamente al finalizar el job.
+- Se resolvio `actions/create-github-app-token@v3.2.0` al commit `bcd2ba49218906704ab6c1aa796996da409d3eb1` consultando la API oficial del repositorio de la action.
+
+## Cambios
+
+- `.github/workflows/qga-governance.yml`:
+  - Trigger `pull_request_target` restringido a base `main`; permisos top-level exactos `contents: read`; concurrencia por PR; timeout 10 minutos.
+  - Checkout del base confiable y checkout del head candidato como datos inertes en `qga-candidate-head` con `persist-credentials: false`; ningun paso ejecuta codigo del candidato.
+  - El validador `scripts/governance/workflow-security-validator.mjs` de `main` se ejecuta con working directory en el checkout candidato, de modo que analiza los workflows candidatos con la politica confiable.
+  - `actions/create-github-app-token` emite el installation token de la App con `client-id` desde `vars.QGA_GOVERNANCE_APP_CLIENT_ID` y `private-key` desde `secrets.QGA_GOVERNANCE_APP_PRIVATE_KEY`.
+  - `gh api` publica el check run `qga-workflow-security` sobre `CANDIDATE_HEAD_SHA` con conclusion `success` o `failure` y el reporte del validador como summary.
+  - Un paso final propaga la conclusion al job para mantener visibilidad fail-closed tambien en el job de Actions.
+- `scripts/governance/workflow-security-policy.mjs`: nueva entrada allowlisted `actions/create-github-app-token` y `POLICY_VERSION = "QGA-4.2"`.
+- `test/unit/infrastructure/workflow-security-policy-contract.test.ts`: sexto workflow canonico, digest SHA-256 congelado del nuevo workflow, referencias pinneadas esperadas, referencia mutable prohibida `@v3`, allowlist y version de politica actualizadas.
+- `test/unit/infrastructure/workflow-security-validator-contract.test.ts`: lista de seis workflows reales, version de politica y allowlist de repositorios de actions actualizadas.
+
+## Propiedad de no-falsificabilidad
+
+- La definicion del workflow y el validador provienen siempre de `main` (`pull_request_target`); el codigo candidato no puede modificarlos para la corrida que lo evalua.
+- El check es emitido por la App dedicada via API de Checks, que es exclusiva de GitHub Apps; un workflow candidato no puede suplantar la identidad de la App porque no tiene acceso a su private key mas alla del uso interno del workflow confiable.
+- Si el minting del token o la publicacion fallan, no se publica check: la ausencia de check es bloqueante una vez que el check sea required (fail-closed por ausencia).
+
+## Archivos modificados
+
+- `.github/workflows/qga-governance.yml` (nuevo)
+- `scripts/governance/workflow-security-policy.mjs`
+- `test/unit/infrastructure/workflow-security-policy-contract.test.ts`
+- `test/unit/infrastructure/workflow-security-validator-contract.test.ts`
+- `docs/implementation/qga-governance-app-check-workflow.md` (nuevo)
+- `docs/audit/qga-governance-app-check-workflow-audit.md` (nuevo)
+
+## Validaciones
+
+Ver tabla de validaciones en el documento de auditoria asociado.
+
+## Resultado
+
+El workflow QGA Governance queda implementado y pasa la politica de seguridad de workflows con seis workflows canonicos, dieciocho referencias externas pinneadas y la excepcion exacta `postgres:16` preexistente. El check `qga-workflow-security` se activara para PRs cuando el workflow llegue a `main`.
+
+## Riesgo residual
+
+- El check no sera emitido para PRs hasta que este workflow exista en `main`; esta es la semantica esperada de `pull_request_target`.
+- La conversion del check en required y la fase de canarios quedan pendientes por decision explicita de governance.
+- `actions/create-github-app-token` queda cubierta por Dependabot (`package-ecosystem: github-actions`); las actualizaciones futuras deberan repinnear SHA y digest congelado.
+
+## Estado final
+
+No se modifico branch protection, required checks, backend, frontend, DB, dependencias npm ni lockfiles. El worktree protegido y la rama e2e permanecen intactos.

--- a/scripts/governance/workflow-security-policy.mjs
+++ b/scripts/governance/workflow-security-policy.mjs
@@ -6,7 +6,7 @@ const deepFreeze = (value) => {
   return value;
 };
 
-export const POLICY_VERSION = "QGA-4.1";
+export const POLICY_VERSION = "QGA-4.2";
 
 export const WORKFLOW_PATH_PREFIX = ".github/workflows/";
 export const WORKFLOW_EXTENSIONS = deepFreeze([".yml", ".yaml"]);
@@ -16,6 +16,11 @@ export const APPROVED_EXTERNAL_ACTIONS = deepFreeze([
     repository: "actions/checkout",
     owner: "CI owner",
     reason: "Repository checkout is required by the tracked CI workflows.",
+  },
+  {
+    repository: "actions/create-github-app-token",
+    owner: "CI owner",
+    reason: "Minting the governance App installation token is required by the QGA governance check workflow.",
   },
   {
     repository: "actions/setup-node",

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -18,6 +18,7 @@ const canonicalWorkflowPaths = [
   ".github/workflows/backend-ci.yml",
   ".github/workflows/frontend-ci.yml",
   ".github/workflows/pr-governance.yml",
+  ".github/workflows/qga-governance.yml",
   ".github/workflows/visual-regression-manual.yml",
 ] as const;
 
@@ -48,6 +49,16 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
     ],
   ],
   [
+    ".github/workflows/qga-governance.yml",
+    [
+      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1",
+      "actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e",
+      "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
+    ],
+  ],
+  [
     ".github/workflows/visual-regression-manual.yml",
     [
       "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
@@ -60,6 +71,7 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
 
 const mutableActionReferences = [
   "uses: actions/checkout@v7",
+  "uses: actions/create-github-app-token@v3",
   "uses: actions/setup-node@v6",
   "uses: actions/upload-artifact@v7",
   "uses: pnpm/action-setup@v4",
@@ -70,6 +82,7 @@ const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/backend-ci.yml", "1c46f2ef4291dd893ea3683a62d200d9d0623b5a896b68567fed497d76abf07f"],
   [".github/workflows/frontend-ci.yml", "7567b16a6c3b518d0a7e710838f6b2b05c9aa7f8402d561b39f8888d4a7b0944"],
   [".github/workflows/pr-governance.yml", "508d46915bb8f6b303a20eacdf31c47c6aa9e158e0041e7c240c0144b0313cac"],
+  [".github/workflows/qga-governance.yml", "0642833caad71b300196ac6083dab498da3ec5ff2447a528a2a1f9a43fd13c3c"],
   [".github/workflows/visual-regression-manual.yml", "48d6f8c4c2c04a2cb744b410a6114ac3aa1fbe9b6097ac405d2a56bc43d2bb0a"],
 ]);
 
@@ -96,10 +109,16 @@ function repositoryFromActionReference(reference: string): string {
 }
 
 test("workflow security policy exposes immutable QGA-4 declarative contract", () => {
-  assert.equal(POLICY_VERSION, "QGA-4.1");
+  assert.equal(POLICY_VERSION, "QGA-4.2");
   assert.deepEqual(
     APPROVED_EXTERNAL_ACTIONS.map((action) => action.repository).sort(),
-    ["actions/checkout", "actions/setup-node", "actions/upload-artifact", "pnpm/action-setup"],
+    [
+      "actions/checkout",
+      "actions/create-github-app-token",
+      "actions/setup-node",
+      "actions/upload-artifact",
+      "pnpm/action-setup",
+    ],
   );
   assert.deepEqual(PERMISSION_POLICY.topLevel, { contents: "read" });
   assert.deepEqual(PERMISSION_POLICY.jobLevelExceptions, []);
@@ -117,7 +136,7 @@ test("workflow security policy exposes immutable QGA-4 declarative contract", ()
   ]);
 });
 
-test("repository tracks exactly the five canonical workflow files", () => {
+test("repository tracks exactly the six canonical workflow files", () => {
   const actualWorkflowPaths = readdirSync(resolve(process.cwd(), ".github/workflows"))
     .filter((name) => name.endsWith(".yml") || name.endsWith(".yaml"))
     .map((name) => `.github/workflows/${name}`)

--- a/test/unit/infrastructure/workflow-security-validator-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-validator-contract.test.ts
@@ -83,7 +83,7 @@ function assertFailsWith(
   }
 }
 
-test("parser-backed validator accepts the five real workflows", () => {
+test("parser-backed validator accepts the six real workflows", () => {
   const report = evaluateWorkflowSecurity();
 
   assertPasses(report);
@@ -94,10 +94,11 @@ test("parser-backed validator accepts the five real workflows", () => {
       ".github/workflows/backend-ci.yml",
       ".github/workflows/frontend-ci.yml",
       ".github/workflows/pr-governance.yml",
+      ".github/workflows/qga-governance.yml",
       ".github/workflows/visual-regression-manual.yml",
     ],
   );
-  assert.equal(report.policyVersion, "QGA-4.1");
+  assert.equal(report.policyVersion, "QGA-4.2");
   assert.equal(report.exceptionsUsed.length, 1);
   assert.equal(report.exceptionsUsed[0].path, "jobs.validate-backend.services.postgres.image");
 });
@@ -110,9 +111,13 @@ test("current pinned actions are approved and use lowercase SHA refs", () => {
   for (const action of report.externalActions) {
     assert.match(action.ref, /^[0-9a-f]{40}$/);
     assert.ok(
-      ["actions/checkout", "actions/setup-node", "actions/upload-artifact", "pnpm/action-setup"].includes(
-        action.repository,
-      ),
+      [
+        "actions/checkout",
+        "actions/create-github-app-token",
+        "actions/setup-node",
+        "actions/upload-artifact",
+        "pnpm/action-setup",
+      ].includes(action.repository),
       action.repository,
     );
   }
@@ -654,7 +659,7 @@ test("human summary stays deterministic and includes exact failure causes", (t) 
   const summary = renderWorkflowSecuritySummary(report);
 
   assert.match(summary, /^Workflow security validator FAIL\./);
-  assert.match(summary, /Policy version: QGA-4\.1\./);
+  assert.match(summary, /Policy version: QGA-4\.2\./);
   assert.match(summary, /jobs\.validate\.steps\[0\]\.uses/);
   assert.match(summary, /not a tag, branch or expression/);
 });


### PR DESCRIPTION
## Summary
- Change type: CI governance (QGA-4B).
- Context / issue: QGA-4B requires a non-forgeable check published by the dedicated GitHub App `LABVETNEB-PORTAL-QGA-Governance` on `pull_request.head.sha`, so candidate code cannot control the identity that publishes the verdict.
- What changed: new trusted `pull_request_target` workflow `.github/workflows/qga-governance.yml` that runs the base-branch parser-backed workflow security validator over the candidate head (checked out as inert data, never executed), mints an installation token via `actions/create-github-app-token` (SHA-pinned, allowlisted) and publishes the `qga-workflow-security` check run through the App. `workflow-security-policy.mjs` bumps to `QGA-4.2` with the new allowlisted action, and both workflow-security contract tests track the sixth canonical workflow with its frozen digest.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [x] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test` (3092 tests, fail 0)
- [ ] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected)
- [ ] `pnpm --dir frontend typecheck` (if frontend affected)
- [ ] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [x] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Additional validation: `node scripts/governance/workflow-security-validator.mjs` passes with 6 workflows and 18 SHA-pinned external action references.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Rollback
- Trigger: the QGA Governance workflow fails to mint the App token, publishes wrong conclusions, or interferes with existing PR flows.
- Steps: revert this commit on `main` (removes the workflow and restores policy `QGA-4.1` state); the check is not required by branch protection, so no merge flow is blocked meanwhile.
- Data impact: none; the workflow only reads repository content and publishes check runs.
