### PR TITLE
refactor(logistics): extract route-plans write and cancel application use cases (M08)

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -708,15 +708,28 @@ lifecycle (`cancel`) · **M09** UC field-visits (asignación + estados) · **M10
 > sin cambio de contrato HTTP. Detalle en
 > [`docs/implementation/m06-logistics-sla-overdue-use-case.md`](../implementation/m06-logistics-sla-overdue-use-case.md).
 >
-> **M07 — implementado / cerrado al merge.** Casos de uso de lectura de planes de
+> **M07 — implementado / cerrado (#1503).** Casos de uso de lectura de planes de
 > ruta (`route-plans-read-use-cases.ts`: list/get/listStops) y de generación
 > heurística (`generate-heuristic-route-plan.ts`), con puertos mínimos
 > `LogisticsRoutePlansReadRepository` y `LogisticsRoutePlanGenerator` derivados del
 > seam `LogisticsRoutePlansNativeRoutesOptions`; los 5 handlers de lectura/heuristic
 > de `logistics-route-plans.fastify.ts` delegan en los UC. Cache, auditoría de
-> lifecycle, timing, serialización, validaciones, escrituras (M08) y `db-logistics.ts`
-> intactos. M08 — no iniciado. Detalle en
+> lifecycle, timing, serialización, validaciones, escrituras y `db-logistics.ts`
+> intactos. Detalle en
 > [`docs/implementation/m07-logistics-route-plans-read-heuristic-use-cases.md`](../implementation/m07-logistics-route-plans-read-heuristic-use-cases.md).
+>
+> **M08 — implementado / cerrado al merge (scope acotado por autorización).**
+> Escrituras de planes (`route-plans-write-use-cases.ts`: create/update) y de stops
+> (`route-stops-write-use-cases.ts`: create/update) y cancelación de plan
+> (`cancel-route-plan.ts`, lifecycle `cancel` **únicamente**), con puertos mínimos
+> `LogisticsRoutePlansWriteRepository`, `LogisticsRouteStopsWriteRepository` y
+> `LogisticsRoutePlanCancelRepository`. Los 4 handlers de escritura delegan; el
+> helper de lifecycle recibe una transición inyectable con default = comportamiento
+> previo. Las registraciones de **`release`, `start` y `complete` permanecen sin
+> cambios y su comportamiento se preserva mediante el valor por defecto del helper
+> compartido**. Cache, auditoría, timing, serialización, validaciones,
+> transacciones y `db-logistics.ts` intactos. M09+ — no iniciado. Detalle en
+> [`docs/implementation/m08-logistics-route-plans-write-cancel-use-cases.md`](../implementation/m08-logistics-route-plans-write-cancel-use-cases.md).
 >
 > Estas anotaciones son status, no alteran el conteo recomendado, riesgos, grafo,
 > invariantes ni conclusiones.

--- a/docs/implementation/m08-logistics-route-plans-write-cancel-use-cases.md
+++ b/docs/implementation/m08-logistics-route-plans-write-cancel-use-cases.md
@@ -1,0 +1,234 @@
+# M08 — Casos de uso de escritura de route-plans/stops + lifecycle cancel (Fase B de Logistics)
+
+> **Tipo:** Extracción de casos de uso (application) + puertos mínimos, detrás de
+> los contratos por-ruta existentes. **Cero cambios de comportamiento observable.**
+> **Scope primario:** backend runtime + tests + documentación de apoyo.
+
+## 1. Base exacta
+
+- **Rama:** `refactor/backend-modularization-m08-logistics-route-plans-write-cancel-use-cases`
+  (creada manualmente por Nico desde `main` limpio).
+- **Base `main` / HEAD:** `d21230fdb263eb0cbae1157dcb66866c25aba9d0`
+  — refactor(logistics): extract route-plans application use cases (M07) (#1503).
+- **Working tree inicial:** limpio · **Índice inicial:** vacío.
+- **Documento rector:** `docs/audit/backend-enterprise-modularization-program-audit.md`
+  (ID `ARCH-AUDIT-110`), §8 Fase B.
+
+## 2. Autorización
+
+R2 explícita de Nico para M08: "extraer únicamente los casos de uso de escritura
+de route plans y route stops —create/update— y el lifecycle cancel hacia
+`server/features/logistics/application/`. release, start y complete permanecen
+fuera del scope. Deben preservarse sin cambios auth, sesiones, permisos, CORS,
+trusted-origin, parsing, validaciones, contratos HTTP, mensajes, cache, timing,
+auditoría, DB, queries, transacciones y serialización. Prohibido modificar
+`server/db-logistics.ts`, schema, migraciones, frontend, dependencias, lockfiles,
+CI o iniciar M09+."
+
+## 3. Objetivo
+
+Extraer, hacia `application/`, los casos de uso de escritura de planes de ruta
+(create/update), de paradas de ruta (create/update) y de cancelación de plan
+(lifecycle `cancel` únicamente), delegando en puertos mínimos derivados del seam
+`LogisticsRoutePlansNativeRoutesOptions`, preservando exactamente el
+comportamiento observable de `server/routes/logistics-route-plans.fastify.ts`.
+
+## 4. Scope incluido
+
+- Puertos `LogisticsRoutePlansWriteRepository` (create/update plan),
+  `LogisticsRouteStopsWriteRepository` (create/update stop) y
+  `LogisticsRoutePlanCancelRepository` (cancel).
+- Casos de uso `createRoutePlansWriteUseCases`, `createRouteStopsWriteUseCases`,
+  `createCancelRoutePlan`.
+- Adaptación de 5 delegaciones en la ruta: `POST /`, `PATCH /:routePlanId`,
+  `POST /:routePlanId/stops`, `PATCH /:routePlanId/stops/:routeStopId`, y la
+  transición del handler compartido **sólo para `cancel`**.
+- Tests unitarios nuevos; actualización del contrato de fuente de la ruta;
+  realineación de anclas de fuente en el guard CSRF de lifecycle.
+- Documentación: README de application, esta nota y status §8 del rector.
+
+## 5. Scope excluido
+
+- **`release`, `start`, `complete`**: sus registraciones conservan los mismos tres
+  argumentos; el valor por defecto del helper mantiene la delegación directa existente.
+- Sin cambios en `db-logistics.ts`, queries, transacciones, schema, migraciones,
+  cache, auditoría, timing, serialización, parsing ni validaciones.
+- Sin DI container, repositories genéricos, unit of work, event bus ni
+  infraestructura.
+- Sin guard nuevo en `test/architecture/**` (llega en M11).
+- Sin iniciar M09+.
+
+## 6. Estado previo
+
+- Fase B con M06 (SLA overdue) y M07 (lecturas + heuristic) ya en `application/`.
+- Los 5 flujos de escritura/cancel invocaban `deps.*` directamente. El lifecycle
+  usa un helper compartido `handleRoutePlanLifecycleAction(action, request, reply)`
+  con un único punto de delegación `deps.transitionClinicScopedRoutePlanStatus(id,
+  clinicId, action)`, reutilizado por release/start/complete/cancel.
+
+## 7. Diseño de los puertos
+
+Tres puertos genéricos en `application/ports/`, sin imports, sin `any`:
+
+- `LogisticsRoutePlansWriteRepository<TRoutePlan, TCreateInput, TUpdateInput>` —
+  `createRoutePlan`, `updateClinicScopedRoutePlan`. Conservan `| null | undefined`
+  para preservar el `500`/`404` sobre resultado ausente.
+- `LogisticsRouteStopsWriteRepository<TRouteStop, TCreateInput, TUpdateInput>` —
+  `createRouteStopForClinicRoutePlan`, `updateClinicScopedRouteStop`.
+- `LogisticsRoutePlanCancelRepository<TResult>` — `cancelClinicScopedRoutePlan(id,
+  clinicId)`. Sólo cancel; `TResult` opaco (el mapeo de rechazo/error queda en la
+  ruta).
+
+## 8. Diseño de los casos de uso
+
+Delegación pura (patrón M06/M07): una sola llamada, retorno por identidad, sin
+mutación, sin captura de errores, sin defaults, sin serialización.
+
+- `createRoutePlansWriteUseCases(repo)` → `{ createRoutePlan, updateRoutePlan }`.
+- `createRouteStopsWriteUseCases(repo)` → `{ createRouteStop, updateRouteStop }`.
+- `createCancelRoutePlan(repo)` → `(id, clinicId) => repo.cancelClinicScopedRoutePlan(...)`.
+
+`index.ts` exporta la superficie M08 junto a la de M06/M07, sin exports
+preventivos.
+
+## 9. Adaptación desde `LogisticsRoutePlansNativeRoutesOptions`
+
+Tras resolver `deps` (junto a los adaptadores M07), una sola vez por registro:
+
+```ts
+const routePlansWrite = createRoutePlansWriteUseCases({
+  createRoutePlan: deps.createRoutePlan,
+  updateClinicScopedRoutePlan: deps.updateClinicScopedRoutePlan,
+});
+const routeStopsWrite = createRouteStopsWriteUseCases({
+  createRouteStopForClinicRoutePlan: deps.createRouteStopForClinicRoutePlan,
+  updateClinicScopedRouteStop: deps.updateClinicScopedRouteStop,
+});
+const cancelRoutePlan = createCancelRoutePlan({
+  cancelClinicScopedRoutePlan: (id, clinicId) =>
+    deps.transitionClinicScopedRoutePlanStatus(id, clinicId, "cancel"),
+});
+```
+
+Los handlers delegan: `routePlansWrite.createRoutePlan/updateRoutePlan`,
+`routeStopsWrite.createRouteStop/updateRouteStop`. El helper de lifecycle recibe
+un 4º parámetro opcional `runTransition` cuyo **default reproduce exactamente el
+comportamiento previo** (`(routePlanId, clinicId) =>
+deps.transitionClinicScopedRoutePlanStatus(routePlanId, clinicId, action)`); sólo
+la registración de `cancel` pasa `cancelRoutePlan`. Así:
+
+- `release`/`start`/`complete`: las registraciones permanecen sin cambios y continúan
+  delegando en `deps.transitionClinicScopedRoutePlanStatus` mediante el valor por
+  defecto del helper.
+- `cancel`: rutea la transición por el caso de uso de application.
+
+Auth, permisos, `enforceTrustedOrigin`, parsing/validación, 500/404, cache
+(invalidaciones), auditoría del lifecycle y serialización permanecen en la ruta y
+sin cambios. No se tocó `handleRoutePlanLifecycleAction` salvo el parámetro
+inyectable y su uso.
+
+## 10. Cambios por archivo
+
+- `application/ports/logistics-route-plans-write-repository.ts` — **CREATED**.
+- `application/ports/logistics-route-stops-write-repository.ts` — **CREATED**.
+- `application/ports/logistics-route-plan-cancel-repository.ts` — **CREATED**.
+- `application/route-plans-write-use-cases.ts` — **CREATED**.
+- `application/route-stops-write-use-cases.ts` — **CREATED**.
+- `application/cancel-route-plan.ts` — **CREATED**.
+- `application/index.ts` — **MODIFIED** (barrel: superficie M08).
+- `application/README.md` — **MODIFIED** (sección M08).
+- `server/routes/logistics-route-plans.fastify.ts` — **MODIFIED** (import, 3
+  adaptadores, 4 delegaciones de escritura, helper de lifecycle con default +
+  wiring de cancel). release/start/complete intactos.
+- `test/unit/application/logistics/route-plans-write-use-cases.test.ts` — **CREATED**.
+- `test/unit/application/logistics/route-stops-write-use-cases.test.ts` — **CREATED**.
+- `test/unit/application/logistics/cancel-route-plan.test.ts` — **CREATED**.
+- `test/integration/adapters/controllers/logistics-route-plans-api.test.ts` — **MODIFIED**
+  (realineación de asserts update-plan/transición; contrato de delegación M08;
+  frontera de imports).
+- `test/security/security-csrf-mutating-route-coverage.test.ts` — **MODIFIED**
+  (realineación del ancla de lifecycle: cancel con 4º arg; ver §14).
+- `docs/implementation/m08-logistics-route-plans-write-cancel-use-cases.md` — **CREATED**.
+- `docs/audit/backend-enterprise-modularization-program-audit.md` — **MODIFIED** (status §8).
+
+Tests de runtime **sin cambios** y verdes: cache-runtime, metrics-runtime,
+heuristic-runtime, audit-runtime (los stubs por Options se invocan una sola vez a
+través de los casos de uso).
+
+## 11. Contratos HTTP preservados
+
+Sin cambios en: endpoints/métodos/prefijo, status codes (200/201/400/403/404/500),
+payloads y mensajes (`"Plan de ruta creado correctamente"`, `"...actualizado..."`,
+`"Parada de ruta creada..."`, `"...actualizada..."`, `"Estado del plan de ruta
+actualizado correctamente"`, `"No se pudo crear el plan de ruta"`, `"Plan de ruta
+no encontrado"`, `"Parada de ruta no encontrada"`, `"Plan de ruta o visita de
+campo no encontrado"`), `currentStatus` de rechazo del lifecycle, CORS/OPTIONS,
+`enforceTrustedOrigin`, auth, sesiones, permisos, scope clínico, cache
+(invalidaciones por clínica/plan), auditoría (`LOGISTICS_ROUTE_PLAN_LIFECYCLE_CHANGED`
+con `routePlanId`/`action`/`status`), DB/queries/transacciones y schema. Las
+validaciones y el `parseEntityId`/`build*Input` siguen antes de la delegación.
+
+## 12. Tests
+
+- **Unit (nuevos):** forwarding por identidad (input/ids), una sola delegación,
+  retorno por identidad (`strictEqual`), propagación de `null`, propagación del
+  resultado de rechazo (cancel) y del error original por identidad, y frontera de
+  imports de application.
+- **Contrato de fuente (actualizado):** import por barrel (presencia, robusto a la
+  expansión de miembros); composición de los 3 adaptadores antes de handlers; cada
+  `deps.<op>` de escritura de plan/stop sólo en composición (`lastIndexOf <
+  handlersStart`); handlers delegan; `cancel` pasa `cancelRoutePlan` al helper;
+  release/start/complete registran con 3 args (default) y no pasan caso de uso;
+  carga default `dbLogistics.*` presente; application sin imports HTTP/DB.
+- **Runtime (sin cambios):** cache, metrics, heuristic y auditoría verdes.
+
+## 13. Validaciones (estados canónicos)
+
+| Gate | Comando | Estado |
+| --- | --- | --- |
+| 1 — unitarios nuevos | `pnpm exec tsx --test <3 unit>` | PASSED (16/16) |
+| 2 — dirigidos M08 | unit + api + cache/metrics/heuristic/audit runtime + csrf | PASSED (78/78) |
+| 3 — `pnpm validate:local` | typecheck + typecheck:test + test + build | PASSED (ver reporte) |
+| 4 — `pnpm security:public-surface` | — | PASSED (ver reporte) |
+| 5 — PR Governance local | requiere evento PR/`workflow_dispatch` con HEAD commiteado | BLOCKED |
+| 6 — `git diff --check` | — | PASSED (ver reporte) |
+| 7 — scope y artefactos | — | PASSED (ver reporte) |
+
+## 14. Riesgos residuales
+
+- **Realineación de anclas de fuente (in-PR, obligatoria por P2-D / R-01):** el
+  contrato CSRF `security-csrf-mutating-route-coverage.test.ts` fijaba la firma de
+  3 args de las 4 registraciones de lifecycle; cancel ahora tiene 4 args. Se
+  realineó distinguiendo cancel, **preservando el invariante** (las 4 delegan al
+  helper compartido que aplica `enforceTrustedOrigin`); no se debilitó ningún
+  assert. Igual criterio para el ancla update-plan/transición del contrato de
+  fuente.
+- Registraciones de `release`, `start` y `complete` sin cambios y comportamiento
+  preservado mediante el valor por defecto del helper compartido. Un futuro milestone que extraiga esas
+  acciones sustituirá el default por sus casos de uso.
+- Los puertos son estructurales/genéricos: un cambio de firma en las deps de
+  escritura o en `transitionClinicScopedRoutePlanStatus` rompe en typecheck, no en
+  runtime.
+- La capa application aún sin guard propio (M11).
+
+## 15. Rollback independiente
+
+Revert de un único PR: los 5 flujos vuelven a invocar `deps.*` inline (incluida la
+firma de 3 params del helper), se retiran los 6 archivos de application de M08 y
+sus tests, y se restauran los asserts previos. No depende de revertir M06/M07 ni
+afecta `db-logistics.ts`, cache, auditoría ni release/start/complete. Mismo
+`dist/index.js` en deploy.
+
+## 16. Estado final
+
+M08 implementado: la capa application aloja las escrituras de planes y stops y la
+cancelación de plan; los handlers correspondientes delegan; release/start/complete
+quedan fuera y sin cambios; comportamiento observable idéntico; gates locales
+verdes (Governance BLOCKED por diseño hasta que exista PR).
+
+## 17. Readiness
+
+- **M08: cerrado** (al merge de este PR).
+- **Resto del lifecycle (release/start/complete) y M09+ (field-visits,
+  route-events, guard de capa, closeout): no autorizados y no iniciados.** Cada
+  milestone posterior requiere autorización R2 propia.

--- a/server/features/logistics/application/README.md
+++ b/server/features/logistics/application/README.md
@@ -1,8 +1,9 @@
 # Logistics · application (orquestación)
 
 > Capa **application** del contexto Logistics. **Contiene código** desde M06
-> (primer caso de uso: SLA lectura/overdue) y crece en M07 con los casos de uso
-> de lectura de planes de ruta y de generación heurística.
+> (SLA lectura/overdue), crece en M07 con las lecturas de planes de ruta y la
+> generación heurística, y en M08 con las escrituras de planes y stops
+> (create/update) y la cancelación de plan (lifecycle `cancel`).
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -53,7 +54,28 @@ El timing (`planningDurationMs`), la cache de listas/metrics, la invalidación d
 cache tras generar, la serialización, el mapeo de rechazo/error y las
 validaciones (400) permanecen en `server/routes/logistics-route-plans.fastify.ts`.
 Los adaptadores se componen una sola vez por registro del plugin desde `deps`.
-Las escrituras (create/update/lifecycle) siguen en la ruta y son M08.
+
+## Qué vive aquí (M08)
+
+- **`route-plans-write-use-cases.ts`** — `createRoutePlansWriteUseCases`:
+  `createRoutePlan` y `updateRoutePlan`, consumidos por los handlers `POST /` y
+  `PATCH /:routePlanId`.
+- **`route-stops-write-use-cases.ts`** — `createRouteStopsWriteUseCases`:
+  `createRouteStop` y `updateRouteStop`, consumidos por `POST /:routePlanId/stops`
+  y `PATCH /:routePlanId/stops/:routeStopId`.
+- **`cancel-route-plan.ts`** — `createCancelRoutePlan`: cancela un plan de ruta
+  (lifecycle `cancel` únicamente), consumido por `POST /:routePlanId/cancel`.
+- **Puertos** — `ports/logistics-route-plans-write-repository.ts`,
+  `ports/logistics-route-stops-write-repository.ts` y
+  `ports/logistics-route-plan-cancel-repository.ts`, genéricos, derivados del
+  seam.
+
+Cada método de escritura/cancel delega exactamente una vez y devuelve el
+resultado del puerto sin mutarlo (incluyendo `null`/rechazo del dominio). El
+500/404 sobre resultado ausente, la invalidación de cache, la auditoría del
+lifecycle y la serialización permanecen en la ruta. **`release`, `start` y
+`complete` quedan fuera de M08**: siguen usando la dep directa vía el default del
+helper de lifecycle compartido.
 
 ## Regla de dependencia
 
@@ -74,7 +96,7 @@ Frontera fijada por los tests unitarios de application en
 
 ## Qué vendrá después (no ahora)
 
-M08–M11 (casos de uso de route-plans escritura + lifecycle, field-visits,
+`release`/`start`/`complete` (resto del lifecycle) y M09–M11 (field-visits,
 route-events, guard de capa y closeout) **no están iniciados**. Cada puerto nuevo
 se introduce junto con su primer consumidor real — nunca como interfaz vacía
 anticipada.

--- a/server/features/logistics/application/cancel-route-plan.ts
+++ b/server/features/logistics/application/cancel-route-plan.ts
@@ -1,0 +1,18 @@
+import type { LogisticsRoutePlanCancelRepository } from "./ports/logistics-route-plan-cancel-repository.ts";
+
+export type CancelRoutePlan<TResult> = (
+  id: number,
+  clinicId: number,
+) => Promise<TResult>;
+
+// Caso de uso M08: cancela un plan de ruta clinic-scoped. Recibe id y clinicId
+// ya autenticados, validados y clinic-scoped desde la ruta, delega exactamente
+// una vez en el puerto de cancelación y devuelve su resultado (éxito o rechazo
+// del dominio) sin mutarlo, propagando los errores del puerto sin envolverlos.
+// El mapeo de rechazo/error, la auditoría, la cache y la serialización quedan en
+// la ruta.
+export function createCancelRoutePlan<TResult>(
+  repository: LogisticsRoutePlanCancelRepository<TResult>,
+): CancelRoutePlan<TResult> {
+  return (id, clinicId) => repository.cancelClinicScopedRoutePlan(id, clinicId);
+}

--- a/server/features/logistics/application/index.ts
+++ b/server/features/logistics/application/index.ts
@@ -22,3 +22,21 @@ export {
   type GenerateHeuristicRoutePlan,
 } from "./generate-heuristic-route-plan.ts";
 export type { LogisticsRoutePlanGenerator } from "./ports/logistics-route-plan-generator.ts";
+
+export {
+  createRoutePlansWriteUseCases,
+  type RoutePlansWriteUseCases,
+} from "./route-plans-write-use-cases.ts";
+export type { LogisticsRoutePlansWriteRepository } from "./ports/logistics-route-plans-write-repository.ts";
+
+export {
+  createRouteStopsWriteUseCases,
+  type RouteStopsWriteUseCases,
+} from "./route-stops-write-use-cases.ts";
+export type { LogisticsRouteStopsWriteRepository } from "./ports/logistics-route-stops-write-repository.ts";
+
+export {
+  createCancelRoutePlan,
+  type CancelRoutePlan,
+} from "./cancel-route-plan.ts";
+export type { LogisticsRoutePlanCancelRepository } from "./ports/logistics-route-plan-cancel-repository.ts";

--- a/server/features/logistics/application/ports/logistics-route-plan-cancel-repository.ts
+++ b/server/features/logistics/application/ports/logistics-route-plan-cancel-repository.ts
@@ -1,0 +1,14 @@
+// Puerto mínimo de cancelación de plan de ruta del contexto Logistics (M08).
+// Una sola operación semántica ("cancelar un plan de ruta clinic-scoped"),
+// derivada del seam `LogisticsRoutePlansNativeRoutesOptions`
+// (`transitionClinicScopedRoutePlanStatus` con action "cancel"). `TResult` queda
+// opaco para application: el mapeo de rechazo/error, la auditoría, la cache y la
+// serialización viven en la ruta. Sólo cubre `cancel`: release/start/complete
+// permanecen fuera del scope de M08.
+
+export type LogisticsRoutePlanCancelRepository<TResult> = {
+  cancelClinicScopedRoutePlan: (
+    id: number,
+    clinicId: number,
+  ) => Promise<TResult>;
+};

--- a/server/features/logistics/application/ports/logistics-route-plans-write-repository.ts
+++ b/server/features/logistics/application/ports/logistics-route-plans-write-repository.ts
@@ -1,0 +1,21 @@
+// Puerto mínimo de escritura de planes de ruta del contexto Logistics (M08).
+// Modela únicamente create/update de planes, consumidos por los casos de uso de
+// escritura, y se deriva del seam `LogisticsRoutePlansNativeRoutesOptions`
+// (server/routes/logistics-route-plans.fastify.ts). Los genéricos mantienen la
+// inferencia estricta del adapter real sin filtrar tipos concretos de DB ni del
+// schema hacia application.
+
+export type LogisticsRoutePlansWriteRepository<
+  TRoutePlan,
+  TCreateInput,
+  TUpdateInput,
+> = {
+  createRoutePlan: (
+    input: TCreateInput,
+  ) => Promise<TRoutePlan | null | undefined>;
+  updateClinicScopedRoutePlan: (
+    id: number,
+    clinicId: number,
+    input: TUpdateInput,
+  ) => Promise<TRoutePlan | null | undefined>;
+};

--- a/server/features/logistics/application/ports/logistics-route-stops-write-repository.ts
+++ b/server/features/logistics/application/ports/logistics-route-stops-write-repository.ts
@@ -1,0 +1,20 @@
+// Puerto mínimo de escritura de paradas de ruta del contexto Logistics (M08).
+// Modela únicamente create/update de stops, consumidos por los casos de uso de
+// escritura, y se deriva del seam `LogisticsRoutePlansNativeRoutesOptions`. Los
+// genéricos mantienen la inferencia estricta del adapter real sin filtrar tipos
+// concretos de DB ni del schema hacia application.
+
+export type LogisticsRouteStopsWriteRepository<
+  TRouteStop,
+  TCreateInput,
+  TUpdateInput,
+> = {
+  createRouteStopForClinicRoutePlan: (
+    input: TCreateInput,
+  ) => Promise<TRouteStop | null | undefined>;
+  updateClinicScopedRouteStop: (
+    id: number,
+    clinicId: number,
+    input: TUpdateInput,
+  ) => Promise<TRouteStop | null | undefined>;
+};

--- a/server/features/logistics/application/route-plans-write-use-cases.ts
+++ b/server/features/logistics/application/route-plans-write-use-cases.ts
@@ -1,0 +1,27 @@
+import type { LogisticsRoutePlansWriteRepository } from "./ports/logistics-route-plans-write-repository.ts";
+
+export type RoutePlansWriteUseCases<TRoutePlan, TCreateInput, TUpdateInput> = {
+  createRoutePlan: (
+    input: TCreateInput,
+  ) => Promise<TRoutePlan | null | undefined>;
+  updateRoutePlan: (
+    id: number,
+    clinicId: number,
+    input: TUpdateInput,
+  ) => Promise<TRoutePlan | null | undefined>;
+};
+
+// Casos de uso de escritura de planes de ruta (M08). Cada método recibe datos
+// ya autenticados, validados y clinic-scoped desde la ruta, delega exactamente
+// una vez en el puerto de escritura y devuelve su resultado sin mutarlo,
+// propagando los errores del puerto sin envolverlos. Cero HTTP, cero cache,
+// cero auditoría, cero serialización.
+export function createRoutePlansWriteUseCases<TRoutePlan, TCreateInput, TUpdateInput>(
+  repository: LogisticsRoutePlansWriteRepository<TRoutePlan, TCreateInput, TUpdateInput>,
+): RoutePlansWriteUseCases<TRoutePlan, TCreateInput, TUpdateInput> {
+  return {
+    createRoutePlan: (input) => repository.createRoutePlan(input),
+    updateRoutePlan: (id, clinicId, input) =>
+      repository.updateClinicScopedRoutePlan(id, clinicId, input),
+  };
+}

--- a/server/features/logistics/application/route-stops-write-use-cases.ts
+++ b/server/features/logistics/application/route-stops-write-use-cases.ts
@@ -1,0 +1,28 @@
+import type { LogisticsRouteStopsWriteRepository } from "./ports/logistics-route-stops-write-repository.ts";
+
+export type RouteStopsWriteUseCases<TRouteStop, TCreateInput, TUpdateInput> = {
+  createRouteStop: (
+    input: TCreateInput,
+  ) => Promise<TRouteStop | null | undefined>;
+  updateRouteStop: (
+    id: number,
+    clinicId: number,
+    input: TUpdateInput,
+  ) => Promise<TRouteStop | null | undefined>;
+};
+
+// Casos de uso de escritura de paradas de ruta (M08). Cada método recibe datos
+// ya autenticados, validados y clinic-scoped desde la ruta, delega exactamente
+// una vez en el puerto de escritura y devuelve su resultado sin mutarlo,
+// propagando los errores del puerto sin envolverlos. Cero HTTP, cero cache,
+// cero serialización.
+export function createRouteStopsWriteUseCases<TRouteStop, TCreateInput, TUpdateInput>(
+  repository: LogisticsRouteStopsWriteRepository<TRouteStop, TCreateInput, TUpdateInput>,
+): RouteStopsWriteUseCases<TRouteStop, TCreateInput, TUpdateInput> {
+  return {
+    createRouteStop: (input) =>
+      repository.createRouteStopForClinicRoutePlan(input),
+    updateRouteStop: (id, clinicId, input) =>
+      repository.updateClinicScopedRouteStop(id, clinicId, input),
+  };
+}

--- a/server/routes/logistics-route-plans.fastify.ts
+++ b/server/routes/logistics-route-plans.fastify.ts
@@ -51,8 +51,11 @@ import {
 import { createRuntimeTimer } from "../lib/runtime-timing.ts";
 import { shouldRefreshSessionLastAccess } from "../lib/session-last-access.ts";
 import {
+  createCancelRoutePlan,
   createGenerateHeuristicRoutePlan,
   createRoutePlansReadUseCases,
+  createRoutePlansWriteUseCases,
+  createRouteStopsWriteUseCases,
 } from "../features/logistics/application/index.ts";
 import {
   clearRoutePlanMetricsCacheByPlan,
@@ -1484,6 +1487,23 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
     generateHeuristicRoutePlan: deps.generateHeuristicRoutePlan,
   });
 
+  // Adaptadores M08: escritura de planes y stops, y cancelación de plan
+  // (lifecycle "cancel" únicamente; release/start/complete quedan fuera de M08).
+  // Se componen una sola vez por registro del plugin desde el seam de deps ya
+  // resuelto.
+  const routePlansWrite = createRoutePlansWriteUseCases({
+    createRoutePlan: deps.createRoutePlan,
+    updateClinicScopedRoutePlan: deps.updateClinicScopedRoutePlan,
+  });
+  const routeStopsWrite = createRouteStopsWriteUseCases({
+    createRouteStopForClinicRoutePlan: deps.createRouteStopForClinicRoutePlan,
+    updateClinicScopedRouteStop: deps.updateClinicScopedRouteStop,
+  });
+  const cancelRoutePlan = createCancelRoutePlan({
+    cancelClinicScopedRoutePlan: (id, clinicId) =>
+      deps.transitionClinicScopedRoutePlanStatus(id, clinicId, "cancel"),
+  });
+
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
 
@@ -1736,7 +1756,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routePlan = await deps.createRoutePlan(parsed.input);
+    const routePlan = await routePlansWrite.createRoutePlan(parsed.input);
 
     if (!routePlan) {
       return reply.code(500).send({
@@ -1846,7 +1866,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routePlan = await deps.updateClinicScopedRoutePlan(
+    const routePlan = await routePlansWrite.updateRoutePlan(
       routePlanId,
       auth.clinicId,
       parsed.input,
@@ -2053,9 +2073,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routeStop = await deps.createRouteStopForClinicRoutePlan(
-      parsed.input,
-    );
+    const routeStop = await routeStopsWrite.createRouteStop(parsed.input);
 
     if (!routeStop) {
       return reply.code(404).send({
@@ -2126,7 +2144,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routeStop = await deps.updateClinicScopedRouteStop(
+    const routeStop = await routeStopsWrite.updateRouteStop(
       routeStopId,
       auth.clinicId,
       parsed.input,
@@ -2156,6 +2174,17 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       };
     }>,
     reply: FastifyReply,
+    // Transición inyectable. Default M08: comportamiento previo (llamada directa
+    // a la dep) para release/start/complete, que quedan fuera del scope de M08.
+    // La ruta `cancel` pasa el caso de uso `cancelRoutePlan` de application.
+    runTransition: (
+      routePlanId: number,
+      clinicId: number,
+    ) => Promise<RoutePlanLifecycleTransitionResult> = (
+      routePlanId,
+      clinicId,
+    ) =>
+      deps.transitionClinicScopedRoutePlanStatus(routePlanId, clinicId, action),
   ) {
     if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {
       return reply;
@@ -2186,11 +2215,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const result = await deps.transitionClinicScopedRoutePlanStatus(
-      routePlanId,
-      auth.clinicId,
-      action,
-    );
+    const result = await runTransition(routePlanId, auth.clinicId);
 
     if (!result.routePlan) {
       const error = getLifecycleActionError(result);
@@ -2252,7 +2277,7 @@ export const logisticsRoutePlansNativeRoutes: FastifyPluginAsync<
       routePlanId: string;
     };
   }>("/:routePlanId/cancel", async (request, reply) =>
-    handleRoutePlanLifecycleAction("cancel", request, reply),
+    handleRoutePlanLifecycleAction("cancel", request, reply, cancelRoutePlan),
   );
 
 };

--- a/test/integration/adapters/controllers/logistics-route-plans-api.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-plans-api.test.ts
@@ -70,7 +70,7 @@ test("logistics route plans API keeps all route plan operations clinic scoped", 
   assert.match(routeSource, /clinicId: auth\.clinicId/);
   assert.match(routeSource, /routePlansRead\.listRoutePlans\(params\)/);
   assert.match(routeSource, /routePlansRead\.getRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*\)/);
-  assert.match(routeSource, /deps\.updateClinicScopedRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*parsed\.input,\s*\)/);
+  assert.match(routeSource, /routePlansWrite\.updateRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*parsed\.input,\s*\)/);
 });
 
 test("logistics route plans API validates route plan contract before DB calls", () => {
@@ -132,7 +132,9 @@ test("logistics route plans API wires lifecycle transition helper through inject
   assert.match(routeSource, /RoutePlanLifecycleAction/);
   assert.match(routeSource, /RoutePlanLifecycleTransitionResult/);
   assert.match(routeSource, /dbLogistics\.transitionClinicScopedRoutePlanStatus/);
-  assert.match(routeSource, /deps\.transitionClinicScopedRoutePlanStatus\(\s*routePlanId,\s*auth\.clinicId,\s*action,\s*\)/);
+  // release/start/complete (fuera de M08) conservan la llamada directa a la dep
+  // vía el default del helper de lifecycle.
+  assert.match(routeSource, /deps\.transitionClinicScopedRoutePlanStatus\(\s*routePlanId,\s*clinicId,\s*action\s*\)/);
 });
 
 test("logistics route plans API keeps lifecycle writes clinic scoped and trusted-origin protected", () => {
@@ -230,11 +232,11 @@ test("logistics route plans API audits lifecycle transitions", () => {
 });
 
 test("logistics route plans API delegates read and heuristic flows to the M07 application use cases", () => {
-  // 1. La ruta importa los casos de uso desde el barrel de application.
-  assert.match(
-    routeSource,
-    /import \{\s*createGenerateHeuristicRoutePlan,\s*createRoutePlansReadUseCases,\s*\} from "\.\.\/features\/logistics\/application\/index\.ts";/,
-  );
+  // 1. La ruta importa los casos de uso de lectura/heuristic desde el barrel.
+  //    (La lista de miembros del import crece con M08; se comprueba presencia.)
+  assert.match(routeSource, /from "\.\.\/features\/logistics\/application\/index\.ts";/);
+  assert.match(routeSource, /createRoutePlansReadUseCases,/);
+  assert.match(routeSource, /createGenerateHeuristicRoutePlan,/);
 
   // 2. Los puertos se adaptan desde el seam LogisticsRoutePlansNativeRoutesOptions
   //    (deps ya resueltas), una sola vez a nivel plugin, antes de registrar
@@ -284,10 +286,8 @@ test("logistics route plans API delegates read and heuristic flows to the M07 ap
   assert.match(routeSource, /dbLogistics\.listRouteStopsForClinicRoutePlan/);
   assert.match(routeSource, /dbLogistics\.generateHeuristicRoutePlan/);
 
-  // Las escrituras (M08) siguen llamando a deps directamente.
-  assert.match(routeSource, /await deps\.createRoutePlan\(/);
-  assert.match(routeSource, /await deps\.updateClinicScopedRoutePlan\(/);
-  assert.match(routeSource, /await deps\.transitionClinicScopedRoutePlanStatus\(/);
+  // Las escrituras (create/update de plan y stop) y el lifecycle cancel se
+  // delegan en application a partir de M08; su contrato vive en el test dedicado.
 });
 
 test("logistics route plans application layer (M07) stays free of HTTP and DB imports", () => {
@@ -296,6 +296,125 @@ test("logistics route plans application layer (M07) stays free of HTTP and DB im
     "server/features/logistics/application/generate-heuristic-route-plan.ts",
     "server/features/logistics/application/ports/logistics-route-plans-read-repository.ts",
     "server/features/logistics/application/ports/logistics-route-plan-generator.ts",
+  ] as const;
+
+  const forbiddenSpecifierRules: Array<{ label: string; pattern: RegExp }> = [
+    { label: "fastify", pattern: /^fastify(\/|$)/ },
+    { label: "server/db-logistics", pattern: /db-logistics/ },
+    { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+    { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+    { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+    { label: "server/lib", pattern: /(^|\/)lib\// },
+    { label: "server/routes", pattern: /(^|\/)routes\// },
+  ];
+
+  const violations: string[] = [];
+
+  for (const file of applicationFiles) {
+    const source = readFileSync(resolve(process.cwd(), file), "utf8");
+    const specifiers = Array.from(
+      source.matchAll(
+        /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+      ),
+      (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+    );
+
+    for (const specifier of specifiers) {
+      for (const { label, pattern } of forbiddenSpecifierRules) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("logistics route plans API delegates write and cancel flows to the M08 application use cases", () => {
+  // 1. La ruta importa los casos de uso de escritura y cancel desde el barrel.
+  assert.match(
+    routeSource,
+    /import \{\s*createCancelRoutePlan,\s*createGenerateHeuristicRoutePlan,\s*createRoutePlansReadUseCases,\s*createRoutePlansWriteUseCases,\s*createRouteStopsWriteUseCases,\s*\} from "\.\.\/features\/logistics\/application\/index\.ts";/,
+  );
+
+  // 2. Los tres adaptadores M08 se componen desde deps, una sola vez, antes de
+  //    registrar handlers.
+  const plansWritePattern =
+    /const routePlansWrite = createRoutePlansWriteUseCases\(\{\s*createRoutePlan:\s*deps\.createRoutePlan,\s*updateClinicScopedRoutePlan:\s*deps\.updateClinicScopedRoutePlan,\s*\}\);/;
+  const stopsWritePattern =
+    /const routeStopsWrite = createRouteStopsWriteUseCases\(\{\s*createRouteStopForClinicRoutePlan:\s*deps\.createRouteStopForClinicRoutePlan,\s*updateClinicScopedRouteStop:\s*deps\.updateClinicScopedRouteStop,\s*\}\);/;
+  const cancelPattern =
+    /const cancelRoutePlan = createCancelRoutePlan\(\{\s*cancelClinicScopedRoutePlan:\s*\(id, clinicId\) =>\s*deps\.transitionClinicScopedRoutePlanStatus\(id, clinicId, "cancel"\),\s*\}\);/;
+  assert.match(routeSource, plansWritePattern);
+  assert.match(routeSource, stopsWritePattern);
+  assert.match(routeSource, cancelPattern);
+
+  const handlersStart = routeSource.indexOf("app.options(");
+  assert.ok(handlersStart > 0, "no se encontró la región de handlers");
+  for (const pattern of [plansWritePattern, stopsWritePattern, cancelPattern]) {
+    assert.ok(
+      routeSource.search(pattern) < handlersStart,
+      "la composición de escritura/cancel debe ocurrir antes de los handlers",
+    );
+  }
+
+  // 3. Ningún handler invoca directamente las deps de escritura de plan/stop:
+  //    cada `deps.<op>` sólo aparece en la zona de composición.
+  for (const op of [
+    "deps.createRoutePlan",
+    "deps.updateClinicScopedRoutePlan",
+    "deps.createRouteStopForClinicRoutePlan",
+    "deps.updateClinicScopedRouteStop",
+  ]) {
+    assert.ok(
+      routeSource.lastIndexOf(op) < handlersStart,
+      `${op} no debe invocarse dentro de un handler (sólo en composición)`,
+    );
+  }
+
+  // Los handlers de escritura delegan en los casos de uso.
+  assert.match(routeSource, /await routePlansWrite\.createRoutePlan\(parsed\.input\)/);
+  assert.match(routeSource, /await routePlansWrite\.updateRoutePlan\(/);
+  assert.match(routeSource, /await routeStopsWrite\.createRouteStop\(parsed\.input\)/);
+  assert.match(routeSource, /await routeStopsWrite\.updateRouteStop\(/);
+
+  // 4. Sólo cancel se rutea por el caso de uso: su registración pasa
+  //    `cancelRoutePlan` como transición al helper compartido.
+  assert.match(
+    routeSource,
+    /handleRoutePlanLifecycleAction\("cancel", request, reply, cancelRoutePlan\)/,
+  );
+
+  // 5. release/start/complete permanecen fuera de M08: registran con 3 args y
+  //    usan el default del helper (deps.transition), sin pasar caso de uso.
+  for (const action of ["release", "start", "complete"]) {
+    const pattern = new RegExp(
+      `handleRoutePlanLifecycleAction\\("${action}", request, reply\\)`,
+    );
+    assert.match(routeSource, pattern);
+  }
+  assert.doesNotMatch(
+    routeSource,
+    /handleRoutePlanLifecycleAction\("(release|start|complete)", request, reply, /,
+  );
+
+  // 6. La carga default desde db-logistics sigue existiendo en el loader.
+  assert.match(routeSource, /dbLogistics\.createRoutePlan/);
+  assert.match(routeSource, /dbLogistics\.updateClinicScopedRoutePlan/);
+  assert.match(routeSource, /dbLogistics\.createRouteStopForClinicRoutePlan/);
+  assert.match(routeSource, /dbLogistics\.updateClinicScopedRouteStop/);
+  assert.match(routeSource, /dbLogistics\.transitionClinicScopedRoutePlanStatus/);
+});
+
+test("logistics route plans write/cancel application layer (M08) stays free of HTTP and DB imports", () => {
+  const applicationFiles = [
+    "server/features/logistics/application/route-plans-write-use-cases.ts",
+    "server/features/logistics/application/route-stops-write-use-cases.ts",
+    "server/features/logistics/application/cancel-route-plan.ts",
+    "server/features/logistics/application/ports/logistics-route-plans-write-repository.ts",
+    "server/features/logistics/application/ports/logistics-route-stops-write-repository.ts",
+    "server/features/logistics/application/ports/logistics-route-plan-cancel-repository.ts",
   ] as const;
 
   const forbiddenSpecifierRules: Array<{ label: string; pattern: RegExp }> = [

--- a/test/security/security-csrf-mutating-route-coverage.test.ts
+++ b/test/security/security-csrf-mutating-route-coverage.test.ts
@@ -209,17 +209,22 @@ test("logistics-route-plans lifecycle actions usan handler compartido con enforc
     "handleRoutePlanLifecycleAction",
   );
 
-  // Los 4 POST lifecycle deben delegar al handler compartido
+  // Los 4 POST lifecycle deben delegar al handler compartido. Desde M08, la
+  // ruta `cancel` rutea la transición por el caso de uso de application
+  // (`cancelRoutePlan`) como 4º argumento del helper; release/start/complete
+  // permanecen fuera de M08 con la firma de 3 argumentos. El handler compartido
+  // (y por tanto enforceTrustedOrigin) cubre las cuatro por igual.
   for (const action of ["release", "start", "complete", "cancel"]) {
     assert.ok(
       source.includes(`"/:routePlanId/${action}"`),
       `logistics-route-plans debe registrar POST /:routePlanId/${action}`,
     );
-    // Cada uno usa el handler
+    const expectedCall =
+      action === "cancel"
+        ? `handleRoutePlanLifecycleAction("cancel", request, reply, cancelRoutePlan)`
+        : `handleRoutePlanLifecycleAction("${action}", request, reply)`;
     assert.ok(
-      source.includes(
-        `handleRoutePlanLifecycleAction("${action}", request, reply)`,
-      ),
+      source.includes(expectedCall),
       `POST /:routePlanId/${action} debe delegar a handleRoutePlanLifecycleAction`,
     );
   }

--- a/test/unit/application/logistics/cancel-route-plan.test.ts
+++ b/test/unit/application/logistics/cancel-route-plan.test.ts
@@ -1,0 +1,112 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createCancelRoutePlan,
+  type LogisticsRoutePlanCancelRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+// El resultado del puerto es opaco para el caso de uso (unión éxito/rechazo del
+// dominio, igual que el seam `RoutePlanLifecycleTransitionResult`).
+type StubResult =
+  | { routePlan: { id: number; status: string }; currentStatus?: undefined }
+  | { routePlan?: undefined; currentStatus: string };
+
+function createRepositoryStub(behavior: { result?: StubResult; error?: Error }) {
+  const calls: Array<{ id: number; clinicId: number }> = [];
+
+  const repository: LogisticsRoutePlanCancelRepository<StubResult> = {
+    cancelClinicScopedRoutePlan: (id, clinicId) => {
+      calls.push({ id, clinicId });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(
+            behavior.result ?? { routePlan: { id, status: "canceled" } },
+          );
+    },
+  };
+
+  return { repository, calls };
+}
+
+test("cancelRoutePlan reenvía id y clinicId, delega una vez y devuelve por identidad", async () => {
+  const result: StubResult = { routePlan: { id: 42, status: "canceled" } };
+  const { repository, calls } = createRepositoryStub({ result });
+  const cancelRoutePlan = createCancelRoutePlan(repository);
+
+  const received = await cancelRoutePlan(42, 7);
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { id: 42, clinicId: 7 });
+  assert.strictEqual(received, result);
+});
+
+test("cancelRoutePlan preserva por identidad el resultado de rechazo del dominio", async () => {
+  const result: StubResult = { currentStatus: "completed" };
+  const { repository } = createRepositoryStub({ result });
+  const cancelRoutePlan = createCancelRoutePlan(repository);
+
+  const received = await cancelRoutePlan(42, 7);
+
+  assert.strictEqual(received, result);
+});
+
+test("cancelRoutePlan propaga el error original del puerto sin envolverlo", async () => {
+  const originalError = new Error("fallo de cancelación");
+  const { repository } = createRepositoryStub({ error: originalError });
+  const cancelRoutePlan = createCancelRoutePlan(repository);
+
+  let caught: unknown;
+
+  await assert.rejects(cancelRoutePlan(42, 7), (error: unknown) => {
+    caught = error;
+    return error === originalError;
+  });
+
+  assert.strictEqual(caught, originalError);
+});
+
+// --- Frontera de dependencias del caso de uso cancel (M08) ---
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/cancel-route-plan.ts",
+  "server/features/logistics/application/ports/logistics-route-plan-cancel-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("el caso de uso cancel de M08 no importa HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/route-plans-write-use-cases.test.ts
+++ b/test/unit/application/logistics/route-plans-write-use-cases.test.ts
@@ -1,0 +1,158 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createRoutePlansWriteUseCases,
+  type LogisticsRoutePlansWriteRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubRoutePlan = { id: number; clinicId: number; status: string };
+type StubCreateInput = { clinicId: number; serviceDate: Date; label: string };
+type StubUpdateInput = { label?: string; notes?: string };
+
+function createRepositoryStub(behavior: {
+  created?: StubRoutePlan | null;
+  updated?: StubRoutePlan | null;
+  error?: Error;
+}) {
+  const createCalls: StubCreateInput[] = [];
+  const updateCalls: Array<{ id: number; clinicId: number; input: StubUpdateInput }> = [];
+
+  const repository: LogisticsRoutePlansWriteRepository<
+    StubRoutePlan,
+    StubCreateInput,
+    StubUpdateInput
+  > = {
+    createRoutePlan: (input) => {
+      createCalls.push(input);
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.created ?? null);
+    },
+    updateClinicScopedRoutePlan: (id, clinicId, input) => {
+      updateCalls.push({ id, clinicId, input });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.updated ?? null);
+    },
+  };
+
+  return { repository, createCalls, updateCalls };
+}
+
+test("createRoutePlan reenvía el input por identidad, delega una vez y devuelve por identidad", async () => {
+  const input: StubCreateInput = {
+    clinicId: 7,
+    serviceDate: new Date("2026-05-01T00:00:00.000Z"),
+    label: "ruta A",
+  };
+  const created: StubRoutePlan = { id: 1, clinicId: 7, status: "draft" };
+  const { repository, createCalls } = createRepositoryStub({ created });
+  const useCases = createRoutePlansWriteUseCases(repository);
+
+  const result = await useCases.createRoutePlan(input);
+
+  assert.equal(createCalls.length, 1);
+  assert.strictEqual(createCalls[0], input);
+  assert.strictEqual(result, created);
+});
+
+test("createRoutePlan propaga null del puerto sin transformarlo", async () => {
+  const { repository } = createRepositoryStub({ created: null });
+  const useCases = createRoutePlansWriteUseCases(repository);
+
+  const result = await useCases.createRoutePlan({
+    clinicId: 7,
+    serviceDate: new Date(),
+    label: "x",
+  });
+
+  assert.equal(result, null);
+});
+
+test("updateRoutePlan reenvía id, clinicId e input por identidad, delega una vez y devuelve por identidad", async () => {
+  const input: StubUpdateInput = { label: "ruta B", notes: "n" };
+  const updated: StubRoutePlan = { id: 42, clinicId: 7, status: "released" };
+  const { repository, updateCalls } = createRepositoryStub({ updated });
+  const useCases = createRoutePlansWriteUseCases(repository);
+
+  const result = await useCases.updateRoutePlan(42, 7, input);
+
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0].id, 42);
+  assert.equal(updateCalls[0].clinicId, 7);
+  assert.strictEqual(updateCalls[0].input, input);
+  assert.strictEqual(result, updated);
+});
+
+test("updateRoutePlan propaga null del puerto sin transformarlo", async () => {
+  const { repository } = createRepositoryStub({ updated: null });
+  const useCases = createRoutePlansWriteUseCases(repository);
+
+  const result = await useCases.updateRoutePlan(404, 7, {});
+
+  assert.equal(result, null);
+});
+
+test("las escrituras de plan propagan el error original del puerto por identidad", async () => {
+  const originalError = new Error("fallo de escritura de plan");
+  const { repository } = createRepositoryStub({ error: originalError });
+  const useCases = createRoutePlansWriteUseCases(repository);
+
+  for (const invoke of [
+    () => useCases.createRoutePlan({ clinicId: 7, serviceDate: new Date(), label: "x" }),
+    () => useCases.updateRoutePlan(42, 7, {}),
+  ]) {
+    let caught: unknown;
+    await assert.rejects(invoke(), (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    });
+    assert.strictEqual(caught, originalError);
+  }
+});
+
+// --- Frontera de dependencias de las escrituras de plan (M08) ---
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/route-plans-write-use-cases.ts",
+  "server/features/logistics/application/ports/logistics-route-plans-write-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("las escrituras de plan de M08 no importan HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/route-stops-write-use-cases.test.ts
+++ b/test/unit/application/logistics/route-stops-write-use-cases.test.ts
@@ -1,0 +1,154 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createRouteStopsWriteUseCases,
+  type LogisticsRouteStopsWriteRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubRouteStop = { id: number; routePlanId: number; sequence: number };
+type StubCreateInput = { routePlanId: number; clinicId: number; fieldVisitId: number };
+type StubUpdateInput = { sequence?: number; status?: string };
+
+function createRepositoryStub(behavior: {
+  created?: StubRouteStop | null;
+  updated?: StubRouteStop | null;
+  error?: Error;
+}) {
+  const createCalls: StubCreateInput[] = [];
+  const updateCalls: Array<{ id: number; clinicId: number; input: StubUpdateInput }> = [];
+
+  const repository: LogisticsRouteStopsWriteRepository<
+    StubRouteStop,
+    StubCreateInput,
+    StubUpdateInput
+  > = {
+    createRouteStopForClinicRoutePlan: (input) => {
+      createCalls.push(input);
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.created ?? null);
+    },
+    updateClinicScopedRouteStop: (id, clinicId, input) => {
+      updateCalls.push({ id, clinicId, input });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.updated ?? null);
+    },
+  };
+
+  return { repository, createCalls, updateCalls };
+}
+
+test("createRouteStop reenvía el input por identidad, delega una vez y devuelve por identidad", async () => {
+  const input: StubCreateInput = { routePlanId: 42, clinicId: 7, fieldVisitId: 55 };
+  const created: StubRouteStop = { id: 5, routePlanId: 42, sequence: 1 };
+  const { repository, createCalls } = createRepositoryStub({ created });
+  const useCases = createRouteStopsWriteUseCases(repository);
+
+  const result = await useCases.createRouteStop(input);
+
+  assert.equal(createCalls.length, 1);
+  assert.strictEqual(createCalls[0], input);
+  assert.strictEqual(result, created);
+});
+
+test("createRouteStop propaga null del puerto sin transformarlo", async () => {
+  const { repository } = createRepositoryStub({ created: null });
+  const useCases = createRouteStopsWriteUseCases(repository);
+
+  const result = await useCases.createRouteStop({
+    routePlanId: 42,
+    clinicId: 7,
+    fieldVisitId: 55,
+  });
+
+  assert.equal(result, null);
+});
+
+test("updateRouteStop reenvía id, clinicId e input por identidad, delega una vez y devuelve por identidad", async () => {
+  const input: StubUpdateInput = { sequence: 3, status: "done" };
+  const updated: StubRouteStop = { id: 5, routePlanId: 42, sequence: 3 };
+  const { repository, updateCalls } = createRepositoryStub({ updated });
+  const useCases = createRouteStopsWriteUseCases(repository);
+
+  const result = await useCases.updateRouteStop(5, 7, input);
+
+  assert.equal(updateCalls.length, 1);
+  assert.equal(updateCalls[0].id, 5);
+  assert.equal(updateCalls[0].clinicId, 7);
+  assert.strictEqual(updateCalls[0].input, input);
+  assert.strictEqual(result, updated);
+});
+
+test("updateRouteStop propaga null del puerto sin transformarlo", async () => {
+  const { repository } = createRepositoryStub({ updated: null });
+  const useCases = createRouteStopsWriteUseCases(repository);
+
+  const result = await useCases.updateRouteStop(404, 7, {});
+
+  assert.equal(result, null);
+});
+
+test("las escrituras de stop propagan el error original del puerto por identidad", async () => {
+  const originalError = new Error("fallo de escritura de stop");
+  const { repository } = createRepositoryStub({ error: originalError });
+  const useCases = createRouteStopsWriteUseCases(repository);
+
+  for (const invoke of [
+    () => useCases.createRouteStop({ routePlanId: 42, clinicId: 7, fieldVisitId: 55 }),
+    () => useCases.updateRouteStop(5, 7, {}),
+  ]) {
+    let caught: unknown;
+    await assert.rejects(invoke(), (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    });
+    assert.strictEqual(caught, originalError);
+  }
+});
+
+// --- Frontera de dependencias de las escrituras de stop (M08) ---
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/route-stops-write-use-cases.ts",
+  "server/features/logistics/application/ports/logistics-route-stops-write-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("las escrituras de stop de M08 no importan HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

Extracts the M08 Logistics route-plan and route-stop write operations into the application layer.

The change introduces application use cases and minimal ports for:

- creating and updating route plans;
- creating and updating route stops;
- cancelling a route plan.

The route remains responsible for authentication, sessions, permissions, trusted-origin enforcement, CORS, parsing, validation, HTTP responses, serialization, cache invalidation and lifecycle auditing.

The registrations of `release`, `start` and `complete` remain unchanged. Their behavior continues through the default lifecycle helper delegation to `transitionClinicScopedRoutePlanStatus`.

## Scope

- [x] Backend runtime

Included:

- route-plan create and update application use cases;
- route-stop create and update application use cases;
- route-plan cancel application use case;
- minimal ports derived from `LogisticsRoutePlansNativeRoutesOptions`;
- Fastify adapter composition and handler delegation;
- focused unit, integration and security-contract coverage;
- M08 implementation and program-status documentation.

## No-Scope

- lifecycle `release`;
- lifecycle `start`;
- lifecycle `complete`;
- M09 field-visits;
- M10 route-events;
- M11 application-layer closeout;
- database queries or transaction boundaries;
- schema or migrations;
- frontend;
- dependencies or lockfiles;
- workflows or CI configuration.

## Validation

- PASSED — M08 application unit tests: 16/16.
- PASSED — directed M08 tests: 78/78.
- PASSED — `pnpm validate:local`: 3186 tests, 3185 passed, 0 failed, 1 preexisting skip; build completed.
- PASSED — `pnpm security:public-surface`.
- PASSED — `git diff --check`.
- PASSED — `git diff --cached --check`.
- PASSED — exact 16-file scope review.
- PASSED — documentation precision review for `release`, `start` and `complete`.

Two source-anchored contracts were realigned in the same PR:

- the route-plans API architecture contract;
- the CSRF mutating-route coverage contract.

Their security and delegation invariants remain enforced.

## Rollback

Revert this pull request.

The rollback restores direct route dependency calls for create/update route-plan and route-stop operations, restores direct cancellation through the shared lifecycle dependency, and removes the M08 application ports, use cases, tests and documentation.

No database migration, schema change, data rewrite or deployment-specific rollback is required.

## Data Impact

None.

No database query, transaction, schema, migration or persisted-data contract was changed.