### PR TITLE
refactor(logistics): extract route-plans application use cases (M07)

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -700,14 +700,25 @@ docs. *(M02b+M03 fusionables → mínima 40.)*
 lifecycle (`cancel`) · **M09** UC field-visits (asignación + estados) · **M10** UC route-events ·
 **M11** guard application + suite UCs + closeout de capa.
 
-> **Status de ejecución (2026-07-19):** **M06 — implementado / cerrado al merge.**
+> **Status de ejecución (2026-07-19):** **M06 — implementado / cerrado (#1502).**
 > Fase B iniciada: primer caso de uso de application materializado
 > (`server/features/logistics/application/list-overdue-active-sla-instances.ts`)
 > con puerto mínimo de lectura derivado del seam `LogisticsSlaNativeRoutesOptions`
 > (§2.5) y adaptador compuesto en la ruta; el handler `/overdue` delega en el UC
-> sin cambio de contrato HTTP. M07 — no iniciado. Detalle en
+> sin cambio de contrato HTTP. Detalle en
 > [`docs/implementation/m06-logistics-sla-overdue-use-case.md`](../implementation/m06-logistics-sla-overdue-use-case.md).
-> Esta anotación es status, no altera el conteo recomendado, riesgos, grafo,
+>
+> **M07 — implementado / cerrado al merge.** Casos de uso de lectura de planes de
+> ruta (`route-plans-read-use-cases.ts`: list/get/listStops) y de generación
+> heurística (`generate-heuristic-route-plan.ts`), con puertos mínimos
+> `LogisticsRoutePlansReadRepository` y `LogisticsRoutePlanGenerator` derivados del
+> seam `LogisticsRoutePlansNativeRoutesOptions`; los 5 handlers de lectura/heuristic
+> de `logistics-route-plans.fastify.ts` delegan en los UC. Cache, auditoría de
+> lifecycle, timing, serialización, validaciones, escrituras (M08) y `db-logistics.ts`
+> intactos. M08 — no iniciado. Detalle en
+> [`docs/implementation/m07-logistics-route-plans-read-heuristic-use-cases.md`](../implementation/m07-logistics-route-plans-read-heuristic-use-cases.md).
+>
+> Estas anotaciones son status, no alteran el conteo recomendado, riesgos, grafo,
 > invariantes ni conclusiones.
 
 **Fase C — Logistics infra + rutas (6):**

--- a/docs/implementation/m07-logistics-route-plans-read-heuristic-use-cases.md
+++ b/docs/implementation/m07-logistics-route-plans-read-heuristic-use-cases.md
@@ -1,0 +1,209 @@
+# M07 — Casos de uso de lectura de route-plans + generate-heuristic (Fase B de Logistics)
+
+> **Tipo:** Extracción de casos de uso (application) + puertos mínimos, detrás de
+> los contratos por-ruta existentes. **Cero cambios de comportamiento observable.**
+> **Scope primario:** backend runtime + tests + documentación de apoyo.
+
+## 1. Base exacta
+
+- **Rama:** `refactor/backend-modularization-m07-logistics-route-plans-read-heuristic-use-cases`.
+- **Base `main` / HEAD:** `89af3cb3724625494513198f20f9be6f5cd09c34`
+  — refactor(logistics): extract SLA overdue use case (M06) (#1502).
+- **Working tree inicial:** limpio · **Índice inicial:** vacío.
+- **Documento rector:** `docs/audit/backend-enterprise-modularization-program-audit.md`
+  (ID `ARCH-AUDIT-110`), §8 Fase B.
+
+## 2. Autorización
+
+R2 explícita de Nico para M07: "auditar e implementar exclusivamente los casos de
+uso Logistics route-plans de lectura y generate-heuristic definidos por el
+documento rector y el seam existente, preservando HTTP, auth, sesiones, permisos,
+CORS, cache, auditoría, DB, queries, transacciones, schema y comportamiento
+observable; sin iniciar M08 ni milestones posteriores". No cubre M08+.
+
+## 3. Objetivo
+
+Extraer, hacia `server/features/logistics/application/`, los casos de uso de
+lectura de planes de ruta (list, detalle, stops, y las dos lecturas que alimentan
+metrics) y el de generación heurística, delegando en puertos mínimos derivados
+del seam `LogisticsRoutePlansNativeRoutesOptions`, preservando exactamente el
+comportamiento observable de `server/routes/logistics-route-plans.fastify.ts`.
+
+## 4. Scope incluido
+
+- Puerto de lectura `LogisticsRoutePlansReadRepository` (3 operaciones:
+  `listClinicRoutePlans`, `getClinicScopedRoutePlan`,
+  `listRouteStopsForClinicRoutePlan`) y puerto `LogisticsRoutePlanGenerator`
+  (`generateHeuristicRoutePlan`).
+- Casos de uso `createRoutePlansReadUseCases` (list/get/listStops) y
+  `createGenerateHeuristicRoutePlan`.
+- Adaptación de 5 handlers de la ruta para delegar: `GET /`, `GET /:routePlanId`,
+  `GET /:routePlanId/metrics`, `GET /:routePlanId/stops`, `POST /heuristic`.
+- Tests unitarios nuevos; actualización del contrato de fuente de la ruta.
+- Documentación: README de application, esta nota y status §8 del rector.
+
+## 5. Scope excluido
+
+- Escrituras (`POST /`, `PATCH /:routePlanId`, stops create/update, lifecycle
+  release/start/complete/cancel): siguen llamando a `deps.*` directamente (M08).
+- Sin cambios en `db-logistics.ts`, queries, transacciones, cache
+  (`logistics-route-plans-cache.ts`), auditoría, schema ni migraciones.
+- Sin DI container, repositories genéricos, unit of work, event bus ni archivo de
+  `infrastructure`.
+- Sin mover cálculo de metrics (ya es dominio `calculateRouteStopComplianceMetrics`)
+  ni tocar el domain.
+- Sin guard nuevo en `test/architecture/**` (llega en M11).
+
+## 6. Estado previo
+
+- Fase B iniciada en M06 (`application/` con el UC SLA overdue).
+- Los 5 handlers de lectura/heuristic invocaban `deps.*` directamente tras auth →
+  permisos → parsing (y cache/timing donde aplica).
+- Seam existente `LogisticsRoutePlansNativeRoutesOptions` con las deps de lectura
+  y `generateHeuristicRoutePlan`; carga default lazy desde `db-logistics.ts` en
+  `loadDefaultDeps`.
+
+## 7. Diseño de los puertos
+
+`ports/logistics-route-plans-read-repository.ts`:
+
+- `LogisticsRoutePlansReadRepository<TRoutePlan, TRouteStop, TListParams>` con las
+  3 operaciones de lectura. Genérico: en la ruta se infieren `RoutePlan`,
+  `RouteStop` y `ListRoutePlansParams` sin casts; no importa `db-logistics.ts` ni
+  `drizzle/schema.ts`. `getClinicScopedRoutePlan` conserva `| null | undefined`
+  para preservar el `if (!routePlan) → 404`.
+
+`ports/logistics-route-plan-generator.ts`:
+
+- `LogisticsRoutePlanGenerator<TInput, TResult>` con una sola operación;
+  `TInput`/`TResult` opacos (la validación de input y el mapeo de rechazo/error
+  viven en la ruta). Cero imports en ambos puertos, sin `any`.
+
+## 8. Diseño de los casos de uso
+
+`route-plans-read-use-cases.ts`:
+
+- `createRoutePlansReadUseCases(repository)` → `{ listRoutePlans, getRoutePlan,
+  listRoutePlanStops }`. Cada método delega exactamente una vez y devuelve el
+  resultado del puerto por identidad, sin mapear, clonar ni capturar errores.
+
+`generate-heuristic-route-plan.ts`:
+
+- `createGenerateHeuristicRoutePlan(generator)` → `(input) => Promise<TResult>`.
+  Una sola delegación; preserva el resultado (éxito o rechazo `reason`) por
+  identidad y propaga el error original.
+
+`index.ts` exporta la superficie M07 junto a la de M06, sin exports preventivos.
+
+## 9. Adaptación desde `LogisticsRoutePlansNativeRoutesOptions`
+
+Tras resolver `deps`, en el cuerpo del plugin (una sola vez, no por request):
+
+```ts
+const routePlansRead = createRoutePlansReadUseCases({
+  listClinicRoutePlans: deps.listClinicRoutePlans,
+  getClinicScopedRoutePlan: deps.getClinicScopedRoutePlan,
+  listRouteStopsForClinicRoutePlan: deps.listRouteStopsForClinicRoutePlan,
+});
+const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan({
+  generateHeuristicRoutePlan: deps.generateHeuristicRoutePlan,
+});
+```
+
+Los handlers pasan a llamar `routePlansRead.listRoutePlans/getRoutePlan/
+listRoutePlanStops` y `generateHeuristicRoutePlan`. Todo lo demás (auth,
+permisos, `enforceTrustedOrigin` para heuristic, parsing/400, cache get/set y
+`X-Logistics-Cache`, `createRuntimeTimer`/`planningDurationMs`, invalidación de
+cache tras generar, serialización, 404, envelope) permanece intacto. La carga
+default desde `db-logistics.ts` no se movió.
+
+## 10. Cambios por archivo
+
+- `server/features/logistics/application/ports/logistics-route-plans-read-repository.ts` — **CREATED**.
+- `server/features/logistics/application/ports/logistics-route-plan-generator.ts` — **CREATED**.
+- `server/features/logistics/application/route-plans-read-use-cases.ts` — **CREATED**.
+- `server/features/logistics/application/generate-heuristic-route-plan.ts` — **CREATED**.
+- `server/features/logistics/application/index.ts` — **MODIFIED** (barrel: superficie M07).
+- `server/features/logistics/application/README.md` — **MODIFIED** (sección M07).
+- `server/routes/logistics-route-plans.fastify.ts` — **MODIFIED** (import del barrel,
+  composición de los dos adaptadores, delegación de los 5 handlers de
+  lectura/heuristic). Escrituras y lifecycle intactos.
+- `test/unit/application/logistics/route-plans-read-use-cases.test.ts` — **CREATED**.
+- `test/unit/application/logistics/generate-heuristic-route-plan.test.ts` — **CREATED**.
+- `test/integration/adapters/controllers/logistics-route-plans-api.test.ts` — **MODIFIED**
+  (asserts de lectura/heuristic → delegación; contrato de delegación M07; frontera
+  de imports de application).
+- `docs/implementation/m07-logistics-route-plans-read-heuristic-use-cases.md` — **CREATED**.
+- `docs/audit/backend-enterprise-modularization-program-audit.md` — **MODIFIED** (status §8).
+
+Tests de runtime **sin cambios** y verdes: `logistics-route-plans-cache-runtime`,
+`-metrics-runtime`, `-heuristic-runtime`, `logistics-audit-runtime` (los stubs por
+Options siguen invocándose una sola vez a través de los casos de uso).
+
+## 11. Contratos HTTP preservados
+
+Sin cambios en: endpoints/métodos/prefijo, status codes (200/201/400/403/404),
+payloads (`routePlans`/`routePlan`/`routeStops`/`planning`/`metrics`/`pagination`),
+header `X-Logistics-Cache` (HIT/MISS), `planningDurationMs`, `missingFieldVisitIds`,
+textos de error, CORS/OPTIONS, `enforceTrustedOrigin` para heuristic, auth,
+sesiones, permisos (`canManageLogisticsRoutePlans` bajo métodos unsafe), scope
+clínico, cache TTL/keys, orden de auditoría de lifecycle, DB/queries/transacciones
+y schema. Las validaciones (fechas, tolerancias, `MAX_ROUTE_PLAN_FIELD_VISIT_IDS`)
+siguen antes de la llamada al caso de uso.
+
+## 12. Tests
+
+- **Unit (nuevos):** forwarding exacto por identidad (params, id/clinicId, input y
+  su `fieldVisitIds`), una sola delegación por método, retorno por identidad
+  (`strictEqual`), propagación de `null`, propagación del error original y del
+  resultado de rechazo `reason`, y frontera de imports de application.
+- **Contrato de fuente (actualizado):** import por barrel; composición de ambos
+  puertos antes de los handlers; cada `deps.<op>` de lectura/heuristic sólo en la
+  zona de composición (no dentro de handlers, verificado por `lastIndexOf < handlersStart`);
+  handlers delegan en los casos de uso; carga default `dbLogistics.*` presente;
+  escrituras siguen en `deps.*`; application sin imports HTTP/DB.
+- **Runtime (sin cambios):** cache HIT/MISS, metrics, heuristic (timing, warnings,
+  missing ids, invalidación) y auditoría de lifecycle verdes.
+
+## 13. Validaciones (estados canónicos)
+
+| Gate | Comando | Estado |
+| --- | --- | --- |
+| 1 — unitarios nuevos | `pnpm exec tsx --test <2 unit>` | PASSED (12/12) |
+| 2 — dirigidos M07 | unit + api + cache/metrics/heuristic/audit runtime | PASSED (55/55) |
+| 3 — `pnpm validate:local` | typecheck + typecheck:test + test + build | PASSED (ver reporte) |
+| 4 — `pnpm security:public-surface` | — | PASSED (ver reporte) |
+| 5 — PR Governance local | requiere evento PR/`workflow_dispatch` con HEAD commiteado | BLOCKED |
+| 6 — `git diff --check` | — | PASSED (ver reporte) |
+| 7 — scope y artefactos | — | PASSED (ver reporte) |
+
+## 14. Riesgos residuales
+
+- El contrato de delegación usa `indexOf("app.options(")` como frontera
+  composición/handlers; si M14 (thin route) reordena la composición o los handlers,
+  se realinea en el mismo PR (patrón asumido por los source-contracts del repo).
+- Los puertos son estructurales/genéricos: un cambio de firma en las deps de
+  lectura o en `GenerateHeuristic*` se propaga por inferencia (falla typecheck, no
+  runtime).
+- La capa application aún no tiene guard propio (M11); la frontera la fijan los
+  tests unitarios y el contrato de fuente.
+
+## 15. Rollback independiente
+
+Revert de un único PR: los 5 handlers vuelven a invocar `deps.*` inline, se retiran
+los 4 archivos de application de M07 y sus tests, y se restauran los asserts
+previos del contrato. No depende de revertir M06 ni afecta `db-logistics.ts`,
+cache, auditoría ni ninguna otra ruta. Mismo `dist/index.js` en deploy.
+
+## 16. Estado final
+
+M07 implementado: la capa application aloja los casos de uso de lectura de
+route-plans y de generación heurística; los 5 handlers delegan; comportamiento
+observable idéntico; gates locales verdes (Governance BLOCKED por diseño hasta que
+exista PR).
+
+## 17. Readiness
+
+- **M07: cerrado** (al merge de este PR).
+- **M08 (UC route-plans escritura + lifecycle `cancel`): no autorizado y no
+  iniciado.** Cada milestone posterior requiere autorización R2 propia.

--- a/server/features/logistics/application/README.md
+++ b/server/features/logistics/application/README.md
@@ -1,7 +1,8 @@
 # Logistics · application (orquestación)
 
-> Capa **application** del contexto Logistics. **Contiene código** desde M06:
-> el primer caso de uso real (SLA lectura/overdue) y su puerto mínimo.
+> Capa **application** del contexto Logistics. **Contiene código** desde M06
+> (primer caso de uso: SLA lectura/overdue) y crece en M07 con los casos de uso
+> de lectura de planes de ruta y de generación heurística.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -32,6 +33,28 @@ El adaptador real del puerto se construye **en la ruta**
 `deps`; la carga default desde `db-logistics.ts` sigue viviendo en la zona de
 composición de la ruta, no aquí.
 
+## Qué vive aquí (M07)
+
+- **`route-plans-read-use-cases.ts`** — `createRoutePlansReadUseCases`: agrupa las
+  lecturas de planes de ruta (`listRoutePlans`, `getRoutePlan`,
+  `listRoutePlanStops`) consumidas por los handlers de list, detalle, metrics y
+  stops. Cada método delega exactamente una vez en el puerto y devuelve su
+  resultado sin mutarlo.
+- **`generate-heuristic-route-plan.ts`** — `createGenerateHeuristicRoutePlan`:
+  caso de uso de generación heurística; delega una vez en el puerto generador y
+  preserva tal cual el resultado de éxito o rechazo del dominio.
+- **`ports/logistics-route-plans-read-repository.ts`** —
+  `LogisticsRoutePlansReadRepository`, genérico sobre plan/stop/params, derivado
+  del seam `LogisticsRoutePlansNativeRoutesOptions`.
+- **`ports/logistics-route-plan-generator.ts`** — `LogisticsRoutePlanGenerator`,
+  con `TInput`/`TResult` opacos.
+
+El timing (`planningDurationMs`), la cache de listas/metrics, la invalidación de
+cache tras generar, la serialización, el mapeo de rechazo/error y las
+validaciones (400) permanecen en `server/routes/logistics-route-plans.fastify.ts`.
+Los adaptadores se componen una sola vez por registro del plugin desde `deps`.
+Las escrituras (create/update/lifecycle) siguen en la ruta y son M08.
+
 ## Regla de dependencia
 
 - **Puede importar:** `domain`, **puertos** (interfaces) y el shared kernel.
@@ -44,16 +67,17 @@ composición de la ruta, no aquí.
   serialización permanecen en `routes`. La persistencia concreta permanece fuera
   de application.
 
-Frontera fijada por
-`test/unit/application/logistics/list-overdue-active-sla-instances.test.ts` y por
-el contrato de fuente
-`test/integration/adapters/controllers/logistics-sla-routes-api.test.ts`.
+Frontera fijada por los tests unitarios de application en
+`test/unit/application/logistics/` y por los contratos de fuente
+`test/integration/adapters/controllers/logistics-sla-routes-api.test.ts` y
+`logistics-route-plans-api.test.ts`.
 
 ## Qué vendrá después (no ahora)
 
-M07–M11 (casos de uso de route-plans, field-visits, route-events, guard de capa y
-closeout) **no están iniciados**. Cada puerto nuevo se introduce junto con su
-primer consumidor real — nunca como interfaz vacía anticipada.
+M08–M11 (casos de uso de route-plans escritura + lifecycle, field-visits,
+route-events, guard de capa y closeout) **no están iniciados**. Cada puerto nuevo
+se introduce junto con su primer consumidor real — nunca como interfaz vacía
+anticipada.
 
 ## Qué NO hacer
 

--- a/server/features/logistics/application/generate-heuristic-route-plan.ts
+++ b/server/features/logistics/application/generate-heuristic-route-plan.ts
@@ -1,0 +1,16 @@
+import type { LogisticsRoutePlanGenerator } from "./ports/logistics-route-plan-generator.ts";
+
+export type GenerateHeuristicRoutePlan<TInput, TResult> = (
+  input: TInput,
+) => Promise<TResult>;
+
+// Caso de uso M07: genera un plan de ruta heurístico. Recibe un input ya
+// autenticado y validado desde la ruta, delega exactamente una vez en el puerto
+// generador y devuelve su resultado (éxito o rechazo del dominio) sin mutarlo,
+// propagando los errores del generador sin envolverlos. El timing, la
+// invalidación de cache y la serialización permanecen en la ruta.
+export function createGenerateHeuristicRoutePlan<TInput, TResult>(
+  generator: LogisticsRoutePlanGenerator<TInput, TResult>,
+): GenerateHeuristicRoutePlan<TInput, TResult> {
+  return (input) => generator.generateHeuristicRoutePlan(input);
+}

--- a/server/features/logistics/application/index.ts
+++ b/server/features/logistics/application/index.ts
@@ -1,6 +1,6 @@
 // Barrel público de la capa application de Logistics. Expone únicamente la
-// superficie de M06 (caso de uso SLA overdue + su puerto de lectura); sin
-// exports preventivos para milestones futuros.
+// superficie ya materializada (M06 SLA overdue + M07 route-plans lectura y
+// generate-heuristic); sin exports preventivos para milestones futuros.
 
 export {
   createListOverdueActiveSlaInstances,
@@ -10,3 +10,15 @@ export type {
   ListOverdueActiveSlaInstancesInput,
   LogisticsSlaReadRepository,
 } from "./ports/logistics-sla-read-repository.ts";
+
+export {
+  createRoutePlansReadUseCases,
+  type RoutePlansReadUseCases,
+} from "./route-plans-read-use-cases.ts";
+export type { LogisticsRoutePlansReadRepository } from "./ports/logistics-route-plans-read-repository.ts";
+
+export {
+  createGenerateHeuristicRoutePlan,
+  type GenerateHeuristicRoutePlan,
+} from "./generate-heuristic-route-plan.ts";
+export type { LogisticsRoutePlanGenerator } from "./ports/logistics-route-plan-generator.ts";

--- a/server/features/logistics/application/ports/logistics-route-plan-generator.ts
+++ b/server/features/logistics/application/ports/logistics-route-plan-generator.ts
@@ -1,0 +1,9 @@
+// Puerto mínimo de generación heurística de planes de ruta del contexto
+// Logistics (M07). Una sola operación semántica, derivada del seam
+// `LogisticsRoutePlansNativeRoutesOptions`. `TInput`/`TResult` quedan opacos
+// para application: la validación de entrada y el mapeo de rechazo/error viven
+// en la ruta; la persistencia y el cálculo concreto, en infrastructure.
+
+export type LogisticsRoutePlanGenerator<TInput, TResult> = {
+  generateHeuristicRoutePlan: (input: TInput) => Promise<TResult>;
+};

--- a/server/features/logistics/application/ports/logistics-route-plans-read-repository.ts
+++ b/server/features/logistics/application/ports/logistics-route-plans-read-repository.ts
@@ -1,0 +1,23 @@
+// Puerto mínimo de lectura de planes de ruta del contexto Logistics (M07).
+// Modela únicamente las operaciones de lectura consumidas por los casos de uso
+// de lectura (list, detalle, stops, metrics) y se deriva del seam
+// `LogisticsRoutePlansNativeRoutesOptions`
+// (server/routes/logistics-route-plans.fastify.ts). Los genéricos mantienen la
+// inferencia estricta del adapter real sin filtrar tipos concretos de DB ni del
+// schema hacia application.
+
+export type LogisticsRoutePlansReadRepository<
+  TRoutePlan,
+  TRouteStop,
+  TListParams,
+> = {
+  listClinicRoutePlans: (params: TListParams) => Promise<TRoutePlan[]>;
+  getClinicScopedRoutePlan: (
+    id: number,
+    clinicId: number,
+  ) => Promise<TRoutePlan | null | undefined>;
+  listRouteStopsForClinicRoutePlan: (
+    routePlanId: number,
+    clinicId: number,
+  ) => Promise<TRouteStop[]>;
+};

--- a/server/features/logistics/application/route-plans-read-use-cases.ts
+++ b/server/features/logistics/application/route-plans-read-use-cases.ts
@@ -1,0 +1,30 @@
+import type { LogisticsRoutePlansReadRepository } from "./ports/logistics-route-plans-read-repository.ts";
+
+export type RoutePlansReadUseCases<TRoutePlan, TRouteStop, TListParams> = {
+  listRoutePlans: (params: TListParams) => Promise<TRoutePlan[]>;
+  getRoutePlan: (
+    id: number,
+    clinicId: number,
+  ) => Promise<TRoutePlan | null | undefined>;
+  listRoutePlanStops: (
+    routePlanId: number,
+    clinicId: number,
+  ) => Promise<TRouteStop[]>;
+};
+
+// Casos de uso de lectura de planes de ruta (M07). Cada método recibe datos ya
+// autenticados, validados y clinic-scoped desde la ruta, delega exactamente una
+// vez en el puerto de lectura y devuelve su resultado sin mutarlo, propagando
+// los errores del puerto sin envolverlos. Cero HTTP, cero cache, cero
+// serialización.
+export function createRoutePlansReadUseCases<TRoutePlan, TRouteStop, TListParams>(
+  repository: LogisticsRoutePlansReadRepository<TRoutePlan, TRouteStop, TListParams>,
+): RoutePlansReadUseCases<TRoutePlan, TRouteStop, TListParams> {
+  return {
+    listRoutePlans: (params) => repository.listClinicRoutePlans(params),
+    getRoutePlan: (id, clinicId) =>
+      repository.getClinicScopedRoutePlan(id, clinicId),
+    listRoutePlanStops: (routePlanId, clinicId) =>
+      repository.listRouteStopsForClinicRoutePlan(routePlanId, clinicId),
+  };
+}

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -51,6 +51,10 @@ import {
 import { createRuntimeTimer } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import {
+  createGenerateHeuristicRoutePlan,
+  createRoutePlansReadUseCases,
+} from "../features/logistics/application/index.ts";
+import {
   clearRoutePlanMetricsCacheByPlan,
   clearRoutePlansCacheByClinic,
   getCachedRoutePlanMetricsSnapshot,
@@ -1467,6 +1471,19 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       })),
   };
 
+  // Adaptadores M07: los puertos de lectura y de generación heurística de
+  // application se construyen una sola vez por registro del plugin desde el seam
+  // de deps ya resuelto (no por request). La carga default desde db-logistics.ts
+  // sigue viviendo en loadDefaultDeps.
+  const routePlansRead = createRoutePlansReadUseCases({
+    listClinicRoutePlans: deps.listClinicRoutePlans,
+    getClinicScopedRoutePlan: deps.getClinicScopedRoutePlan,
+    listRouteStopsForClinicRoutePlan: deps.listRouteStopsForClinicRoutePlan,
+  });
+  const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan({
+    generateHeuristicRoutePlan: deps.generateHeuristicRoutePlan,
+  });
+
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
 
@@ -1556,7 +1573,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     }
 
     const planningTimer = createRuntimeTimer();
-    const result = await deps.generateHeuristicRoutePlan(parsed.input);
+    const result = await generateHeuristicRoutePlan(parsed.input);
     const planningDurationMs = planningTimer.elapsedMs();
 
     if (result.reason) {
@@ -1668,7 +1685,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       return reply.code(200).send(cachedSnapshot);
     }
 
-    const routePlans = await deps.listClinicRoutePlans(params);
+    const routePlans = await routePlansRead.listRoutePlans(params);
     const snapshot: RoutePlansListSnapshot = {
       success: true,
       count: routePlans.length,
@@ -1767,7 +1784,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routePlan = await deps.getClinicScopedRoutePlan(
+    const routePlan = await routePlansRead.getRoutePlan(
       routePlanId,
       auth.clinicId,
     );
@@ -1905,11 +1922,11 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     }
 
     const [routePlan, routeStops] = await Promise.all([
-      deps.getClinicScopedRoutePlan(
+      routePlansRead.getRoutePlan(
         routePlanId,
         auth.clinicId,
       ),
-      deps.listRouteStopsForClinicRoutePlan(
+      routePlansRead.listRoutePlanStops(
         routePlanId,
         auth.clinicId,
       ),
@@ -1974,7 +1991,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routeStops = await deps.listRouteStopsForClinicRoutePlan(
+    const routeStops = await routePlansRead.listRoutePlanStops(
       routePlanId,
       auth.clinicId,
     );

--- a/test/architecture/security/security-validation-cutoff-boundaries.test.ts
+++ b/test/architecture/security/security-validation-cutoff-boundaries.test.ts
@@ -321,7 +321,7 @@ test("logistics heuristic route validates fieldVisitIds bound before planning ex
       "const parsed = buildGenerateHeuristicRoutePlanInput(",
       "if (!parsed.input) {",
       "return reply.code(400).send({",
-      "const result = await deps.generateHeuristicRoutePlan(parsed.input);",
+      "const result = await generateHeuristicRoutePlan(parsed.input);",
     ],
     "logistics heuristic validation cut-off",
   );

--- a/test/integration/adapters/controllers/logistics-route-plans-api.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-plans-api.test.ts
@@ -68,8 +68,8 @@ test("logistics route plans API wires route stop DB helpers through injectable d
 
 test("logistics route plans API keeps all route plan operations clinic scoped", () => {
   assert.match(routeSource, /clinicId: auth\.clinicId/);
-  assert.match(routeSource, /deps\.listClinicRoutePlans\(params\)/);
-  assert.match(routeSource, /deps\.getClinicScopedRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /routePlansRead\.listRoutePlans\(params\)/);
+  assert.match(routeSource, /routePlansRead\.getRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
   assert.match(routeSource, /deps\.updateClinicScopedRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*parsed\.input,\s*\)/);
 });
 
@@ -148,7 +148,7 @@ test("logistics route plans API exposes heuristic generation endpoint", () => {
   assert.match(routeSource, /app\.options\("\/heuristic", optionsHandler\)/);
   assert.match(routeSource, /app\.post<[\s\S]*>\("\/heuristic", async/);
   assert.match(routeSource, /buildGenerateHeuristicRoutePlanInput/);
-  assert.match(routeSource, /deps\.generateHeuristicRoutePlan\(parsed\.input\)/);
+  assert.match(routeSource, /await generateHeuristicRoutePlan\(parsed\.input\)/);
   assert.match(routeSource, /createRuntimeTimer/);
   assert.match(routeSource, /planningDurationMs/);
   assert.match(routeSource, /planning:\s*{\s*mode: "heuristic"/);
@@ -181,7 +181,7 @@ test("logistics route plans API validates heuristic generation input before DB c
 test("logistics route plans API keeps heuristic planning call behind 400 validation cut-off", () => {
   assert.match(
     routeSource,
-    /const parsed = buildGenerateHeuristicRoutePlanInput\([\s\S]*?if \(!parsed\.input\) {[\s\S]*?return reply\.code\(400\)\.send\({[\s\S]*?}\);\s*}\s*const planningTimer = createRuntimeTimer\(\);\s*const result = await deps\.generateHeuristicRoutePlan\(parsed\.input\);/,
+    /const parsed = buildGenerateHeuristicRoutePlanInput\([\s\S]*?if \(!parsed\.input\) {[\s\S]*?return reply\.code\(400\)\.send\({[\s\S]*?}\);\s*}\s*const planningTimer = createRuntimeTimer\(\);\s*const result = await generateHeuristicRoutePlan\(parsed\.input\);/,
   );
 });
 
@@ -198,8 +198,8 @@ test("logistics route plans API exposes route compliance metrics endpoint", () =
   assert.match(routeSource, /RouteStopComplianceInput/);
   assert.match(routeSource, /buildRouteStopComplianceInputs/);
   assert.match(routeSource, /"\/:routePlanId\/metrics"/);
-  assert.match(routeSource, /deps\.getClinicScopedRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
-  assert.match(routeSource, /deps\.listRouteStopsForClinicRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /routePlansRead\.getRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /routePlansRead\.listRoutePlanStops\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
   assert.match(routeSource, /metrics: calculateRouteStopComplianceMetrics\(metricInputs\.inputs\)/);
 });
 
@@ -227,4 +227,106 @@ test("logistics route plans API audits lifecycle transitions", () => {
   assert.match(routeSource, /await deps\.writeAuditLog\(createAuditRequestLike\(request, auth\),/);
   assert.match(routeSource, /routePlanId,/);
   assert.match(routeSource, /action,/);
+});
+
+test("logistics route plans API delegates read and heuristic flows to the M07 application use cases", () => {
+  // 1. La ruta importa los casos de uso desde el barrel de application.
+  assert.match(
+    routeSource,
+    /import \{\s*createGenerateHeuristicRoutePlan,\s*createRoutePlansReadUseCases,\s*\} from "\.\.\/features\/logistics\/application\/index\.ts";/,
+  );
+
+  // 2. Los puertos se adaptan desde el seam LogisticsRoutePlansNativeRoutesOptions
+  //    (deps ya resueltas), una sola vez a nivel plugin, antes de registrar
+  //    handlers.
+  const readCompositionPattern =
+    /const routePlansRead = createRoutePlansReadUseCases\(\{\s*listClinicRoutePlans:\s*deps\.listClinicRoutePlans,\s*getClinicScopedRoutePlan:\s*deps\.getClinicScopedRoutePlan,\s*listRouteStopsForClinicRoutePlan:\s*deps\.listRouteStopsForClinicRoutePlan,\s*\}\);/;
+  const heuristicCompositionPattern =
+    /const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan\(\{\s*generateHeuristicRoutePlan:\s*deps\.generateHeuristicRoutePlan,\s*\}\);/;
+  assert.match(routeSource, readCompositionPattern);
+  assert.match(routeSource, heuristicCompositionPattern);
+
+  const handlersStart = routeSource.indexOf("app.options(");
+  assert.ok(handlersStart > 0, "no se encontró la región de handlers");
+  assert.ok(
+    routeSource.search(readCompositionPattern) < handlersStart,
+    "la composición de lecturas debe ocurrir antes de los handlers",
+  );
+  assert.ok(
+    routeSource.search(heuristicCompositionPattern) < handlersStart,
+    "la composición del generador debe ocurrir antes de los handlers",
+  );
+
+  // 3–4. Ningún handler invoca directamente las deps de lectura/heuristic: cada
+  //      `deps.<op>` de estas cuatro operaciones sólo aparece en la zona de
+  //      composición (antes de los handlers). La adaptación desde deps es legítima.
+  for (const op of [
+    "deps.listClinicRoutePlans",
+    "deps.getClinicScopedRoutePlan",
+    "deps.listRouteStopsForClinicRoutePlan",
+    "deps.generateHeuristicRoutePlan",
+  ]) {
+    assert.ok(
+      routeSource.lastIndexOf(op) < handlersStart,
+      `${op} no debe invocarse dentro de un handler (sólo en composición)`,
+    );
+  }
+
+  // Los handlers delegan en los casos de uso.
+  assert.match(routeSource, /await routePlansRead\.listRoutePlans\(params\)/);
+  assert.match(routeSource, /await routePlansRead\.getRoutePlan\(/);
+  assert.match(routeSource, /routePlansRead\.listRoutePlanStops\(/);
+  assert.match(routeSource, /await generateHeuristicRoutePlan\(parsed\.input\)/);
+
+  // 5. La carga default desde db-logistics sigue existiendo en el loader.
+  assert.match(routeSource, /dbLogistics\.listClinicRoutePlans/);
+  assert.match(routeSource, /dbLogistics\.getClinicScopedRoutePlan/);
+  assert.match(routeSource, /dbLogistics\.listRouteStopsForClinicRoutePlan/);
+  assert.match(routeSource, /dbLogistics\.generateHeuristicRoutePlan/);
+
+  // Las escrituras (M08) siguen llamando a deps directamente.
+  assert.match(routeSource, /await deps\.createRoutePlan\(/);
+  assert.match(routeSource, /await deps\.updateClinicScopedRoutePlan\(/);
+  assert.match(routeSource, /await deps\.transitionClinicScopedRoutePlanStatus\(/);
+});
+
+test("logistics route plans application layer (M07) stays free of HTTP and DB imports", () => {
+  const applicationFiles = [
+    "server/features/logistics/application/route-plans-read-use-cases.ts",
+    "server/features/logistics/application/generate-heuristic-route-plan.ts",
+    "server/features/logistics/application/ports/logistics-route-plans-read-repository.ts",
+    "server/features/logistics/application/ports/logistics-route-plan-generator.ts",
+  ] as const;
+
+  const forbiddenSpecifierRules: Array<{ label: string; pattern: RegExp }> = [
+    { label: "fastify", pattern: /^fastify(\/|$)/ },
+    { label: "server/db-logistics", pattern: /db-logistics/ },
+    { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+    { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+    { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+    { label: "server/lib", pattern: /(^|\/)lib\// },
+    { label: "server/routes", pattern: /(^|\/)routes\// },
+  ];
+
+  const violations: string[] = [];
+
+  for (const file of applicationFiles) {
+    const source = readFileSync(resolve(process.cwd(), file), "utf8");
+    const specifiers = Array.from(
+      source.matchAll(
+        /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+      ),
+      (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+    );
+
+    for (const specifier of specifiers) {
+      for (const { label, pattern } of forbiddenSpecifierRules) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
 });

--- a/test/unit/application/logistics/generate-heuristic-route-plan.test.ts
+++ b/test/unit/application/logistics/generate-heuristic-route-plan.test.ts
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createGenerateHeuristicRoutePlan,
+  type LogisticsRoutePlanGenerator,
+} from "../../../../server/features/logistics/application/index.ts";
+
+// Tipos de stub propios del test: el caso de uso no conoce Fastify, DB ni el
+// schema. `TInput`/`TResult` son opacos para el caso de uso.
+type StubInput = {
+  clinicId: number;
+  serviceDate: Date;
+  fieldVisitIds: number[];
+};
+
+type StubResult =
+  | { routePlan: { id: number }; warnings: string[]; reason?: undefined }
+  | { routePlan?: undefined; reason: "no_visits" };
+
+function createGeneratorStub(behavior: {
+  result?: StubResult;
+  error?: Error;
+}) {
+  const receivedInputs: StubInput[] = [];
+
+  const generator: LogisticsRoutePlanGenerator<StubInput, StubResult> = {
+    generateHeuristicRoutePlan: (input) => {
+      receivedInputs.push(input);
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(
+            behavior.result ?? { routePlan: { id: 1 }, warnings: [] },
+          );
+    },
+  };
+
+  return { generator, receivedInputs };
+}
+
+test("el caso de uso reenvía el input exacto al generador por identidad y delega una vez", async () => {
+  const input: StubInput = {
+    clinicId: 7,
+    serviceDate: new Date("2026-05-01T00:00:00.000Z"),
+    fieldVisitIds: [11, 22, 33],
+  };
+  const { generator, receivedInputs } = createGeneratorStub({});
+  const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan(generator);
+
+  await generateHeuristicRoutePlan(input);
+
+  assert.equal(receivedInputs.length, 1);
+  assert.strictEqual(receivedInputs[0], input);
+  assert.strictEqual(receivedInputs[0].fieldVisitIds, input.fieldVisitIds);
+});
+
+test("el caso de uso devuelve el resultado del generador por identidad, sin mapear ni clonar", async () => {
+  const result: StubResult = {
+    routePlan: { id: 99 },
+    warnings: ["ventana ajustada"],
+  };
+  const { generator } = createGeneratorStub({ result });
+  const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan(generator);
+
+  const received = await generateHeuristicRoutePlan({
+    clinicId: 7,
+    serviceDate: new Date(),
+    fieldVisitIds: [1],
+  });
+
+  assert.strictEqual(received, result);
+});
+
+test("el caso de uso preserva el resultado de rechazo del dominio sin reinterpretarlo", async () => {
+  const result: StubResult = { reason: "no_visits" };
+  const { generator } = createGeneratorStub({ result });
+  const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan(generator);
+
+  const received = await generateHeuristicRoutePlan({
+    clinicId: 7,
+    serviceDate: new Date(),
+    fieldVisitIds: [],
+  });
+
+  assert.strictEqual(received, result);
+});
+
+test("el caso de uso propaga el error original del generador sin envolverlo", async () => {
+  const originalError = new Error("fallo de generación heurística");
+  const { generator } = createGeneratorStub({ error: originalError });
+  const generateHeuristicRoutePlan = createGenerateHeuristicRoutePlan(generator);
+
+  let caught: unknown;
+
+  await assert.rejects(
+    generateHeuristicRoutePlan({
+      clinicId: 7,
+      serviceDate: new Date(),
+      fieldVisitIds: [1],
+    }),
+    (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    },
+  );
+
+  assert.strictEqual(caught, originalError);
+});
+
+// --- Frontera de dependencias del generador heurístico (M07) ---
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/generate-heuristic-route-plan.ts",
+  "server/features/logistics/application/ports/logistics-route-plan-generator.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("el generador heurístico de M07 no importa HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/route-plans-read-use-cases.test.ts
+++ b/test/unit/application/logistics/route-plans-read-use-cases.test.ts
@@ -1,0 +1,188 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createRoutePlansReadUseCases,
+  type LogisticsRoutePlansReadRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+// Tipos de stub propios del test: el caso de uso es unit-testable sin Fastify,
+// sin DB y sin tipos concretos del schema.
+type StubListParams = {
+  clinicId: number;
+  status?: string;
+  limit: number;
+  offset: number;
+};
+
+type StubRoutePlan = { id: number; clinicId: number; serviceDate: Date };
+type StubRouteStop = { id: number; routePlanId: number; sequence: number };
+
+function createRepositoryStub(behavior: {
+  routePlans?: StubRoutePlan[];
+  routePlan?: StubRoutePlan | null;
+  routeStops?: StubRouteStop[];
+  error?: Error;
+}) {
+  const listParamsCalls: StubListParams[] = [];
+  const getCalls: Array<{ id: number; clinicId: number }> = [];
+  const stopsCalls: Array<{ routePlanId: number; clinicId: number }> = [];
+
+  const repository: LogisticsRoutePlansReadRepository<
+    StubRoutePlan,
+    StubRouteStop,
+    StubListParams
+  > = {
+    listClinicRoutePlans: (params) => {
+      listParamsCalls.push(params);
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.routePlans ?? []);
+    },
+    getClinicScopedRoutePlan: (id, clinicId) => {
+      getCalls.push({ id, clinicId });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.routePlan ?? null);
+    },
+    listRouteStopsForClinicRoutePlan: (routePlanId, clinicId) => {
+      stopsCalls.push({ routePlanId, clinicId });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.routeStops ?? []);
+    },
+  };
+
+  return { repository, listParamsCalls, getCalls, stopsCalls };
+}
+
+test("listRoutePlans reenvía los params exactos por identidad y delega una sola vez", async () => {
+  const params: StubListParams = {
+    clinicId: 7,
+    status: "released",
+    limit: 13,
+    offset: 29,
+  };
+  const { repository, listParamsCalls } = createRepositoryStub({});
+  const useCases = createRoutePlansReadUseCases(repository);
+
+  await useCases.listRoutePlans(params);
+
+  assert.equal(listParamsCalls.length, 1);
+  assert.strictEqual(listParamsCalls[0], params);
+});
+
+test("listRoutePlans devuelve el resultado del puerto por identidad, sin mapear ni clonar", async () => {
+  const routePlans = [{ id: 1, clinicId: 7, serviceDate: new Date() }];
+  const { repository } = createRepositoryStub({ routePlans });
+  const useCases = createRoutePlansReadUseCases(repository);
+
+  const result = await useCases.listRoutePlans({
+    clinicId: 7,
+    limit: 50,
+    offset: 0,
+  });
+
+  assert.strictEqual(result, routePlans);
+  assert.strictEqual(result[0], routePlans[0]);
+});
+
+test("getRoutePlan reenvía id y clinicId, delega una vez y devuelve por identidad", async () => {
+  const serviceDate = new Date("2026-05-01T00:00:00.000Z");
+  const routePlan = { id: 42, clinicId: 7, serviceDate };
+  const { repository, getCalls } = createRepositoryStub({ routePlan });
+  const useCases = createRoutePlansReadUseCases(repository);
+
+  const result = await useCases.getRoutePlan(42, 7);
+
+  assert.equal(getCalls.length, 1);
+  assert.deepEqual(getCalls[0], { id: 42, clinicId: 7 });
+  assert.strictEqual(result, routePlan);
+  assert.strictEqual(result?.serviceDate, serviceDate);
+});
+
+test("getRoutePlan propaga null del puerto sin transformarlo", async () => {
+  const { repository } = createRepositoryStub({ routePlan: null });
+  const useCases = createRoutePlansReadUseCases(repository);
+
+  const result = await useCases.getRoutePlan(404, 7);
+
+  assert.equal(result, null);
+});
+
+test("listRoutePlanStops reenvía routePlanId y clinicId, delega una vez y devuelve por identidad", async () => {
+  const routeStops = [{ id: 5, routePlanId: 42, sequence: 1 }];
+  const { repository, stopsCalls } = createRepositoryStub({ routeStops });
+  const useCases = createRoutePlansReadUseCases(repository);
+
+  const result = await useCases.listRoutePlanStops(42, 7);
+
+  assert.equal(stopsCalls.length, 1);
+  assert.deepEqual(stopsCalls[0], { routePlanId: 42, clinicId: 7 });
+  assert.strictEqual(result, routeStops);
+});
+
+test("los casos de uso de lectura propagan el error original del puerto por identidad", async () => {
+  const originalError = new Error("fallo de lectura route-plans");
+  const { repository } = createRepositoryStub({ error: originalError });
+  const useCases = createRoutePlansReadUseCases(repository);
+
+  for (const invoke of [
+    () => useCases.listRoutePlans({ clinicId: 7, limit: 50, offset: 0 }),
+    () => useCases.getRoutePlan(42, 7),
+    () => useCases.listRoutePlanStops(42, 7),
+  ]) {
+    let caught: unknown;
+    await assert.rejects(invoke(), (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    });
+    assert.strictEqual(caught, originalError);
+  }
+});
+
+// --- Frontera de dependencias de las lecturas de route-plans (M07) ---
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/route-plans-read-use-cases.ts",
+  "server/features/logistics/application/ports/logistics-route-plans-read-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("las lecturas de route-plans de M07 no importan HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

Extracts the Logistics route-plans read operations and heuristic generation into the application layer for milestone M07.

The route keeps ownership of authentication, sessions, permissions, CORS, request validation, HTTP responses, cache, timing and audit behavior. The application use cases delegate through minimal ports derived from the existing route seam.

## Scope

- [x] Backend runtime

Included:

- route-plans list, clinic-scoped get and route-stop list application use cases;
- heuristic route-plan generation application use case;
- minimal generic read and generator ports;
- Fastify adapter composition and handler delegation;
- focused unit, integration and architecture contracts;
- M07 implementation and program-status documentation.

## No-Scope

- M08 route-plan and route-stop writes;
- route-plan lifecycle transitions;
- M09 or later milestones;
- database, schema, migrations or transaction changes;
- frontend changes;
- dependencies or lockfiles;
- workflows or CI configuration.

## Validation

- PASSED — application unit tests: 12/12.
- PASSED — directed M07 tests: 55/55.
- PASSED — `pnpm validate:local`: 3168 tests, 3167 passed, 0 failed, 1 preexisting skip; build completed.
- PASSED — `pnpm security:public-surface`.
- PASSED — `git diff --check`.
- PASSED — exact 13-file scope review.
- The heuristic validation cut-off source guard was realigned to the application call-site while preserving validation → HTTP 400 → execution ordering.

## Rollback

Revert this pull request.

The rollback restores the direct route dependency calls, removes the M07 application use cases and ports, and removes their focused tests and documentation. No database migration, schema change, data rewrite or deployment-specific rollback is required.

## Data Impact

None. No database schema, migration, query or persisted-data contract was changed.