### PR TITLE
fix(dashboard): improve clinic mobile content access

### DIFF
--- a/frontend/e2e/dashboard-clinic-mobile-content-reachability.spec.ts
+++ b/frontend/e2e/dashboard-clinic-mobile-content-reachability.spec.ts
@@ -1,0 +1,269 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// VIS-MOBILE-001 — Clinic dashboard mobile low-height content access.
+//
+// Root cause: `.dashboard-module-body` (the ModuleSurface content region) was
+// `overflow: hidden` on clinic mobile, so Operaciones and Perfil — the two
+// modules without pagination/tabs bounding every card to the viewport — could
+// clip real content below the fold with no way to reach it (measured deficit
+// at 360×640: dashboard-module-body scrollHeight ≈559 vs clientHeight ≈271).
+//
+// Fix: `.dashboard-module-body` becomes the single, reachable scroll owner for
+// ONLY these two modules on clinic mobile (`frontend/src/styles/dashboard/mobile-clinic.css`),
+// scoped by the existing `[data-clinic-mobile-module]` hook. Every other clinic
+// module (informes/logistica/tokens) and the whole admin dashboard keep their
+// prior no-scroll-owner behavior untouched.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TOLERANCE = 2;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+type ScrollOwnerMetrics = {
+  found: boolean;
+  overflowY: string | null;
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+  reachedEnd: boolean;
+};
+
+async function readScrollOwner(
+  page: Page,
+  selector: string,
+): Promise<ScrollOwnerMetrics> {
+  return page.evaluate((sel) => {
+    const el = document.querySelector<HTMLElement>(sel);
+    if (!el) {
+      return {
+        found: false,
+        overflowY: null,
+        clientHeight: 0,
+        scrollHeight: 0,
+        scrollTop: 0,
+        reachedEnd: false,
+      };
+    }
+    el.scrollTop = el.scrollHeight;
+    const reachedEnd =
+      Math.abs(el.scrollHeight - el.clientHeight - el.scrollTop) <= 2;
+    return {
+      found: true,
+      overflowY: getComputedStyle(el).overflowY,
+      clientHeight: el.clientHeight,
+      scrollHeight: el.scrollHeight,
+      scrollTop: el.scrollTop,
+      reachedEnd,
+    };
+  }, selector);
+}
+
+async function readHorizontalOverflow(page: Page) {
+  return page.evaluate(() => ({
+    scrollWidth: document.documentElement.scrollWidth,
+    clientWidth: document.documentElement.clientWidth,
+  }));
+}
+
+test.describe("VIS-MOBILE-001 — operaciones content reachability", () => {
+  test("360x640: last card is reachable, no horizontal overflow, no double scroll", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 640 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const owner = await readScrollOwner(
+      page,
+      '[data-clinic-mobile-module="operaciones"] .dashboard-module-body',
+    );
+    expect(owner.found, "scroll owner present").toBe(true);
+    expect(owner.overflowY, "single controlled scroll owner").toBe("auto");
+    expect(
+      owner.reachedEnd,
+      `reached end (scrollHeight=${owner.scrollHeight}, clientHeight=${owner.clientHeight}, scrollTop=${owner.scrollTop})`,
+    ).toBe(true);
+
+    const hOverflow = await readHorizontalOverflow(page);
+    expect(hOverflow.scrollWidth, "no horizontal overflow").toBeLessThanOrEqual(
+      hOverflow.clientWidth + TOLERANCE,
+    );
+
+    // No other element inside the module workspace introduces a second
+    // independent scroll container.
+    const secondaryScrollCount = await page.evaluate(() => {
+      const workspace = document.querySelector(
+        '[data-dashboard-module-workspace="operaciones"]',
+      );
+      if (!workspace) return -1;
+      return Array.from(workspace.querySelectorAll<HTMLElement>("*")).filter(
+        (el) =>
+          !el.classList.contains("dashboard-module-body") &&
+          ["auto", "scroll"].includes(getComputedStyle(el).overflowY),
+      ).length;
+    });
+    expect(secondaryScrollCount, "no second scroll owner").toBe(0);
+  });
+
+  test("390x844: stable, no regression (matches strict no-internal-scroll baseline when content fits taller viewport)", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const main = page.locator("main.dashboard-main");
+    const mainOverflowY = await main.evaluate(
+      (el) => getComputedStyle(el).overflowY,
+    );
+    expect(mainOverflowY, "main never becomes a scroll container").not.toBe(
+      "auto",
+    );
+    expect(mainOverflowY).not.toBe("scroll");
+
+    const hOverflow = await readHorizontalOverflow(page);
+    expect(hOverflow.scrollWidth).toBeLessThanOrEqual(
+      hOverflow.clientWidth + TOLERANCE,
+    );
+  });
+});
+
+test.describe("VIS-MOBILE-001 — perfil content reachability", () => {
+  test("375x667: last section is reachable, actions stay accessible, no double scroll", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=perfil");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="perfil"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const owner = await readScrollOwner(
+      page,
+      '[data-clinic-mobile-module="perfil"] .dashboard-module-body',
+    );
+    expect(owner.found, "scroll owner present").toBe(true);
+    expect(owner.overflowY, "single controlled scroll owner").toBe("auto");
+    expect(
+      owner.reachedEnd,
+      `reached end (scrollHeight=${owner.scrollHeight}, clientHeight=${owner.clientHeight}, scrollTop=${owner.scrollTop})`,
+    ).toBe(true);
+
+    // The profile tab-content wrapper no longer clips internally on its own.
+    const fieldsOverflowY = await page.evaluate(() => {
+      const fields = document.querySelector('[data-clinic-profile-fields="true"]');
+      return fields ? getComputedStyle(fields).overflowY : null;
+    });
+    expect(fieldsOverflowY, "profile fields do not self-clip").not.toBe("hidden");
+
+    // "Guardar perfil público" stays reachable/clickable after the fix.
+    const saveButton = page.getByRole("button", {
+      name: "Guardar perfil público",
+      exact: true,
+    });
+    await expect(saveButton).toBeVisible();
+
+    const hOverflow = await readHorizontalOverflow(page);
+    expect(hOverflow.scrollWidth).toBeLessThanOrEqual(
+      hOverflow.clientWidth + TOLERANCE,
+    );
+
+    const secondaryScrollCount = await page.evaluate(() => {
+      const editor = document.querySelector('[data-clinic-profile-editor="true"]');
+      if (!editor) return -1;
+      return Array.from(editor.querySelectorAll<HTMLElement>("*")).filter(
+        (el) =>
+          !el.classList.contains("dashboard-module-body") &&
+          ["auto", "scroll"].includes(getComputedStyle(el).overflowY),
+      ).length;
+    });
+    expect(secondaryScrollCount, "no second scroll owner").toBe(0);
+  });
+
+  test("390x844: stable, no regression", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=perfil");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="perfil"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const main = page.locator("main.dashboard-main");
+    const mainOverflowY = await main.evaluate(
+      (el) => getComputedStyle(el).overflowY,
+    );
+    expect(mainOverflowY).not.toBe("auto");
+    expect(mainOverflowY).not.toBe("scroll");
+
+    const hOverflow = await readHorizontalOverflow(page);
+    expect(hOverflow.scrollWidth).toBeLessThanOrEqual(
+      hOverflow.clientWidth + TOLERANCE,
+    );
+  });
+});
+
+test.describe("VIS-MOBILE-001 — desktop composition preserved", () => {
+  test("1366x768: main/body/html do not acquire accidental scroll", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1366, height: 768 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const metrics = await page.evaluate(() => {
+      const html = document.documentElement;
+      const body = document.body;
+      const main = document.querySelector("main.dashboard-main");
+      const moduleBody = document.querySelector(
+        '[data-clinic-mobile-module="operaciones"] .dashboard-module-body',
+      );
+      return {
+        htmlScrollHeight: html.scrollHeight,
+        htmlClientHeight: html.clientHeight,
+        bodyScrollHeight: body.scrollHeight,
+        bodyClientHeight: body.clientHeight,
+        mainOverflowY: main ? getComputedStyle(main).overflowY : null,
+        moduleBodyOverflowY: moduleBody
+          ? getComputedStyle(moduleBody).overflowY
+          : null,
+      };
+    });
+
+    expect(metrics.htmlScrollHeight).toBeLessThanOrEqual(
+      metrics.htmlClientHeight + TOLERANCE,
+    );
+    expect(metrics.bodyScrollHeight).toBeLessThanOrEqual(
+      metrics.bodyClientHeight + TOLERANCE,
+    );
+    expect(metrics.mainOverflowY).not.toBe("auto");
+    // The VIS-MOBILE-001 scroll-owner CSS is mobile-only (max-width: 767px);
+    // desktop keeps the original bounded (overflow: hidden) module body.
+    expect(metrics.moduleBodyOverflowY, "desktop module body unaffected").toBe(
+      "hidden",
+    );
+
+    const hOverflow = await readHorizontalOverflow(page);
+    expect(hOverflow.scrollWidth).toBeLessThanOrEqual(
+      hOverflow.clientWidth + TOLERANCE,
+    );
+  });
+});

--- a/frontend/e2e/dashboard-clinic-mobile-operational-density.spec.ts
+++ b/frontend/e2e/dashboard-clinic-mobile-operational-density.spec.ts
@@ -1,0 +1,296 @@
+import { expect, test, type Page } from "@playwright/test";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FASE 2B — Clinic dashboard mobile compaction / operational density.
+//
+// Every clinic mobile module rendered a second, redundant title+subtitle pair
+// inside its own ModuleSurface toolbar on top of the module's own header
+// (DashboardModuleWorkspace already renders the module title once). This spec
+// pins: the duplicated copy stays removed, secondary CTAs share a compact
+// (h-8/32px) scale, the operational chrome cannot be selected by accident
+// while form fields remain editable, and pinch-zoom stays available on the
+// clinic mobile shell (low-vision accessibility) while interactive controls
+// use `touch-action: manipulation` to suppress accidental double-tap zoom.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const VIEWPORTS = [
+  { name: "360x640", width: 360, height: 640 },
+  { name: "375x667", width: 375, height: 667 },
+  { name: "390x844", width: 390, height: 844 },
+] as const;
+
+const COMPACT_BUTTON_MAX_HEIGHT = 34;
+
+async function setPopulatedClinicSession(page: Page) {
+  await page.context().addCookies([
+    {
+      name: "app_session_id",
+      value: "e2e_populated_clinic_session",
+      url: "http://127.0.0.1:3000",
+    },
+  ]);
+}
+
+for (const viewport of VIEWPORTS) {
+  test.describe(`clinic mobile operational density — ${viewport.name}`, () => {
+    test("informes: redundant header removed, filter/link CTAs compact", async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await setPopulatedClinicSession(page);
+      await page.goto("/dashboard?module=informes");
+      const workspace = page.locator(
+        '[data-dashboard-module-workspace="informes"]',
+      );
+      await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+      await expect(
+        workspace.getByText("Informes recientes", { exact: true }),
+      ).toHaveCount(0);
+      await expect(
+        workspace.getByText("Últimos estudios cargados", { exact: false }),
+      ).toHaveCount(0);
+
+      const openFullModule = workspace.getByRole("button", {
+        name: "Abrir módulo completo de informes",
+      });
+      await expect(openFullModule).toBeVisible();
+      const box = await openFullModule.boundingBox();
+      expect(box?.height ?? 0).toBeLessThanOrEqual(COMPACT_BUTTON_MAX_HEIGHT);
+    });
+
+    test("logistica: redundant header removed, link CTA compact", async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await setPopulatedClinicSession(page);
+      await page.goto("/dashboard?module=logistica");
+      const workspace = page.locator(
+        '[data-dashboard-module-workspace="logistica"]',
+      );
+      await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+      await expect(
+        workspace.getByText("Visitas de campo recientes", { exact: true }),
+      ).toHaveCount(0);
+      await expect(
+        workspace.getByText("Programación logística activa", { exact: false }),
+      ).toHaveCount(0);
+
+      const openFullModule = workspace.getByRole("button", {
+        name: "Abrir módulo completo de logística",
+      });
+      await expect(openFullModule).toBeVisible();
+      const box = await openFullModule.boundingBox();
+      expect(box?.height ?? 0).toBeLessThanOrEqual(COMPACT_BUTTON_MAX_HEIGHT);
+    });
+
+    test("perfil: redundant header removed, save CTA compact, content reachable", async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await setPopulatedClinicSession(page);
+      await page.goto("/dashboard?module=perfil");
+      const workspace = page.locator(
+        '[data-dashboard-module-workspace="perfil"]',
+      );
+      await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+      await expect(
+        workspace.getByText("Perfil para banco de especialidades", {
+          exact: true,
+        }),
+      ).toHaveCount(0);
+      await expect(
+        workspace.getByText("Publicación, calidad, avatar", { exact: false }),
+      ).toHaveCount(0);
+
+      const saveButton = workspace.getByRole("button", {
+        name: "Guardar perfil público",
+        exact: true,
+      });
+      await expect(saveButton).toBeVisible();
+      const box = await saveButton.boundingBox();
+      expect(box?.height ?? 0).toBeLessThanOrEqual(COMPACT_BUTTON_MAX_HEIGHT);
+    });
+
+    test("tokens: redundant header removed (module title kept once), CTAs compact", async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await setPopulatedClinicSession(page);
+      await page.goto("/dashboard?module=tokens");
+      const workspace = page.locator(
+        '[data-dashboard-module-workspace="tokens"]',
+      );
+      await expect(workspace).toBeVisible({ timeout: 15_000 });
+
+      await expect(
+        workspace.getByText("Generación, actualización, estado", {
+          exact: false,
+        }),
+      ).toHaveCount(0);
+      // The outer DashboardModuleWorkspace header still renders the module
+      // title exactly once — it must not be duplicated.
+      await expect(
+        workspace.getByText("Tokens particulares", { exact: true }),
+      ).toHaveCount(1);
+
+      const updateButton = workspace.getByRole("button", { name: "Actualizar" });
+      await expect(updateButton).toBeVisible();
+      const updateBox = await updateButton.boundingBox();
+      expect(updateBox?.height ?? 0).toBeLessThanOrEqual(COMPACT_BUTTON_MAX_HEIGHT);
+
+      const generateButton = workspace.getByRole("button", {
+        name: "Generar token particular",
+      });
+      await expect(generateButton).toBeVisible();
+      const generateBox = await generateButton.boundingBox();
+      expect(generateBox?.height ?? 0).toBeLessThanOrEqual(
+        COMPACT_BUTTON_MAX_HEIGHT,
+      );
+    });
+
+    test("no horizontal overflow on any of the four compacted modules", async ({
+      page,
+    }) => {
+      await page.setViewportSize(viewport);
+      await setPopulatedClinicSession(page);
+
+      for (const moduleId of ["informes", "logistica", "perfil", "tokens"]) {
+        await page.goto(`/dashboard?module=${moduleId}`);
+        await expect(
+          page.locator(`[data-dashboard-module-workspace="${moduleId}"]`),
+        ).toBeVisible({ timeout: 15_000 });
+        const overflow = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+        }));
+        expect(
+          overflow.scrollWidth,
+          `${moduleId}: no horizontal overflow`,
+        ).toBeLessThanOrEqual(overflow.clientWidth + 2);
+      }
+    });
+  });
+}
+
+test.describe("clinic mobile shell — anti-selection and anti-zoom", () => {
+  test("operational chrome is not selectable, form fields remain editable", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 640 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const shellStyles = await page.evaluate(() => {
+      const heading = document.querySelector(
+        ".dashboard-section-heading",
+      ) as HTMLElement | null;
+      return {
+        headingUserSelect: heading
+          ? getComputedStyle(heading).userSelect
+          : null,
+      };
+    });
+
+    expect(
+      shellStyles.headingUserSelect,
+      "operational headings are not selectable",
+    ).toBe("none");
+  });
+
+  test("pinch-zoom stays available on the shell, interactive controls use manipulation", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 360, height: 640 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const touchActions = await page.evaluate(() => {
+      const computedTouchAction = (selector: string) => {
+        const el = document.querySelector(selector) as HTMLElement | null;
+        return el ? getComputedStyle(el).touchAction : null;
+      };
+      return {
+        shell: computedTouchAction('[data-vetneb-app-shell-surface="clinic"]'),
+        button: computedTouchAction(
+          '[data-vetneb-app-shell-surface="clinic"] button',
+        ),
+        tab: computedTouchAction(
+          '[data-vetneb-app-shell-surface="clinic"] [role="tab"]',
+        ),
+      };
+    });
+
+    // Low-vision accessibility: the shell must never opt out of pinch-zoom.
+    // `auto` and `manipulation` both allow pinch-zoom; any pan-* value that
+    // omits pinch-zoom (or `none`) blocks it.
+    const allowsPinchZoom = (touchAction: string | null) =>
+      touchAction === "auto" ||
+      touchAction === "manipulation" ||
+      (touchAction ?? "").includes("pinch-zoom");
+    expect(touchActions.shell, "shell computed touch-action").not.toBeNull();
+    expect(
+      allowsPinchZoom(touchActions.shell),
+      `shell touch-action "${touchActions.shell}" must allow pinch-zoom`,
+    ).toBe(true);
+    expect(touchActions.shell).not.toBe("pan-x pan-y");
+
+    // Interactive controls suppress accidental double-tap zoom / tap delay
+    // without blocking pinch-zoom.
+    expect(
+      touchActions.button,
+      "clinic buttons use touch-action: manipulation",
+    ).toBe("manipulation");
+    expect(
+      touchActions.tab,
+      "clinic tabs use touch-action: manipulation",
+    ).toBe("manipulation");
+  });
+
+  test("perfil form inputs stay selectable and editable", async ({ page }) => {
+    await page.setViewportSize({ width: 375, height: 667 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=perfil");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="perfil"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    await page.getByRole("tab", { name: "Datos", exact: true }).click();
+    const nameInput = page.locator("#clinic-profile-display-name");
+    await expect(nameInput).toBeVisible();
+
+    const inputUserSelect = await nameInput.evaluate(
+      (el) => getComputedStyle(el).userSelect,
+    );
+    expect(inputUserSelect, "profile inputs stay selectable").toBe("text");
+
+    await nameInput.fill("Clínica de prueba editable");
+    await expect(nameInput).toHaveValue("Clínica de prueba editable");
+  });
+
+  test("desktop (1280x800) is unaffected by the mobile-only anti-select/anti-zoom rules", async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: 1280, height: 800 });
+    await setPopulatedClinicSession(page);
+    await page.goto("/dashboard?module=operaciones");
+    await expect(
+      page.locator('[data-dashboard-module-workspace="operaciones"]'),
+    ).toBeVisible({ timeout: 15_000 });
+
+    const heading = page.locator(".dashboard-section-heading").first();
+    const headingUserSelect = await heading.evaluate(
+      (el) => getComputedStyle(el).userSelect,
+    );
+    // The mobile-only rule block (max-width: 767px) must not apply at desktop.
+    expect(headingUserSelect).not.toBe("none");
+  });
+});

--- a/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
+++ b/frontend/e2e/dashboard-clinic-perfil-mobile-operability.spec.ts
@@ -122,9 +122,15 @@ async function expectNoProfileInternalScroll(page: Page, label: string) {
     const fields = document.querySelector<HTMLElement>(
       '[data-clinic-profile-fields="true"]',
     );
+    // VIS-MOBILE-001: `.dashboard-module-body` is the single sanctioned scroll
+    // owner for the perfil module on low-height mobile viewports (it makes
+    // otherwise-clipped tab content reachable). Any OTHER internal scroll
+    // container would mean a second, unintended scroll owner, which is still
+    // disallowed.
     const scrollContainers = editor
       ? [editor, ...Array.from(editor.querySelectorAll<HTMLElement>("*"))].flatMap(
           (element) => {
+            if (element.classList.contains("dashboard-module-body")) return [];
             const style = window.getComputedStyle(element);
             return ["auto", "scroll"].includes(style.overflowY)
               ? [

--- a/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/dashboard-global-masked-master-detail.spec.ts
@@ -352,14 +352,21 @@ for (const viewport of VIEWPORTS) {
         page.locator('[data-dashboard-module-workspace="tokens"]').first(),
       ).toBeVisible({ timeout: 12_000 });
 
-      await page
+      // The generate button relies on a React onClick (not a link): under CI
+      // contention a click can land before hydration attaches the handler and
+      // silently open nothing. Retry until the click observably opened the
+      // dialog instead of trusting a single dispatched click.
+      const generateButton = page
         .getByRole("button", { name: "Generar token particular" })
-        .first()
-        .click();
-
-      await expect(
-        page.locator('[data-module-dialog="true"]').first(),
-      ).toBeVisible({ timeout: 5_000 });
+        .first();
+      const altaDialog = page.locator('[data-module-dialog="true"]').first();
+      await expect(generateButton).toBeEnabled();
+      await expect(async () => {
+        if (!(await altaDialog.isVisible())) {
+          await generateButton.click({ timeout: 2_000 });
+        }
+        await expect(altaDialog).toBeVisible({ timeout: 2_000 });
+      }).toPass({ timeout: 10_000 });
       await expect(page.getByText("Paso 1 de 3: Vínculo")).toBeVisible();
       await page.locator("#clinic-token-particular-email").fill("particular@example.com");
       await page.locator("#clinic-token-tutor-last-name").fill("Tutor Demo");

--- a/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
+++ b/frontend/e2e/dashboard-viewport-zoom-adaptability.spec.ts
@@ -314,7 +314,22 @@ async function readWorstInternalVerticalScroll(
       }`;
     };
 
+    // VIS-MOBILE-001: `.dashboard-module-body` inside the clinic operaciones
+    // or perfil mobile modules is a deliberate, single, reachable scroll
+    // owner (their real content can exceed the flex-allocated body height at
+    // low-height mobile portrait). It is intentionally exempt from this
+    // "zero internal scroll" scan; every other element in `main` still must
+    // not introduce its own scroll container.
+    const isSanctionedScrollOwner = (element: HTMLElement) =>
+      element.classList.contains("dashboard-module-body") &&
+      (element.closest('[data-clinic-mobile-module="operaciones"]') !== null ||
+        element.closest('[data-clinic-mobile-module="perfil"]') !== null);
+
     main?.querySelectorAll<HTMLElement>("*").forEach((element) => {
+      if (isSanctionedScrollOwner(element)) {
+        return;
+      }
+
       const style = window.getComputedStyle(element);
       if (style.overflowY !== "auto" && style.overflowY !== "scroll") {
         return;

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -249,10 +249,10 @@ export function ClinicInformesWorkspaceSummary({
     <PublicRouteControl
       href={ROUTES.dashboardInformes}
       variant="bare"
-      className="inline-flex h-9 items-center gap-2 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-3 text-sm font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-2.5 text-xs font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
       aria-label="Abrir módulo completo de informes"
     >
-      <ExternalLink className="h-4 w-4" aria-hidden="true" />
+      <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
       Abrir módulo completo
     </PublicRouteControl>
   );
@@ -369,37 +369,27 @@ export function ClinicInformesWorkspaceSummary({
     <ModuleSurface
       ariaLabel="Informes recientes de la clínica"
       toolbar={
-        <div className="flex w-full flex-wrap items-center justify-between gap-3">
-          <div className="min-w-0">
-            <h3 className="text-sm font-semibold text-vetneb-ink">
-              Informes recientes
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Últimos estudios cargados. Para acceso completo use el módulo de informes.
-            </p>
-          </div>
-          <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
-            <ModuleDialog
-              open={isFilterDialogOpen}
-              onOpenChange={setIsFilterDialogOpen}
-              title="Filtrar informes"
-              description="Los filtros se aplican sobre los informes recientes cargados en la workspace."
-              trigger={
-                <Button
-                  type="button"
-                  variant="outline"
-                  size="sm"
-                  className="h-9 gap-1.5 px-2.5 text-xs md:hidden"
-                >
-                  <Filter className="h-3.5 w-3.5" aria-hidden="true" />
-                  {hasActiveFilters ? "Filtros activos" : "Filtros"}
-                </Button>
-              }
-            >
-              {renderAdvancedFilterForm(true)}
-            </ModuleDialog>
-            {fullModuleLink}
-          </div>
+        <div className="flex w-full flex-wrap items-center justify-end gap-2">
+          <ModuleDialog
+            open={isFilterDialogOpen}
+            onOpenChange={setIsFilterDialogOpen}
+            title="Filtrar informes"
+            description="Los filtros se aplican sobre los informes recientes cargados en la workspace."
+            trigger={
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                className="h-8 gap-1.5 px-2.5 text-xs md:hidden"
+              >
+                <Filter className="h-3.5 w-3.5" aria-hidden="true" />
+                {hasActiveFilters ? "Filtros activos" : "Filtros"}
+              </Button>
+            }
+          >
+            {renderAdvancedFilterForm(true)}
+          </ModuleDialog>
+          {fullModuleLink}
         </div>
       }
     >
@@ -512,11 +502,7 @@ export function ClinicInformesWorkspaceSummary({
                           #{report.id} · {report.patientName ?? "Sin nombre"}
                         </p>
                         <p className="truncate text-[0.6875rem] text-muted-foreground">
-                          {report.studyType ?? "Tipo sin registrar"} ·{" "}
-                          {formatDate(report.uploadDate)}
-                        </p>
-                        <p className="truncate text-[0.6875rem] text-muted-foreground">
-                          {formatReportFile(report)}
+                          {report.studyType ?? "Tipo sin registrar"}
                         </p>
                       </div>
                       <div className="flex shrink-0 items-center gap-1.5">

--- a/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx
@@ -73,10 +73,10 @@ export function ClinicLogisticaWorkspaceSummary({
     <PublicRouteControl
       href={ROUTES.dashboardLogistica}
       variant="bare"
-      className="inline-flex h-9 items-center gap-2 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-3 text-sm font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
+      className="inline-flex h-8 items-center gap-1.5 rounded-md border border-vetneb-teal/45 bg-vetneb-teal/10 px-2.5 text-xs font-semibold text-vetneb-teal transition-colors hover:bg-vetneb-teal/20 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85 focus-visible:ring-offset-2"
       aria-label="Abrir módulo completo de logística"
     >
-      <ExternalLink className="h-4 w-4" aria-hidden="true" />
+      <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
       Abrir módulo completo
     </PublicRouteControl>
   );
@@ -85,15 +85,7 @@ export function ClinicLogisticaWorkspaceSummary({
     <ModuleSurface
       ariaLabel="Visitas de campo recientes de la clínica"
       toolbar={
-        <div className="flex w-full flex-wrap items-center justify-between gap-3">
-          <div className="min-w-0">
-            <h3 className="text-sm font-semibold text-vetneb-ink">
-              Visitas de campo recientes
-            </h3>
-            <p className="text-xs text-muted-foreground">
-              Programación logística activa. Para gestión completa use el módulo de logística.
-            </p>
-          </div>
+        <div className="flex w-full flex-wrap items-center justify-end gap-2">
           {fullModuleLink}
         </div>
       }

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -845,29 +845,19 @@ export function ClinicParticularTokensCard() {
             data-clinic-access-toolbar="true"
             className="flex w-full flex-wrap items-center justify-between gap-2"
           >
-            <div className="min-w-0">
-              <h3 className="dashboard-section-heading">
-                Tokens particulares
-              </h3>
-              <p className="dashboard-section-description line-clamp-1">
-                Generación, actualización, estado y detalle clínico en un módulo
-                compacto.
-              </p>
-            </div>
+            <ParticularTokensMetricStrip
+              metrics={[
+                { label: "Tokens", value: tokens.length },
+                { label: "Activos", value: activeTokensCount },
+                { label: "Informes", value: linkedReportsCount },
+              ]}
+              className="grid grid-cols-3 rounded-md"
+              itemClassName="min-w-[4.25rem] px-2 py-1"
+              valueClassName="text-sm"
+              aria-label="Métricas de tokens particulares"
+            />
 
             <div className="flex min-w-0 flex-wrap items-center justify-end gap-2">
-              <ParticularTokensMetricStrip
-                metrics={[
-                  { label: "Tokens", value: tokens.length },
-                  { label: "Activos", value: activeTokensCount },
-                  { label: "Informes", value: linkedReportsCount },
-                ]}
-                className="grid grid-cols-3 rounded-md"
-                itemClassName="min-w-[4.25rem] px-2 py-1"
-                valueClassName="text-sm"
-                aria-label="Métricas de tokens particulares"
-              />
-
               <ModuleDialog
                 open={isFilterDialogOpen}
                 onOpenChange={setIsFilterDialogOpen}
@@ -878,7 +868,7 @@ export function ClinicParticularTokensCard() {
                     type="button"
                     variant="outline"
                     size="sm"
-                    className="h-10 min-h-10 gap-1.5 px-2.5 text-xs md:hidden"
+                    className="h-8 gap-1.5 px-2.5 text-xs md:hidden"
                   >
                     <Filter className="h-3.5 w-3.5" aria-hidden="true" />
                     {hasActiveFilters ? "Filtros activos" : "Filtros"}
@@ -892,6 +882,7 @@ export function ClinicParticularTokensCard() {
                 type="button"
                 variant="outline"
                 size="sm"
+                className="h-8 px-2.5 text-xs"
                 onClick={() => void loadTokens(effectiveFetchLimit)}
                 disabled={isLoadingTokens}
               >
@@ -900,6 +891,7 @@ export function ClinicParticularTokensCard() {
               <Button
                 type="button"
                 size="sm"
+                className="h-8 px-2.5 text-xs"
                 onClick={() => setIsCreateDialogOpen(true)}
                 disabled={generatedToken !== null}
               >

--- a/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
+++ b/frontend/src/components/dashboard/ClinicPublicProfileCard.tsx
@@ -794,31 +794,22 @@ export function ClinicPublicProfileCard() {
         toolbar={
           <div
             data-clinic-profile-toolbar="true"
-            className="flex w-full flex-wrap items-center justify-between gap-2"
+            className="flex w-full flex-wrap items-center justify-end gap-2"
           >
-            <div className="min-w-0">
-              <h3 className="dashboard-section-heading">
-                Perfil para banco de especialidades
-              </h3>
-              <p className="dashboard-section-description line-clamp-1">
-                Publicación, calidad, avatar y datos visibles en tabs compactos.
-              </p>
-            </div>
-            <div className="flex flex-wrap items-center justify-end gap-2">
-              <Badge variant={getPublicationVariant(profile)}>
-                {getPublicationLabel(profile)}
-              </Badge>
-              {!isPasswordTabActive ? (
-                <Button
-                  type="submit"
-                  size="sm"
-                  disabled={isWorking}
-                  form={PROFILE_FORM_ID}
-                >
-                  {isSubmitting ? "Guardando..." : "Guardar perfil público"}
-                </Button>
-              ) : null}
-            </div>
+            <Badge variant={getPublicationVariant(profile)}>
+              {getPublicationLabel(profile)}
+            </Badge>
+            {!isPasswordTabActive ? (
+              <Button
+                type="submit"
+                size="sm"
+                className="h-8 px-3 text-xs"
+                disabled={isWorking}
+                form={PROFILE_FORM_ID}
+              >
+                {isSubmitting ? "Guardando..." : "Guardar perfil público"}
+              </Button>
+            ) : null}
           </div>
         }
       >
@@ -830,7 +821,7 @@ export function ClinicPublicProfileCard() {
 
         {profileLoadErrorMessage ? (
           <div
-            className="clinical-alert-error flex shrink-0 flex-wrap items-center justify-between gap-2 px-3 py-2"
+            className="clinical-alert-error flex shrink-0 flex-wrap items-center justify-between gap-2 px-2.5 py-1.5 text-xs"
             role="alert"
           >
             <span>{profileLoadErrorMessage}</span>
@@ -838,6 +829,7 @@ export function ClinicPublicProfileCard() {
               type="button"
               variant="outline"
               size="sm"
+              className="h-8 px-2.5 text-xs"
               onClick={() => void loadProfile()}
               disabled={isWorking}
             >

--- a/frontend/src/styles/dashboard/mobile-clinic.css
+++ b/frontend/src/styles/dashboard/mobile-clinic.css
@@ -26,8 +26,7 @@
   }
 
   [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-list-body="true"],
-  [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-list-panel="true"],
-  [data-vetneb-app-shell-surface="clinic"] [data-clinic-profile-fields="true"] {
+  [data-vetneb-app-shell-surface="clinic"] [data-clinic-access-list-panel="true"] {
     min-height: 0;
     min-width: 0;
     overflow: hidden;
@@ -73,6 +72,37 @@
     --clinic-mobile-bottom-nav-h: clamp(3.15rem, 0.3rem + 0.45svh, 3.5rem);
     --clinic-mobile-bottom-nav-gap: clamp(0.1rem, 0.08rem + 0.08svw, 0.16rem);
     --clinic-mobile-type-2xs: clamp(0.56rem, 0.48rem + 0.22svw, 0.64rem);
+  }
+
+  /* Pinch-zoom must stay available on the whole clinic mobile shell (low-vision
+     accessibility). Accidental double-tap zoom / tap delay is suppressed only
+     on interactive controls via `manipulation`, which still allows pinch-zoom. */
+  [data-vetneb-app-shell-surface="clinic"]
+    :is(
+      button,
+      a,
+      [role="button"],
+      [role="tab"]
+    ) {
+    touch-action: manipulation;
+  }
+
+  /* FASE 2B: the operational chrome (tabs, cards, badges, buttons, labels,
+     lists, KPIs) must not be selectable by accident on touch; real form
+     fields opt back into normal text selection below. */
+  [data-vetneb-app-shell-surface="clinic"] * {
+    -webkit-user-select: none;
+    user-select: none;
+    -webkit-touch-callout: none;
+  }
+
+  [data-vetneb-app-shell-surface="clinic"] input,
+  [data-vetneb-app-shell-surface="clinic"] textarea,
+  [data-vetneb-app-shell-surface="clinic"] select,
+  [data-vetneb-app-shell-surface="clinic"] [contenteditable="true"] {
+    -webkit-user-select: text;
+    user-select: text;
+    -webkit-touch-callout: default;
   }
 
   [data-vetneb-app-shell-surface="clinic"]
@@ -200,6 +230,36 @@
     button {
     min-height: 2rem;
     font-size: var(--clinic-mobile-type-2xs);
+  }
+
+  /* VIS-MOBILE-001 — operaciones and perfil are the two modules whose real
+     mobile content (tabbed KPI/lists, profile tabs) can exceed
+     dashboard-module-body's flex-allocated height at low-height portrait
+     viewports (measured: scrollHeight ~557-570 vs clientHeight ~270-390).
+     Their descendants already render at natural size (overflow: visible), so
+     making this single node the scroll owner makes the overflow reachable
+     instead of clipped, without introducing a second scroll container. */
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-clinic-mobile-module="operaciones"]
+    .dashboard-module-body,
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-clinic-mobile-module="perfil"]
+    .dashboard-module-body {
+    overflow-y: auto;
+    overflow-x: hidden;
+    overscroll-behavior: contain;
+    -webkit-overflow-scrolling: touch;
+    padding-bottom: calc(
+      var(--clinic-mobile-shell-gutter) + env(safe-area-inset-bottom)
+    );
+  }
+
+  /* Perfil's tab-content wrapper no longer clips internally — the module
+     body above is now the single scroll owner. */
+  [data-vetneb-app-shell-surface="clinic"]
+    [data-clinic-mobile-module="perfil"]
+    [data-clinic-profile-fields="true"] {
+    overflow: visible;
   }
 }
 /* clinic-admin-structure-parity:end */

--- a/test/unit/contracts/clinic/frontend-clinic-public-profile.test.ts
+++ b/test/unit/contracts/clinic/frontend-clinic-public-profile.test.ts
@@ -26,7 +26,10 @@ test("clinic public profile card exists and is clinic scoped", () => {
   assert.ok(source.includes("getClinicPublicProfile"));
   assert.ok(source.includes("updateClinicPublicProfile"));
   assert.ok(source.includes('id="clinic-public-profile"'));
-  assert.ok(source.includes("Perfil para banco de especialidades"));
+  // FASE 2B: the card no longer duplicates the module title/subtitle that
+  // DashboardModuleWorkspace already renders once above it — it keeps the
+  // aria-label instead.
+  assert.ok(source.includes('ariaLabel="Perfil público de la clínica"'));
   assert.ok(source.includes("especialidades"));
   assert.equal(source.includes("/api/admin"), false);
 });


### PR DESCRIPTION
## Summary
- Resolve VIS-MOBILE-001 clipping in Clinic Operations and Profile on low-height mobile portrait viewports.
- Remove duplicated mobile workspace copy and compact secondary controls in Info, Logistics, Profile, and Particular Tokens.
- Preserve a single sanctioned scroll owner for Operations and Profile while keeping paginated modules contained.
- Simplify mobile report rows to prioritize patient and study data.

## Scope
- [ ] backend runtime
- [x] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception

## Validation
- [x] `pnpm test` — 3092 passed / 0 failed
- [x] `pnpm --dir frontend lint`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [x] New mobile reachability and operational-density E2E tests — 23 passed
- [x] Visual-contract E2E suite — 273 passed
- [x] Clinic mobile parity tests passed
- [ ] Relevant CI checks passed — pending PR execution

## Security / Regression Checklist
- [x] No secret or token exposure.
- [x] Authentication and authorization unchanged.
- [x] API and data-access behavior unchanged.
- [x] Dependencies and supply chain unchanged.
- [x] Database and schema unchanged.
- [x] Desktop behavior preserved.

## Rollback
- Trigger: mobile content-access regression, nested scrolling, clipping, navigation obstruction, or operational-density degradation.
- Steps: revert the squash commit, rerun frontend lint/typecheck/build, unit tests, and affected Playwright dashboard suites.
- Data impact: none.

## Root cause
Clinic Operations and Profile inherited `overflow: hidden` from the module body despite containing more content than their low-height mobile region. Unlike paginated modules, they had no mechanism to reach clipped content.

Several compact workspaces also rendered duplicated headings and descriptions inside their toolbars, while secondary actions used excessive height and report rows included nonessential mobile metadata.

## Implementation
- Assign `.dashboard-module-body` as the only mobile scroll owner for Operations and Profile.
- Preserve `html`, `body`, `main`, shell, stage, and workspace as contained regions.
- Add structural bottom padding with safe-area support.
- Remove duplicated toolbar copy from Info, Logistics, Profile, and Particular Tokens.
- Standardize compact actions to the `h-8 px-2.5 text-xs` family.
- Simplify mobile report rows to identifier/patient, study, status, and action.
- Scope anti-selection and touch-action behavior to the Clinic mobile shell while preserving text selection in editable controls.

## Evidence
Validated at 360×640, 375×667, and 390×844. Operations and Profile reach the end of their content, preserve horizontal containment, and maintain structural bottom spacing. Info, Logistics, and Particular Tokens remain pager-contained.

## Residual risks
- Landscape remediation remains outside this PR.
- The obsolete `dashboard-clinic-mobile-nav-stage-parity.spec.ts` is intentionally not removed here; it will be retired in a separate tests-only PR because it represents pre-existing test-suite debt.

No backend, API, authentication, database, dependency, lockfile, workflow, CI, or business-logic changes were made.