### PR TITLE
test(governance): verify qga workflow security negative canary

### DIFF
--- a/.github/workflows/qga-negative-canary.yml
+++ b/.github/workflows/qga-negative-canary.yml
@@ -1,0 +1,14 @@
+name: QGA Negative Canary
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  negative-canary:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deliberately mutable action reference
+        uses: actions/checkout@v7


### PR DESCRIPTION
## Summary
- Change type: temporary negative governance canary.
- Context / issue: verify that the trusted App-published `qga-workflow-security` check rejects a candidate workflow containing a mutable action reference.
- What changed: added one temporary workflow that intentionally uses `actions/checkout@v7` instead of a full immutable SHA. It must never merge.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [x] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

## Validation
- [ ] `pnpm typecheck` (not applicable: temporary negative workflow canary)
- [ ] `pnpm typecheck:test` (not applicable: temporary negative workflow canary)
- [ ] `pnpm test` (not applicable: temporary negative workflow canary)
- [ ] `pnpm build` (not applicable)
- [ ] `pnpm --dir frontend lint` (not applicable)
- [ ] `pnpm --dir frontend typecheck` (not applicable)
- [ ] `pnpm --dir frontend build` (not applicable)
- [ ] `pnpm audit --prod` (not applicable)
- [ ] `pnpm audit` (not applicable)
- [ ] Relevant CI checks passed (negative canary intentionally expects `qga-workflow-security` failure)

Additional validation: `qga-workflow-security` must conclude `failure` on head SHA `ba14edbaf19ebb56f25095536fbc9d3c41dfa4fc`, emitted by App ID `4291335` / slug `labvetneb-portal-qga-governance`.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed: not applicable.
- [x] Dependency and supply-chain impact reviewed: intentional mutable action reference exists only as negative canary evidence.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact explicitly not applicable.

## Rollback
- Trigger: negative check and merge-block evidence verified.
- Steps: close this PR without merge and delete branch `canary/qga-workflow-security-negative`.
- Data impact: none.
