### PR TITLE
refactor(logistics): move SLA and time-window domain modules (M02b)

### DIFF
--- a/docs/implementation/m02b-logistics-sla-time-window-domain-move.md
+++ b/docs/implementation/m02b-logistics-sla-time-window-domain-move.md
@@ -1,0 +1,183 @@
+# M02b · Mover SLA breach y time-window al dominio Logistics
+
+## Base exacta
+
+- **Rama:** `refactor/backend-modularization-m02b-logistics-domain`.
+- **HEAD base:** `7a382f172f229b35a0362396182bb9828aa09a1e` — `refactor(server): remove express-era orphan handlers (M02) (#1497)`.
+- **Working tree inicial:** limpio.
+- **Milestone:** Fase A — M02b.
+
+## Objetivo
+
+Migrar al bounded context Logistics dos módulos que hoy viven en
+`server/lib/logistics/`:
+
+- `time-window.ts` — dominio puro; se mueve a
+  `server/features/logistics/domain/time-window.ts`.
+- `sla-breach.ts` — **no** es íntegramente dominio puro; se separa en núcleo puro
+  (`domain/sla-breach.ts`) y adaptador de DB
+  (`infrastructure/sla-breach-db.ts`).
+
+Preservando comportamiento observable, errores, defaults, payloads y orden de
+side-effects; alineando imports y tests anclados en el mismo PR; manteniendo verde
+el guard de frontera; sin tocar rutas, endpoints, schema, DB ni contratos públicos;
+sin introducir dependencias.
+
+## Censo de importadores (evidencia `git grep`)
+
+Path legacy `lib/logistics/time-window`:
+
+- Runtime: `server/db-logistics.ts` (import de `assertValidTimeWindowRange`,
+  `normalizeTimeWindowTimezone`).
+- Test: `test/unit/migrations/logistics/logistics-time-windows-schema.test.ts`.
+
+Path legacy `lib/logistics/sla-breach`:
+
+- Runtime: **ninguno.** `markOverdueSlaBreaches` y `markOverdueSlaBreachesWithDb`
+  no se importan desde ninguna ruta ni módulo de `server/**` fuera del propio
+  archivo.
+- Test: `test/unit/infrastructure/logistics/logistics-sla-breach-runtime.test.ts`.
+
+Símbolos:
+
+- `assertValidTimeWindowRange`, `normalizeTimeWindowTimezone` — sólo `db-logistics.ts`
+  (runtime) y el test de time-window.
+- `markOverdueSlaBreaches`, `markOverdueSlaBreachesWithDb`,
+  `MarkOverdueSlaBreachesDeps` — sólo el archivo legacy y su test de runtime.
+- `MarkOverdueActiveClinicSlaInstancesBreachedParams`, `SlaInstance` — definidos en
+  `db-logistics.ts`; el legacy `sla-breach.ts` los importaba como tipos.
+
+Docs que referencian los paths legacy (fuera de scope, se dejan como baseline
+histórico): `docs/architecture/shared-lib-boundary-inventory.md` y
+`docs/logistics/ROLLING_ROADMAP.md`.
+
+## Contradicción detectada
+
+```text
+CONTRADICTED:
+la documentación M01/ARCH-4 (docs/architecture/shared-lib-boundary-inventory.md,
+filas de sla-breach) clasifica sla-breach como módulo de dominio puro que importa
+solamente el tipo SlaTargetType del schema, pero el código actual importa tipos
+(MarkOverdueActiveClinicSlaInstancesBreachedParams, SlaInstance) y runtime
+(import dinámico de markOverdueActiveClinicSlaInstancesBreached) desde
+server/db-logistics.ts.
+```
+
+No se modificó el documento rector de auditoría ni el inventario para ocultar la
+divergencia; se resolvió en el código separando núcleo puro y adaptador, y se dejó
+constancia en `server/features/logistics/README.md` (§1, nota) y en este documento.
+
+## Decisión shim / no-shim
+
+Sin shim. El censo prueba que no hay consumidores runtime del path legacy
+`lib/logistics/sla-breach`; conservar un re-export sólo por precaución habría sido
+código muerto. Ambos archivos legacy se eliminan. El único consumidor runtime de
+`time-window` (`db-logistics.ts`) se reapunta al barrel de `domain/`.
+
+## Separación domain / infrastructure
+
+- **`domain/sla-breach.ts`** — núcleo puro `markOverdueSlaBreaches` y sus tipos. No
+  importa `db.ts`, `db-logistics.ts`, Drizzle runtime, Fastify, env ni I/O. Sólo
+  importa el tipo `SlaTargetType` del shared kernel (`drizzle/schema.ts`).
+- **Resolución de tipos sin `db-*`:** el dominio nunca lee campos de una instancia
+  marcada (sólo la cuenta y la reenvía). Se resuelve con **parametrización genérica
+  simple** (`TInstance`): el tipo de la fila es opaco para el dominio, evitando
+  importar `SlaInstance` desde `db-logistics.ts` y sin duplicar el schema ni usar
+  `any`. El contrato de parámetros de la dependencia inyectada se modela con un tipo
+  estructural mínimo de dominio (`MarkOverdueSlaInstancesParams`).
+- **`infrastructure/sla-breach-db.ts`** — adaptador transitorio
+  `markOverdueSlaBreachesWithDb`. Importa el dominio por el barrel
+  (`../domain/index.ts`), importa el tipo `SlaInstance` desde `db-logistics.ts`,
+  mantiene el import dinámico (lazy) de `markOverdueActiveClinicSlaInstancesBreached`
+  y delega en `markOverdueSlaBreaches` (con `TInstance = SlaInstance` inferido). No
+  duplica lógica de negocio.
+- **`domain/index.ts`** — el barrel re-exporta la API de dominio (time-window + SLA
+  puro + lo previo), **no** el adaptador de infraestructura.
+
+## Contratos preservados
+
+- **time-window:** default `"UTC"`, `trim()` del timezone, cap exacto de 64,
+  rango válido sólo si `start < end`, fechas inválidas → `false`, error exacto
+  `windowStart must be earlier than windowEnd`.
+- **sla-breach:** validación de `clinicId`; validación de fechas; llamada única al
+  clock inyectado para los defaults; `dueAtOrBefore`/`breachedAt`; paso de
+  `targetType`; escritura antes de notificación; notificación sólo cuando hay
+  breaches; sin notificación cuando el resultado es vacío; payload de notificación
+  idéntico; mensajes `clinicId debe ser un entero positivo`, `now invalido`,
+  `dueAtOrBefore invalido`, `breachedAt invalido`.
+- **db-logistics.ts:** sólo cambian imports (consume time-window por el barrel).
+  Queries, tipos de entrada, mapping, transacciones y orden de operaciones intactos.
+
+## Archivos
+
+| Archivo | Cambio |
+| --- | --- |
+| `server/features/logistics/domain/time-window.ts` | **CREATED.** Copia literal del dominio puro. |
+| `server/features/logistics/domain/sla-breach.ts` | **CREATED.** Núcleo puro genérico + tipos de dominio. |
+| `server/features/logistics/infrastructure/sla-breach-db.ts` | **CREATED.** Adaptador de DB transitorio. |
+| `server/features/logistics/domain/index.ts` | **MODIFIED.** Barrel re-exporta time-window y SLA puro. |
+| `server/db-logistics.ts` | **MODIFIED.** Import de time-window vía barrel (sólo imports). |
+| `server/lib/logistics/time-window.ts` | **DELETED.** |
+| `server/lib/logistics/sla-breach.ts` | **DELETED.** |
+| `test/unit/domain/logistics/logistics-sla-breach.test.ts` | **CREATED.** 6 casos puros vía barrel. |
+| `test/unit/infrastructure/logistics/logistics-sla-breach-runtime.test.ts` | **MODIFIED.** Adaptador vía infra; regex lazy import `../../../db-logistics.ts`. |
+| `test/unit/migrations/logistics/logistics-time-windows-schema.test.ts` | **MODIFIED.** Import vía barrel. |
+| `test/unit/domain/logistics/logistics-domain-barrel.test.ts` | **MODIFIED.** Cobertura de time-window y SLA puro. |
+| `server/features/logistics/README.md` | **MODIFIED.** Estado real post-M02b. |
+| `server/features/logistics/domain/README.md` | **MODIFIED.** Lista archivos y barrel. |
+| `server/features/logistics/infrastructure/README.md` | **MODIFIED.** Adaptador transitorio. |
+| `docs/implementation/m02b-logistics-sla-time-window-domain-move.md` | **CREATED.** Este documento. |
+
+## Tests anclados
+
+- `test/architecture/logistics-domain-boundary-guard.test.ts` — verde sin cambios;
+  cubre automáticamente los archivos nuevos de `domain/` y exige que el adaptador de
+  `infrastructure/` importe el dominio por el barrel.
+- `test/unit/domain/logistics/logistics-domain-barrel.test.ts` — +2 casos (time-window
+  y SLA puro).
+- `test/unit/domain/logistics/logistics-sla-breach.test.ts` — 6 casos de comportamiento
+  puro migrados desde el runtime test, consumidos por el barrel.
+- `test/unit/infrastructure/logistics/logistics-sla-breach-runtime.test.ts` — conserva
+  el caso del lazy import + delegación (adaptado al nuevo archivo) y añade un caso que
+  fija el consumo del dominio por el barrel.
+- `test/unit/migrations/logistics/logistics-time-windows-schema.test.ts` — mismos 8
+  casos, import reapuntado al barrel.
+- `test/unit/infrastructure/logistics/logistics-db.test.ts` — sin cambios (el import
+  del barrel y los call-sites de time-window siguen intactos).
+
+**Reconciliación de casos:** SLA runtime 7 → domain 6 + infra 2 = 8 (no reduce, +1);
+barrel 2 → 4 (+2); time-window 8 → 8; db sin cambios. M02b no elimina ningún caso.
+
+## Validaciones
+
+Ver la sección de validaciones del reporte de ejecución (gates dirigidos con
+`pnpm exec tsx --test`, luego `pnpm validate:local`, luego `git diff --check`).
+
+## Riesgos residuales
+
+- Bajo. El cambio preserva comportamiento y está cubierto por el guard de frontera y
+  por los tests de dominio, adaptador y db.
+- Referencias a los paths legacy quedan en `shared-lib-boundary-inventory.md` (no
+  modificable en esta tarea) y `docs/logistics/ROLLING_ROADMAP.md` (fuera de scope):
+  staleza documental, no rompe build/tests/guards. Se reconcilia en un pase de docs
+  posterior.
+
+## Rollback independiente
+
+Revertir el PR restaura los dos archivos legacy y sus imports/tests; no hay cambios
+de schema, migraciones ni contratos que compliquen el revert.
+
+## Exclusiones
+
+Sin cambios en `server/routes/**`, `server/fastify-app.ts`, `drizzle/**`,
+`migrations/**`, schema, auth/sesiones/cookies/CORS/CSP/rate-limits/headers,
+`frontend/**`, `package.json`, lockfiles, `.github/**`, `scripts/**`. No se inició
+M03–M06. No se modificaron `docs/audit/backend-enterprise-modularization-program-audit.md`
+ni `docs/architecture/shared-lib-boundary-inventory.md`.
+
+## Readiness para M03
+
+`route-planning.ts` y `metrics.ts` siguen en `server/lib/logistics/`; ambos importan
+sólo tipos de schema. El patrón M02b (mover a `domain/`, re-exportar por el barrel,
+alinear el consumidor `db-logistics.ts` y los tests) es directamente reutilizable
+para ellos.

--- a/server/db-logistics.ts
+++ b/server/db-logistics.ts
@@ -24,20 +24,18 @@ import {
   type VisitLocationGeoQuality,
 } from "../drizzle/schema.ts";
 import {
-  assertValidTimeWindowRange,
-  normalizeTimeWindowTimezone,
-} from "./lib/logistics/time-window.ts";
-import {
   buildHeuristicRoutePlan,
   type RoutePlanningPoint,
   type RoutePlanningVisit,
 } from "./lib/logistics/route-planning.ts";
 import {
+  assertValidTimeWindowRange,
   LOGISTICS_DEFAULT_LIMIT,
   LOGISTICS_MAX_LIMIT,
   normalizeGenerateHeuristicFieldVisitIds,
   normalizeLogisticsLimit,
   normalizeLogisticsOffset,
+  normalizeTimeWindowTimezone,
 } from "./features/logistics/domain/index.ts";
 
 export {

--- a/server/features/logistics/README.md
+++ b/server/features/logistics/README.md
@@ -1,20 +1,25 @@
-# Logistics — domain shell (read-only)
+# Logistics — bounded context
 
-> **Tipo:** Frontera de módulo **docs-only**. No implementa, no mueve código, no
-> re-exporta, no toca rutas, CSS, tests de runtime, `package.json`, lockfiles, CI
-> ni schema. Sólo README bajo `server/features/logistics/`.
-> **Base:** `main` limpio · **HEAD:** `cacfe3f` docs(architecture): inventory shared lib boundaries (#1298).
-> **Rama:** `refactor/logistics-domain-shell`.
-> **Documentos rectores:** [ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md) · [ARCH-2](../../../docs/architecture/backend-boundary-adr.md) · [ARCH-3](../../../docs/architecture/shared-lib-boundary-inventory.md).
-> **Modelo / esfuerzo:** Claude Opus 4.8 · high.
-> **ID:** ARCH-4.
+> **Tipo:** Frontera de módulo del contexto Logistics. Establecida como shell
+> docs-only en ARCH-4; **desde ARCH-5 contiene código real** en `domain/` y, desde
+> M02b, también en `infrastructure/`.
+> **Origen:** [ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md) · [ARCH-2](../../../docs/architecture/backend-boundary-adr.md) · [ARCH-3](../../../docs/architecture/shared-lib-boundary-inventory.md).
+> **ID:** ARCH-4 (shell) → ARCH-5/7/8 (domain) → M02b (time-window + SLA).
 
-Este directorio es un **shell de frontera** para el contexto Logistics. Declara
-las reglas de dependencia del ADR ([ARCH-2](../../../docs/architecture/backend-boundary-adr.md))
-en el lugar donde vivirán las capas, **sin migrar todavía ni una línea de código**.
-No hay `index.ts`, no hay barrels, no hay re-exports: sólo documentación de
-frontera. El comportamiento en tiempo de ejecución sigue viviendo, sin cambios, en
-`server/lib/logistics/`, `server/db-logistics.ts` y `server/routes/logistics-*.fastify.ts`.
+Este directorio es la **frontera** del contexto Logistics. Declara las reglas de
+dependencia del ADR ([ARCH-2](../../../docs/architecture/backend-boundary-adr.md))
+y ya aloja código migrado, capa por capa, detrás de contratos con tests verdes:
+
+- **`domain/`** — reglas puras con barrel público (`index.ts`): paginación,
+  normalización de visitas heurísticas, ventanas de tiempo y el núcleo puro de
+  breach de SLA.
+- **`infrastructure/`** — adaptador transitorio de DB para el breach de SLA
+  (`sla-breach-db.ts`).
+- **`application/`** y **`routes/`** — todavía sólo README (sin código).
+
+El resto del runtime sigue viviendo, sin cambios en M02b, en
+`server/lib/logistics/{metrics,route-planning}.ts`, `server/db-logistics.ts` y
+`server/routes/logistics-*.fastify.ts`.
 
 ## 1. Responsabilidad del contexto Logistics
 
@@ -26,28 +31,41 @@ bajo**, y por eso es el piloto de migración por dominios. Concentra además los
 god-handlers más grandes del backend (`logistics-route-plans.fastify.ts` ≈ 2.241
 LOC), donde extraer application/domain tiene el mayor retorno de mantenibilidad.
 
-Su superficie actual (por *naming*, no por carpeta) es:
+Su superficie actual es:
 
-- **Dominio puro** — `server/lib/logistics/{metrics,route-planning,sla-breach,time-window}.ts`
-  (~1.5k LOC). Importan **sólo tipos** de `drizzle/schema.ts`; cero `fastify`,
-  cero `db`. Ya cumplen la regla "domain sin framework" del ADR.
-- **Persistencia + dominio mezclados** — `server/db-logistics.ts` (~1.322 LOC). Único
-  `db-*` que delega en helpers de dominio (`time-window`, `route-planning`);
-  candidato natural a repositorio del contexto.
+- **Dominio migrado** — `server/features/logistics/domain/` (paginación,
+  `route-plan-field-visits`, `time-window`, núcleo puro de `sla-breach`), consumido
+  por el resto del backend a través del barrel `domain/index.ts`.
+- **Dominio pendiente** — `server/lib/logistics/{metrics,route-planning}.ts`. Importan
+  **sólo tipos** de `drizzle/schema.ts`; cero `fastify`, cero `db`. Migran en M03/M04.
+- **Adaptador de infraestructura** — `server/features/logistics/infrastructure/sla-breach-db.ts`
+  (transitorio): cablea el núcleo puro de SLA con `db-logistics.ts` vía import lazy.
+- **Persistencia + dominio mezclados (legacy, fuera de M02b)** — `server/db-logistics.ts`
+  (~1.322 LOC). Único `db-*` que delega en helpers de dominio (`time-window`,
+  `route-planning`); candidato natural a repositorio del contexto en M12.
 - **Infra de contexto** — `server/lib/logistics-route-plans-cache.ts`.
 - **Adaptadores HTTP** — `server/routes/logistics-{route-plans,field-visits,route-events,sla}.fastify.ts`.
 
+> **Nota (M01/ARCH-4 vs. código real):** el inventario ARCH-3 clasificaba
+> `sla-breach.ts` como dominio puro que importa "sólo el tipo `SlaTargetType`". En
+> realidad el archivo legacy también importaba **tipos y runtime** desde
+> `db-logistics.ts` (import estático de tipos + import dinámico del helper). M02b
+> resuelve esa divergencia separando el núcleo puro (`domain/sla-breach.ts`, opaco
+> respecto de la fila de `slaInstances`) del adaptador con `db-*`
+> (`infrastructure/sla-breach-db.ts`).
+
 ## 2. Relación temporal con `server/lib/logistics` actual
 
-Esta carpeta **convive** con la estructura actual; no la reemplaza en este PR. El
-código de runtime **no se ha movido**: `server/lib/logistics/*`, `server/db-logistics.ts`
-y `server/routes/logistics-*.fastify.ts` siguen siendo la única fuente de verdad
-ejecutable. `server/features/logistics/` es, por ahora, sólo el **destino
-documentado** de la migración incremental descrita en el ADR.
+Esta carpeta **convive** con la estructura legacy y ya absorbió parte de ella. El
+dominio migrado (`domain/`) es la fuente de verdad ejecutable de la paginación, la
+normalización de visitas heurísticas, las ventanas de tiempo y el núcleo puro de
+SLA; `server/db-logistics.ts` los consume por el barrel. Lo que **aún no se ha
+movido**: `server/lib/logistics/{metrics,route-planning}.ts` (M03/M04),
+`server/db-logistics.ts` (legacy, candidato a repositorio en M12) y
+`server/routes/logistics-*.fastify.ts`.
 
-Es un estado transitorio y deliberado: primero se fija la frontera y su contrato
-en prosa; recién después (ARCH-5+) se mueve código real, capa por capa, detrás de
-los contratos por-ruta existentes y sólo con tests verdes.
+Es una migración incremental y deliberada: se mueve código real capa por capa,
+detrás de los contratos por-ruta existentes y sólo con tests verdes.
 
 ## 3. Reglas de dependencia
 
@@ -63,34 +81,34 @@ cualquier capa; nunca al revés. La dependencia **siempre apunta hacia adentro**
 | **[infrastructure](./infrastructure/README.md)** | Implementa puertos. | domain, shared kernel, Drizzle runtime, clientes externos | routes/http, application (no invierte la dirección) |
 | **[routes](./routes/README.md)** | Adapta HTTP. | application, domain (tipos), shared kernel, adaptadores http, middlewares | `db-*` directo, Drizzle runtime, reglas de negocio inline |
 
-Cada capa detalla su propio contrato en su README. Ninguna capa contiene código
-todavía; los READMEs describen dónde vivirá cada cosa cuando se migre.
+Cada capa detalla su propio contrato en su README. `domain/` e `infrastructure/`
+ya contienen código; `application/` y `routes/` describen dónde vivirá cada cosa
+cuando se migre.
 
-## 4. Qué se puede migrar en ARCH-5 (y siguientes)
+## 4. Estado de la migración
 
 Migración incremental, **un paso por PR**, siempre detrás de contratos y con tests
-verdes:
+verdes. Cada carpeta materializa código **sólo cuando hay algo real que la habite**
+— nunca carpetas/barrels vacíos por dogma.
 
-- **ARCH-5 — Extraer 1 helper de dominio puro.** Mover un helper puro (candidato:
-  `sla-breach.ts` o `time-window.ts`, los más chicos y sin dependencias) de
-  `server/lib/logistics/` a `server/features/logistics/domain/`, con su test,
-  comportamiento idéntico. Valida la regla "domain sin framework".
-- **ARCH-6 — Extraer 1 application service detrás de una ruta existente.** Sacar un
-  caso de uso de un god-handler (candidato: parte de `logistics-route-plans`) a
-  `server/features/logistics/application/`, detrás del contrato por-ruta existente;
-  el handler queda thin. Valida la regla "routes/http delega".
-- **ARCH-7 — Auditoría de eventos (opcional).** Sólo si ARCH-5..6 revelan fan-out
-  real. Si no, documentar "no eventos" y cerrar.
+- **ARCH-5 (hecho)** — `route-plan-field-visits.ts` movido a `domain/`.
+- **ARCH-7 (hecho)** — `pagination.ts` extraído a `domain/`.
+- **ARCH-8 (hecho)** — barrel público `domain/index.ts`.
+- **M02b (este PR)** — `time-window.ts` y el núcleo puro de `sla-breach.ts` movidos a
+  `domain/`; el adaptador de DB de SLA (`markOverdueSlaBreachesWithDb`) a
+  `infrastructure/sla-breach-db.ts`. `server/lib/logistics/{time-window,sla-breach}.ts`
+  eliminados.
+- **M03/M04 (pendiente)** — mover `route-planning.ts` y `metrics.ts` desde
+  `server/lib/logistics/` a `domain/`.
+- **Application / routes (pendiente)** — extraer un caso de uso de un god-handler a
+  `application/` y dejar el handler thin; sólo cuando haya código real que lo habite.
 
-Cada carpeta materializa código **sólo cuando hay algo real que la habite** — nunca
-carpetas/barrels vacíos por dogma.
+## 5. Qué NO se mueve en M02b
 
-## 5. Qué NO se debe mover todavía
-
-- **No** mover `server/lib/logistics/*` a este directorio en este PR.
-- **No** mover `server/db-logistics.ts`.
+- **No** mover `server/lib/logistics/{metrics,route-planning}.ts` (M03/M04).
+- **No** mover `server/db-logistics.ts` (legacy; candidato a repositorio en M12).
 - **No** tocar `server/routes/logistics-*.fastify.ts`.
-- **No** crear `index.ts`, barrels, re-exports, services vacíos ni puertos/interfaces vacíos.
+- **No** crear services vacíos ni puertos/interfaces vacíos.
 - **No** introducir event bus.
 - **No** fragmentar `drizzle/schema.ts` ni tocar migraciones.
 - **No** cambiar auth/security/middlewares.
@@ -116,4 +134,5 @@ la red de seguridad que habilita reorganizar sin cambiar comportamiento.
 - [ARCH-1 — Repository Domain Architecture Audit](../../../docs/audit/repository-domain-architecture-audit.md) — documento rector: clasifica Logistics como piloto.
 - [ARCH-2 — Backend Domain Boundary ADR](../../../docs/architecture/backend-boundary-adr.md) — reglas de dependencia por capa y secuencia de migración.
 - [ARCH-3 — Shared / Lib Boundary Inventory](../../../docs/architecture/shared-lib-boundary-inventory.md) — inventario a nivel de archivo del terreno a migrar.
-- [Nota de implementación — ARCH-4 shell](../../../docs/implementation/logistics-domain-shell.md) — objetivo, alcance y guardrails de este PR.
+- [Nota de implementación — ARCH-4 shell](../../../docs/implementation/logistics-domain-shell.md) — objetivo, alcance y guardrails del shell.
+- [Nota de implementación — M02b](../../../docs/implementation/m02b-logistics-sla-time-window-domain-move.md) — mueve `time-window` y el núcleo puro de `sla-breach` a `domain/`, y el adaptador de DB a `infrastructure/`.

--- a/server/features/logistics/domain/README.md
+++ b/server/features/logistics/domain/README.md
@@ -1,13 +1,13 @@
 # Logistics · domain (reglas puras)
 
-> Capa **domain** del contexto Logistics. Docs-only: hoy no contiene código.
+> Capa **domain** del contexto Logistics. **Contiene código** desde ARCH-5.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
 ## Responsabilidad
 
 Reglas de negocio **puras** de logística: cálculo de ventanas de tiempo,
-planificación de rutas, detección de breach de SLA y métricas. Sin efectos
+planificación de rutas, detección de breach de SLA y paginación. Sin efectos
 secundarios, sin I/O, sin framework. Determinista y testeable en aislamiento.
 
 ## Regla de dependencia
@@ -19,15 +19,35 @@ secundarios, sin I/O, sin framework. Determinista y testeable en aislamiento.
 - La dependencia apunta hacia adentro: `domain` no conoce el transporte HTTP ni el
   motor de persistencia. `infrastructure` depende de `domain`, nunca al revés.
 
-## Qué vivirá aquí (futuro, no ahora)
+Verificado por `test/architecture/logistics-domain-boundary-guard.test.ts`, que
+además exige que todo consumidor runtime importe el dominio por el barrel público
+(`index.ts`), nunca un archivo interno.
 
-Los helpers puros que hoy están en `server/lib/logistics/`
-(`metrics`, `route-planning`, `sla-breach`, `time-window`) ya cumplen esta regla
-(importan sólo tipos de schema). En **ARCH-5** se migrará **uno** de ellos aquí,
-con su test, comportamiento idéntico. No se crea ningún archivo hasta que haya
-código real que mover.
+## Qué vive aquí
+
+Cada archivo materializa código real (nunca stubs por dogma):
+
+- **`pagination.ts`** (ARCH-7) — `LOGISTICS_DEFAULT_LIMIT`, `LOGISTICS_MAX_LIMIT`,
+  `normalizeLogisticsLimit`, `normalizeLogisticsOffset`.
+- **`route-plan-field-visits.ts`** (ARCH-5) — `normalizeGenerateHeuristicFieldVisitIds`.
+- **`time-window.ts`** (M02b) — `DEFAULT_TIME_WINDOW_TIMEZONE`,
+  `TIME_WINDOW_TIMEZONE_MAX_LENGTH`, `isValidTimeWindowRange`,
+  `normalizeTimeWindowTimezone`, `assertValidTimeWindowRange`. Sin imports (100% puro).
+- **`sla-breach.ts`** (M02b) — núcleo puro `markOverdueSlaBreaches` más sus tipos de
+  dominio (`MarkOverdueSlaBreachesInput/Deps/Result/Notification`,
+  `MarkOverdueSlaInstancesParams`). El tipo de las instancias marcadas es opaco
+  (`TInstance`), de modo que el dominio sólo importa el tipo `SlaTargetType` del
+  shared kernel y no se acopla al schema de fila de `slaInstances`. El adaptador con
+  `db-*` (`markOverdueSlaBreachesWithDb`) vive en `../infrastructure/sla-breach-db.ts`,
+  **no aquí**.
+
+## Barrel público
+
+`index.ts` re-exporta la API anterior sin transformarla y es el único punto de
+entrada del dominio. No re-exporta el adaptador de infraestructura.
 
 ## Qué NO hacer
 
-No mover `server/lib/logistics/*` en el PR del shell. No crear stubs, interfaces ni
-barrels vacíos.
+No importar `db-*`, Drizzle runtime, `fastify`, `env` ni I/O. No crear stubs,
+interfaces ni barrels vacíos. `metrics.ts` y `route-planning.ts` siguen en
+`server/lib/logistics/` y se migrarán en M03/M04.

--- a/server/features/logistics/domain/index.ts
+++ b/server/features/logistics/domain/index.ts
@@ -1,10 +1,17 @@
 // Logistics · domain (barrel público)
 //
-// Superficie pública del contexto `logistics/domain`: re-exporta los helpers
-// puros existentes sin agregar lógica ni cambiar su comportamiento. ARCH-8
-// consolida los exports de `route-plan-field-visits.ts` (ARCH-5) y
-// `pagination.ts` (ARCH-7) en un único punto de entrada para que el resto del
-// backend consuma el dominio sin conocer sus archivos internos.
+// Superficie pública del contexto `logistics/domain`: re-exporta los helpers y
+// tipos puros existentes sin agregar lógica ni cambiar su comportamiento. Es el
+// único punto de entrada que el resto del backend debe consumir; nadie fuera de
+// `domain/` importa sus archivos internos (garantizado por
+// `logistics-domain-boundary-guard`).
+//
+// - ARCH-5 · `route-plan-field-visits.ts`
+// - ARCH-7 · `pagination.ts`
+// - M02b   · `time-window.ts` y el núcleo puro `sla-breach.ts`
+//
+// El adaptador de DB de SLA (`markOverdueSlaBreachesWithDb`) NO se re-exporta
+// aquí: vive en `../infrastructure/sla-breach-db.ts` porque conoce `db-*`.
 
 export { normalizeGenerateHeuristicFieldVisitIds } from "./route-plan-field-visits.ts";
 
@@ -14,3 +21,20 @@ export {
   normalizeLogisticsLimit,
   normalizeLogisticsOffset,
 } from "./pagination.ts";
+
+export {
+  DEFAULT_TIME_WINDOW_TIMEZONE,
+  TIME_WINDOW_TIMEZONE_MAX_LENGTH,
+  assertValidTimeWindowRange,
+  isValidTimeWindowRange,
+  normalizeTimeWindowTimezone,
+} from "./time-window.ts";
+
+export { markOverdueSlaBreaches } from "./sla-breach.ts";
+export type {
+  MarkOverdueSlaBreachesDeps,
+  MarkOverdueSlaBreachesInput,
+  MarkOverdueSlaBreachesNotification,
+  MarkOverdueSlaBreachesResult,
+  MarkOverdueSlaInstancesParams,
+} from "./sla-breach.ts";

--- a/server/features/logistics/domain/sla-breach.ts
+++ b/server/features/logistics/domain/sla-breach.ts
@@ -1,24 +1,42 @@
-import type {
-  MarkOverdueActiveClinicSlaInstancesBreachedParams,
-  SlaInstance,
-} from "../../db-logistics.ts";
-import type { SlaTargetType } from "../../../drizzle/schema.ts";
+// Logistics · domain (reglas puras)
+//
+// Núcleo puro de marcado de breach de SLA: valida la entrada, resuelve los
+// defaults contra un reloj inyectado, delega el marcado de instancias en una
+// dependencia inyectada y, si hubo breaches, dispara un hook opcional de
+// notificación. Determinístico respecto de sus dependencias, sin I/O, sin
+// framework y sin persistencia.
+//
+// Esta lógica vivía en `server/lib/logistics/sla-breach.ts` mezclada con un
+// adaptador de DB. M02b separa el núcleo puro (aquí) del adaptador con `db-*`
+// (`server/features/logistics/infrastructure/sla-breach-db.ts`). El dominio no
+// conoce Drizzle, `db-logistics.ts` ni ninguna persistencia: el tipo de las
+// instancias marcadas es opaco (`TInstance`), de forma que el dominio sólo las
+// cuenta y las reenvía sin acoplarse al schema de fila de `slaInstances`.
 
-export type MarkOverdueSlaBreachesNotification = {
+import type { SlaTargetType } from "../../../../drizzle/schema.ts";
+
+export type MarkOverdueSlaInstancesParams = {
   clinicId: number;
-  breachedCount: number;
-  breachedInstances: SlaInstance[];
   dueAtOrBefore: Date;
   breachedAt: Date;
   targetType?: SlaTargetType;
 };
 
-export type MarkOverdueSlaBreachesDeps = {
+export type MarkOverdueSlaBreachesNotification<TInstance> = {
+  clinicId: number;
+  breachedCount: number;
+  breachedInstances: TInstance[];
+  dueAtOrBefore: Date;
+  breachedAt: Date;
+  targetType?: SlaTargetType;
+};
+
+export type MarkOverdueSlaBreachesDeps<TInstance> = {
   markOverdueActiveClinicSlaInstancesBreached: (
-    params: MarkOverdueActiveClinicSlaInstancesBreachedParams,
-  ) => Promise<SlaInstance[]>;
+    params: MarkOverdueSlaInstancesParams,
+  ) => Promise<TInstance[]>;
   notifySlaBreaches?: (
-    notification: MarkOverdueSlaBreachesNotification,
+    notification: MarkOverdueSlaBreachesNotification<TInstance>,
   ) => Promise<void>;
   now?: () => Date;
 };
@@ -30,15 +48,11 @@ export type MarkOverdueSlaBreachesInput = {
   targetType?: SlaTargetType;
 };
 
-export type MarkOverdueSlaBreachesResult = {
+export type MarkOverdueSlaBreachesResult<TInstance> = {
   breachedCount: number;
-  breachedInstances: SlaInstance[];
+  breachedInstances: TInstance[];
   dueAtOrBefore: Date;
   breachedAt: Date;
-};
-
-export type MarkOverdueSlaBreachesWithDbOptions = {
-  now?: () => Date;
 };
 
 function assertValidDate(value: Date, fieldName: string): void {
@@ -53,10 +67,10 @@ function assertValidClinicId(clinicId: number): void {
   }
 }
 
-export async function markOverdueSlaBreaches(
+export async function markOverdueSlaBreaches<TInstance>(
   input: MarkOverdueSlaBreachesInput,
-  deps: MarkOverdueSlaBreachesDeps,
-): Promise<MarkOverdueSlaBreachesResult> {
+  deps: MarkOverdueSlaBreachesDeps<TInstance>,
+): Promise<MarkOverdueSlaBreachesResult<TInstance>> {
   assertValidClinicId(input.clinicId);
 
   const now = deps.now ?? (() => new Date());
@@ -94,18 +108,4 @@ export async function markOverdueSlaBreaches(
     dueAtOrBefore,
     breachedAt,
   };
-}
-
-export async function markOverdueSlaBreachesWithDb(
-  input: MarkOverdueSlaBreachesInput,
-  options: MarkOverdueSlaBreachesWithDbOptions = {},
-): Promise<MarkOverdueSlaBreachesResult> {
-  const { markOverdueActiveClinicSlaInstancesBreached } = await import(
-    "../../db-logistics.ts"
-  );
-
-  return markOverdueSlaBreaches(input, {
-    markOverdueActiveClinicSlaInstancesBreached,
-    now: options.now,
-  });
 }

--- a/server/features/logistics/domain/time-window.ts
+++ b/server/features/logistics/domain/time-window.ts
@@ -1,3 +1,14 @@
+// Logistics · domain (reglas puras)
+//
+// Reglas puras de ventanas de tiempo de una visita de campo: valida el rango
+// `[windowStart, windowEnd)` y normaliza el `timezone`. Determinística, sin I/O,
+// sin framework y sin persistencia — sólo transforma la entrada en la salida.
+//
+// Esta lógica vivía en `server/lib/logistics/time-window.ts`. M02b la mueve al
+// contexto `logistics/domain` manteniendo el comportamiento observable idéntico:
+// `db-logistics.ts` la sigue invocando con el mismo nombre, ahora vía el barrel
+// público del dominio.
+
 export const DEFAULT_TIME_WINDOW_TIMEZONE = "UTC";
 export const TIME_WINDOW_TIMEZONE_MAX_LENGTH = 64;
 

--- a/server/features/logistics/infrastructure/README.md
+++ b/server/features/logistics/infrastructure/README.md
@@ -1,6 +1,7 @@
 # Logistics · infrastructure (implementación de puertos)
 
-> Capa **infrastructure** del contexto Logistics. Docs-only: hoy no contiene código.
+> Capa **infrastructure** del contexto Logistics. **Contiene código** desde M02b:
+> un adaptador transitorio de DB para el breach de SLA.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -12,10 +13,21 @@ de persistencia y el I/O real del contexto.
 
 ## Regla de dependencia
 
-- **Puede importar:** `domain` (para implementar sus puertos), el shared kernel, el
-  runtime de Drizzle y clientes externos.
+- **Puede importar:** `domain` (para implementar sus puertos, vía su barrel público),
+  el shared kernel, el runtime de Drizzle y clientes externos (incluido `db-*`).
 - **No puede importar:** `routes/http` ni `application` (no invierte la dirección de
   la dependencia).
+
+## Qué vive aquí
+
+- **`sla-breach-db.ts`** (M02b) — adaptador **transitorio** que cablea el núcleo puro
+  `markOverdueSlaBreaches` (importado del barrel de `domain`) con la persistencia real
+  de `server/db-logistics.ts`. Conserva el import dinámico (lazy) de
+  `markOverdueActiveClinicSlaInstancesBreached` y expone `markOverdueSlaBreachesWithDb`
+  sin duplicar la lógica de negocio: es el único lugar del contexto que conoce el
+  `db-*`. Su existencia **no** implica mover `server/db-logistics.ts` ni adelantar
+  M12; cuando M12 formalice el repositorio sobre puertos, este adaptador se reemplaza
+  por esa infraestructura.
 
 ## Qué vivirá aquí (futuro, no ahora)
 
@@ -23,7 +35,7 @@ El candidato natural a repositorio del contexto es `server/db-logistics.ts` (~1.
 LOC), único `db-*` que ya delega en helpers de dominio (`time-window`,
 `route-planning`); y la cache `server/lib/logistics-route-plans-cache.ts`. Su
 migración es **posterior** a la extracción de un puerto en `application` que les dé
-forma. **No se mueve `db-logistics.ts` en el PR del shell** ni en ARCH-5.
+forma. **`db-logistics.ts` sigue siendo legacy y fuera de alcance en M02b.**
 
 ## Qué NO hacer
 

--- a/server/features/logistics/infrastructure/sla-breach-db.ts
+++ b/server/features/logistics/infrastructure/sla-breach-db.ts
@@ -1,0 +1,37 @@
+// Logistics · infrastructure (adaptador de DB)
+//
+// Adaptador que cablea el núcleo puro de breach de SLA
+// (`server/features/logistics/domain/sla-breach.ts`, consumido vía barrel) con
+// la persistencia real de `server/db-logistics.ts`. Es el único lugar que conoce
+// el `db-*`: carga `markOverdueActiveClinicSlaInstancesBreached` mediante un
+// import dinámico (lazy) y delega en `markOverdueSlaBreaches`, sin duplicar la
+// lógica de negocio.
+//
+// Adaptador transitorio: cuando M12 formalice el repositorio de Logistics sobre
+// puertos, este archivo se reemplazará por esa infraestructura. No implica
+// mover `server/db-logistics.ts` en M02b.
+
+import {
+  markOverdueSlaBreaches,
+  type MarkOverdueSlaBreachesInput,
+  type MarkOverdueSlaBreachesResult,
+} from "../domain/index.ts";
+import type { SlaInstance } from "../../../db-logistics.ts";
+
+export type MarkOverdueSlaBreachesWithDbOptions = {
+  now?: () => Date;
+};
+
+export async function markOverdueSlaBreachesWithDb(
+  input: MarkOverdueSlaBreachesInput,
+  options: MarkOverdueSlaBreachesWithDbOptions = {},
+): Promise<MarkOverdueSlaBreachesResult<SlaInstance>> {
+  const { markOverdueActiveClinicSlaInstancesBreached } = await import(
+    "../../../db-logistics.ts"
+  );
+
+  return markOverdueSlaBreaches(input, {
+    markOverdueActiveClinicSlaInstancesBreached,
+    now: options.now,
+  });
+}

--- a/test/unit/domain/logistics/logistics-domain-barrel.test.ts
+++ b/test/unit/domain/logistics/logistics-domain-barrel.test.ts
@@ -2,11 +2,17 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  DEFAULT_TIME_WINDOW_TIMEZONE,
   LOGISTICS_DEFAULT_LIMIT,
   LOGISTICS_MAX_LIMIT,
+  TIME_WINDOW_TIMEZONE_MAX_LENGTH,
+  assertValidTimeWindowRange,
+  isValidTimeWindowRange,
+  markOverdueSlaBreaches,
   normalizeGenerateHeuristicFieldVisitIds,
   normalizeLogisticsLimit,
   normalizeLogisticsOffset,
+  normalizeTimeWindowTimezone,
 } from "../../../../server/features/logistics/domain/index.ts";
 
 test("logistics domain barrel re-exports the pagination helpers unchanged", () => {
@@ -26,5 +32,81 @@ test("logistics domain barrel re-exports the route-plan field visit id normalize
   assert.deepEqual(
     normalizeGenerateHeuristicFieldVisitIds([0, -1, 5, 2.5, Number.NaN, 7]),
     [5, 7],
+  );
+});
+
+test("logistics domain barrel re-exports the time-window helpers unchanged", () => {
+  assert.equal(DEFAULT_TIME_WINDOW_TIMEZONE, "UTC");
+  assert.equal(TIME_WINDOW_TIMEZONE_MAX_LENGTH, 64);
+
+  assert.equal(
+    isValidTimeWindowRange(
+      new Date("2026-05-03T10:00:00.000Z"),
+      new Date("2026-05-03T11:00:00.000Z"),
+    ),
+    true,
+  );
+  assert.equal(
+    isValidTimeWindowRange(
+      new Date("2026-05-03T11:00:00.000Z"),
+      new Date("2026-05-03T10:00:00.000Z"),
+    ),
+    false,
+  );
+
+  assert.equal(normalizeTimeWindowTimezone(undefined), "UTC");
+  assert.equal(
+    normalizeTimeWindowTimezone(" America/Argentina/Cordoba "),
+    "America/Argentina/Cordoba",
+  );
+
+  assert.throws(
+    () =>
+      assertValidTimeWindowRange(
+        new Date("2026-05-03T10:00:00.000Z"),
+        new Date("2026-05-03T10:00:00.000Z"),
+      ),
+    /windowStart must be earlier than windowEnd/,
+  );
+});
+
+test("logistics domain barrel re-exports the pure SLA breach core unchanged", async () => {
+  const calls: unknown[] = [];
+  const now = new Date("2026-05-05T00:00:00.000Z");
+
+  const result = await markOverdueSlaBreaches(
+    { clinicId: 9 },
+    {
+      now: () => now,
+      markOverdueActiveClinicSlaInstancesBreached: async (params) => {
+        calls.push(params);
+        return [];
+      },
+      notifySlaBreaches: async () => {
+        throw new Error("must not notify when there are no breaches");
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 0);
+  assert.deepEqual(result.breachedInstances, []);
+  assert.equal(result.dueAtOrBefore, now);
+  assert.equal(result.breachedAt, now);
+  assert.deepEqual(calls, [
+    {
+      clinicId: 9,
+      dueAtOrBefore: now,
+      breachedAt: now,
+      targetType: undefined,
+    },
+  ]);
+
+  await assert.rejects(
+    () =>
+      markOverdueSlaBreaches(
+        { clinicId: 0 },
+        { markOverdueActiveClinicSlaInstancesBreached: async () => [] },
+      ),
+    /clinicId debe ser un entero positivo/,
   );
 });

--- a/test/unit/domain/logistics/logistics-sla-breach.test.ts
+++ b/test/unit/domain/logistics/logistics-sla-breach.test.ts
@@ -1,0 +1,215 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  markOverdueSlaBreaches,
+  type MarkOverdueSlaBreachesDeps,
+} from "../../../../server/features/logistics/domain/index.ts";
+
+function createSlaInstanceFixture() {
+  return {
+    id: 1,
+    clinicId: 7,
+    policyId: 3,
+    targetType: "field_visit",
+    targetId: 11,
+    status: "breached",
+    startedAt: new Date("2026-05-01T10:00:00.000Z"),
+    dueAt: new Date("2026-05-01T12:00:00.000Z"),
+    breachedAt: new Date("2026-05-01T12:30:00.000Z"),
+    resolvedAt: null,
+    pausedAt: null,
+    metadata: null,
+    createdAt: new Date("2026-05-01T10:00:00.000Z"),
+    updatedAt: new Date("2026-05-01T12:30:00.000Z"),
+  };
+}
+
+type SlaInstanceFixture = ReturnType<typeof createSlaInstanceFixture>;
+
+test("SLA breach domain marks overdue active instances with explicit cutoff and breach time", async () => {
+  const calls: unknown[] = [];
+  const fixture = createSlaInstanceFixture();
+
+  const deps: MarkOverdueSlaBreachesDeps<SlaInstanceFixture> = {
+    markOverdueActiveClinicSlaInstancesBreached: async (params) => {
+      calls.push(params);
+      return [fixture as any];
+    },
+  };
+
+  const dueAtOrBefore = new Date("2026-05-01T12:30:00.000Z");
+  const breachedAt = new Date("2026-05-01T12:45:00.000Z");
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 7,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+    deps,
+  );
+
+  assert.equal(result.breachedCount, 1);
+  assert.deepEqual(result.breachedInstances, [fixture]);
+  assert.equal(result.dueAtOrBefore, dueAtOrBefore);
+  assert.equal(result.breachedAt, breachedAt);
+  assert.deepEqual(calls, [
+    {
+      clinicId: 7,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+  ]);
+});
+
+test("SLA breach domain defaults cutoff and breach time to injected now", async () => {
+  const calls: unknown[] = [];
+  const now = new Date("2026-05-05T00:00:00.000Z");
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 9,
+    },
+    {
+      now: () => now,
+      markOverdueActiveClinicSlaInstancesBreached: async (params) => {
+        calls.push(params);
+        return [];
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 0);
+  assert.deepEqual(result.breachedInstances, []);
+  assert.equal(result.dueAtOrBefore, now);
+  assert.equal(result.breachedAt, now);
+  assert.deepEqual(calls, [
+    {
+      clinicId: 9,
+      dueAtOrBefore: now,
+      breachedAt: now,
+      targetType: undefined,
+    },
+  ]);
+});
+
+test("SLA breach domain rejects invalid injected now before DB writes", async () => {
+  let writes = 0;
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches(
+      {
+        clinicId: 1,
+      },
+      {
+        now: () => new Date("invalid"),
+        markOverdueActiveClinicSlaInstancesBreached: async () => {
+          writes += 1;
+          return [];
+        },
+      },
+    );
+  }, /now invalido/);
+
+  assert.equal(writes, 0);
+});
+
+test("SLA breach domain rejects invalid clinic ids and invalid dates before DB writes", async () => {
+  let writes = 0;
+
+  const deps: MarkOverdueSlaBreachesDeps<SlaInstanceFixture> = {
+    now: () => new Date("2026-05-05T00:00:00.000Z"),
+    markOverdueActiveClinicSlaInstancesBreached: async () => {
+      writes += 1;
+      return [];
+    },
+  };
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches({ clinicId: 0 }, deps);
+  }, /clinicId debe ser un entero positivo/);
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches(
+      {
+        clinicId: 1,
+        dueAtOrBefore: new Date("invalid"),
+      },
+      deps,
+    );
+  }, /dueAtOrBefore invalido/);
+
+  await assert.rejects(async () => {
+    await markOverdueSlaBreaches(
+      {
+        clinicId: 1,
+        breachedAt: new Date("invalid"),
+      },
+      deps,
+    );
+  }, /breachedAt invalido/);
+
+  assert.equal(writes, 0);
+});
+
+test("SLA breach domain notifies marked breaches with escalation payload", async () => {
+  const fixture = createSlaInstanceFixture();
+  const dueAtOrBefore = new Date("2026-05-01T12:30:00.000Z");
+  const breachedAt = new Date("2026-05-01T12:45:00.000Z");
+  const notifications: unknown[] = [];
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 7,
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+    {
+      markOverdueActiveClinicSlaInstancesBreached: async () => [
+        fixture as any,
+      ],
+      notifySlaBreaches: async (notification) => {
+        notifications.push(notification);
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 1);
+  assert.deepEqual(notifications, [
+    {
+      clinicId: 7,
+      breachedCount: 1,
+      breachedInstances: [fixture],
+      dueAtOrBefore,
+      breachedAt,
+      targetType: "field_visit",
+    },
+  ]);
+});
+
+test("SLA breach domain skips notification hook when no breaches are marked", async () => {
+  let notifications = 0;
+
+  const result = await markOverdueSlaBreaches(
+    {
+      clinicId: 7,
+      dueAtOrBefore: new Date("2026-05-01T12:30:00.000Z"),
+      breachedAt: new Date("2026-05-01T12:45:00.000Z"),
+      targetType: "route_plan",
+    },
+    {
+      markOverdueActiveClinicSlaInstancesBreached: async () => [],
+      notifySlaBreaches: async () => {
+        notifications += 1;
+      },
+    },
+  );
+
+  assert.equal(result.breachedCount, 0);
+  assert.deepEqual(result.breachedInstances, []);
+  assert.equal(notifications, 0);
+});

--- a/test/unit/infrastructure/logistics/logistics-sla-breach-runtime.test.ts
+++ b/test/unit/infrastructure/logistics/logistics-sla-breach-runtime.test.ts
@@ -2,233 +2,33 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import { readFileSync } from "node:fs";
 
-import {
-  markOverdueSlaBreaches,
-  markOverdueSlaBreachesWithDb,
-  type MarkOverdueSlaBreachesDeps,
-} from "../../../../server/lib/logistics/sla-breach.ts";
+import { markOverdueSlaBreachesWithDb } from "../../../../server/features/logistics/infrastructure/sla-breach-db.ts";
 
-const slaBreachSource = readFileSync(
-  new URL("../../../../server/lib/logistics/sla-breach.ts", import.meta.url),
+const slaBreachDbSource = readFileSync(
+  new URL(
+    "../../../../server/features/logistics/infrastructure/sla-breach-db.ts",
+    import.meta.url,
+  ),
   "utf8",
 );
 
-function createSlaInstanceFixture() {
-  return {
-    id: 1,
-    clinicId: 7,
-    policyId: 3,
-    targetType: "field_visit",
-    targetId: 11,
-    status: "breached",
-    startedAt: new Date("2026-05-01T10:00:00.000Z"),
-    dueAt: new Date("2026-05-01T12:00:00.000Z"),
-    breachedAt: new Date("2026-05-01T12:30:00.000Z"),
-    resolvedAt: null,
-    pausedAt: null,
-    metadata: null,
-    createdAt: new Date("2026-05-01T10:00:00.000Z"),
-    updatedAt: new Date("2026-05-01T12:30:00.000Z"),
-  };
-}
-
-test("SLA breach runtime marks overdue active instances with explicit cutoff and breach time", async () => {
-  const calls: unknown[] = [];
-  const fixture = createSlaInstanceFixture();
-
-  const deps: MarkOverdueSlaBreachesDeps = {
-    markOverdueActiveClinicSlaInstancesBreached: async (params) => {
-      calls.push(params);
-      return [fixture as any];
-    },
-  };
-
-  const dueAtOrBefore = new Date("2026-05-01T12:30:00.000Z");
-  const breachedAt = new Date("2026-05-01T12:45:00.000Z");
-
-  const result = await markOverdueSlaBreaches(
-    {
-      clinicId: 7,
-      dueAtOrBefore,
-      breachedAt,
-      targetType: "field_visit",
-    },
-    deps,
-  );
-
-  assert.equal(result.breachedCount, 1);
-  assert.deepEqual(result.breachedInstances, [fixture]);
-  assert.equal(result.dueAtOrBefore, dueAtOrBefore);
-  assert.equal(result.breachedAt, breachedAt);
-  assert.deepEqual(calls, [
-    {
-      clinicId: 7,
-      dueAtOrBefore,
-      breachedAt,
-      targetType: "field_visit",
-    },
-  ]);
-});
-
-test("SLA breach runtime defaults cutoff and breach time to injected now", async () => {
-  const calls: unknown[] = [];
-  const now = new Date("2026-05-05T00:00:00.000Z");
-
-  const result = await markOverdueSlaBreaches(
-    {
-      clinicId: 9,
-    },
-    {
-      now: () => now,
-      markOverdueActiveClinicSlaInstancesBreached: async (params) => {
-        calls.push(params);
-        return [];
-      },
-    },
-  );
-
-  assert.equal(result.breachedCount, 0);
-  assert.deepEqual(result.breachedInstances, []);
-  assert.equal(result.dueAtOrBefore, now);
-  assert.equal(result.breachedAt, now);
-  assert.deepEqual(calls, [
-    {
-      clinicId: 9,
-      dueAtOrBefore: now,
-      breachedAt: now,
-      targetType: undefined,
-    },
-  ]);
-});
-
-test("SLA breach runtime rejects invalid injected now before DB writes", async () => {
-  let writes = 0;
-
-  await assert.rejects(async () => {
-    await markOverdueSlaBreaches(
-      {
-        clinicId: 1,
-      },
-      {
-        now: () => new Date("invalid"),
-        markOverdueActiveClinicSlaInstancesBreached: async () => {
-          writes += 1;
-          return [];
-        },
-      },
-    );
-  }, /now invalido/);
-
-  assert.equal(writes, 0);
-});
-
-test("SLA breach runtime rejects invalid clinic ids and invalid dates before DB writes", async () => {
-  let writes = 0;
-
-  const deps: MarkOverdueSlaBreachesDeps = {
-    now: () => new Date("2026-05-05T00:00:00.000Z"),
-    markOverdueActiveClinicSlaInstancesBreached: async () => {
-      writes += 1;
-      return [];
-    },
-  };
-
-  await assert.rejects(async () => {
-    await markOverdueSlaBreaches({ clinicId: 0 }, deps);
-  }, /clinicId debe ser un entero positivo/);
-
-  await assert.rejects(async () => {
-    await markOverdueSlaBreaches(
-      {
-        clinicId: 1,
-        dueAtOrBefore: new Date("invalid"),
-      },
-      deps,
-    );
-  }, /dueAtOrBefore invalido/);
-
-  await assert.rejects(async () => {
-    await markOverdueSlaBreaches(
-      {
-        clinicId: 1,
-        breachedAt: new Date("invalid"),
-      },
-      deps,
-    );
-  }, /breachedAt invalido/);
-
-  assert.equal(writes, 0);
-});
-
-test("SLA breach runtime DB-wired entrypoint imports DB helper lazily and delegates through runtime service", () => {
+test("SLA breach runtime DB-wired entrypoint imports DB helper lazily and delegates through the domain core", () => {
   assert.equal(typeof markOverdueSlaBreachesWithDb, "function");
 
   assert.match(
-    slaBreachSource,
-    /const\s+\{\s*markOverdueActiveClinicSlaInstancesBreached\s*\}\s*=\s*await\s+import\(\s*"\.\.\/\.\.\/db-logistics\.ts"\s*\)/,
+    slaBreachDbSource,
+    /const\s+\{\s*markOverdueActiveClinicSlaInstancesBreached\s*\}\s*=\s*await\s+import\(\s*"\.\.\/\.\.\/\.\.\/db-logistics\.ts"\s*\)/,
   );
 
   assert.match(
-    slaBreachSource,
+    slaBreachDbSource,
     /return\s+markOverdueSlaBreaches\(\s*input,\s*\{\s*markOverdueActiveClinicSlaInstancesBreached,\s*now:\s*options\.now,\s*\}\s*\)/,
   );
 });
 
-test("SLA breach runtime notifies marked breaches with escalation payload", async () => {
-  const fixture = createSlaInstanceFixture();
-  const dueAtOrBefore = new Date("2026-05-01T12:30:00.000Z");
-  const breachedAt = new Date("2026-05-01T12:45:00.000Z");
-  const notifications: unknown[] = [];
-
-  const result = await markOverdueSlaBreaches(
-    {
-      clinicId: 7,
-      dueAtOrBefore,
-      breachedAt,
-      targetType: "field_visit",
-    },
-    {
-      markOverdueActiveClinicSlaInstancesBreached: async () => [
-        fixture as any,
-      ],
-      notifySlaBreaches: async (notification) => {
-        notifications.push(notification);
-      },
-    },
+test("SLA breach runtime DB adapter consumes the domain core through the public barrel", () => {
+  assert.match(
+    slaBreachDbSource,
+    /import\s+\{[^}]*markOverdueSlaBreaches[^}]*\}\s+from\s+"\.\.\/domain\/index\.ts"/s,
   );
-
-  assert.equal(result.breachedCount, 1);
-  assert.deepEqual(notifications, [
-    {
-      clinicId: 7,
-      breachedCount: 1,
-      breachedInstances: [fixture],
-      dueAtOrBefore,
-      breachedAt,
-      targetType: "field_visit",
-    },
-  ]);
-});
-
-test("SLA breach runtime skips notification hook when no breaches are marked", async () => {
-  let notifications = 0;
-
-  const result = await markOverdueSlaBreaches(
-    {
-      clinicId: 7,
-      dueAtOrBefore: new Date("2026-05-01T12:30:00.000Z"),
-      breachedAt: new Date("2026-05-01T12:45:00.000Z"),
-      targetType: "route_plan",
-    },
-    {
-      markOverdueActiveClinicSlaInstancesBreached: async () => [],
-      notifySlaBreaches: async () => {
-        notifications += 1;
-      },
-    },
-  );
-
-  assert.equal(result.breachedCount, 0);
-  assert.deepEqual(result.breachedInstances, []);
-  assert.equal(notifications, 0);
 });

--- a/test/unit/migrations/logistics/logistics-time-windows-schema.test.ts
+++ b/test/unit/migrations/logistics/logistics-time-windows-schema.test.ts
@@ -9,7 +9,7 @@ import {
   assertValidTimeWindowRange,
   isValidTimeWindowRange,
   normalizeTimeWindowTimezone,
-} from "../../../../server/lib/logistics/time-window.ts";
+} from "../../../../server/features/logistics/domain/index.ts";
 
 test("logistics schema exports time windows table", () => {
   assert.equal(typeof timeWindows, "object");


### PR DESCRIPTION
## Summary

- Change type: backend modularization / Logistics domain move.
- Context: Fase A — M02b del Backend Enterprise Modularization Program.
- What changed:
  - se mueve `time-window` al dominio Logistics;
  - se separa `sla-breach` en un núcleo puro de dominio y un adaptador DB transitorio;
  - se actualiza el barrel público;
  - se alinean importadores, tests anclados y documentación del contexto.
- Program document: `docs/audit/backend-enterprise-modularization-program-audit.md`.
- Implementation document: `docs/implementation/m02b-logistics-sla-time-window-domain-move.md`.

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception

## Architectural Decision

`time-window.ts` era dominio puro y se trasladó sin modificar su comportamiento.

`sla-breach.ts` no podía moverse íntegramente porque contenía tipos y un import dinámico hacia `db-logistics.ts`. Se separó en:

- `features/logistics/domain/sla-breach.ts`: núcleo puro y dependencias inyectadas;
- `features/logistics/infrastructure/sla-breach-db.ts`: adaptador DB con lazy import.

El dominio no importa `db-*`, Fastify, Drizzle runtime, env ni I/O.

No se conserva shim legacy porque el censo confirmó cero consumidores runtime de los paths eliminados.

## Files

Domain:

- `server/features/logistics/domain/sla-breach.ts`
- `server/features/logistics/domain/time-window.ts`
- `server/features/logistics/domain/index.ts`

Infrastructure:

- `server/features/logistics/infrastructure/sla-breach-db.ts`

Legacy paths removed:

- `server/lib/logistics/sla-breach.ts`
- `server/lib/logistics/time-window.ts`

Consumer alignment:

- `server/db-logistics.ts`

Tests and documentation were updated as supporting changes to the primary backend scope.

## Contracts Preserved

- Timezone default remains `UTC`.
- Timezone trimming and 64-character cap remain unchanged.
- Time-window validation and exact error message remain unchanged.
- SLA clinic/date validation and exact error messages remain unchanged.
- The injected clock semantics remain unchanged.
- DB marking occurs before optional notification.
- Notification occurs only when breaches exist.
- Notification payload remains unchanged.
- The DB adapter preserves the lazy import.
- No query, mapping, transaction, route or HTTP contract changed.

## Validation

- [x] Directed Logistics tests — PASSED: 50 passed, 0 failed.
- [x] `pnpm validate:local` — PASSED.
- [x] Full suite — 3140 tests, 3139 passed, 1 preexisting skip, 0 failed.
- [x] Backend build — PASSED.
- [x] `git diff --check` — PASSED.
- [x] Logistics domain boundary guard — PASSED.
- [x] No test case was removed.
- [x] No dependency or lockfile change.
- [x] No schema or migration change.
- [x] No generated artifact included.
- [ ] Required GitHub status checks pending.

## Security / Regression Checklist

- [x] Authentication, authorization, sessions and cookies unchanged.
- [x] CORS, CSP, rate limits and security headers unchanged.
- [x] Public routes and endpoint contracts unchanged.
- [x] Database queries and transactions unchanged.
- [x] Schema and migrations unchanged.
- [x] Frontend unchanged.
- [x] CI/workflows unchanged.
- [x] No production or staging access.
- [x] No secret exposure.
- [x] No architecture guard was weakened.

## Test Count Explanation

M02b does not reduce test coverage. Existing SLA behavior was redistributed between domain and infrastructure tests, and barrel coverage was extended. The resulting suite increases to 3140 total tests.

## Rollback

- Trigger: domain-boundary regression, import incompatibility, behavioral divergence or an omitted legacy consumer.
- Steps: revert the single M02b commit.
- The revert restores both legacy modules, their imports and their test anchors.
- Data impact: none.
- Schema impact: none.
- Runtime configuration impact: none.
- The rollback is independent from M01 and M02.

## Readiness

M02b completes the first move of Fase A. M03 (`route-planning`) remains outside this PR and requires a new individual R2 authorization.