### PR TITLE
refactor(logistics): extract field-visit update application use case (M09)

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -728,8 +728,19 @@ lifecycle (`cancel`) · **M09** UC field-visits (asignación + estados) · **M10
 > previo. Las registraciones de **`release`, `start` y `complete` permanecen sin
 > cambios y su comportamiento se preserva mediante el valor por defecto del helper
 > compartido**. Cache, auditoría, timing, serialización, validaciones,
-> transacciones y `db-logistics.ts` intactos. M09+ — no iniciado. Detalle en
+> transacciones y `db-logistics.ts` intactos. M10+ — no iniciado. Detalle en
 > [`docs/implementation/m08-logistics-route-plans-write-cancel-use-cases.md`](../implementation/m08-logistics-route-plans-write-cancel-use-cases.md).
+>
+> **M09 — implementado / cerrado al merge (scope acotado por autorización).**
+> El `PATCH /:fieldVisitId` completo delega la actualización clinic-scoped en
+> `update-field-visit.ts`, mediante el puerto mínimo
+> `LogisticsFieldVisitUpdateRepository`; status permanece dentro del mismo input
+> parcial, sin máquina de estados ni side-effects nuevos. La asignación manual
+> mediante route stops y la automática mediante generación heurística ya fueron
+> cubiertas por M08 y M07. `GET /`, `POST /`, location y time-windows permanecen
+> fuera; `db-logistics.ts`, schema y transacciones siguen intactos. M10+ — no
+> iniciado. Detalle en
+> [`docs/implementation/m09-logistics-field-visit-status-use-case.md`](../implementation/m09-logistics-field-visit-status-use-case.md).
 >
 > Estas anotaciones son status, no alteran el conteo recomendado, riesgos, grafo,
 > invariantes ni conclusiones.

--- a/docs/implementation/m09-logistics-field-visit-status-use-case.md
+++ b/docs/implementation/m09-logistics-field-visit-status-use-case.md
@@ -1,0 +1,170 @@
+# M09 — Caso de uso de actualización de field visit (Fase B de Logistics)
+
+> **Tipo:** Extracción de caso de uso application + puerto mínimo detrás del
+> contrato HTTP existente.
+> **Scope primario:** backend runtime, tests y documentación proporcional.
+
+## 1. Baseline
+
+- Rama: `refactor/backend-modularization-m09-logistics-field-visit-status-use-case`.
+- Base: `b0b853f8881e5ead85d6fc3aec09c22ab607d52d` — cierre M08 (#1504).
+- Working tree e índice iniciales: limpios.
+- `AGENTS.md` raíz leído completo; no existen instrucciones anidadas versionadas.
+
+## 2. Autorización R2
+
+Nico autorizó exclusivamente la extracción de
+`updateClinicScopedFieldVisit(id, clinicId, input)` a application, su composición
+desde el seam `LogisticsFieldVisitsNativeRoutesOptions` y la delegación desde
+`PATCH /api/logistics/field-visits/:fieldVisitId`, con allowlist cerrada de diez
+paths. No se autorizó ninguna otra operación Git/GitHub ni cambio de backend.
+
+## 3. Scope incluido
+
+- Puerto mínimo `LogisticsFieldVisitUpdateRepository`.
+- Caso de uso factory `createUpdateFieldVisit`.
+- Composición desde `deps.updateClinicScopedFieldVisit` antes de los handlers.
+- Sustitución exclusiva de la llamada persistente del PATCH por el caso de uso.
+- Test unitario, contrato de fuente y test runtime Fastify sin DB real.
+- Barrel, README application y status del rector.
+
+## 4. Scope excluido
+
+- `GET /`, `POST /`, location, time-windows y OPTIONS.
+- Route plans, route stops, route events, SLA y cache.
+- DB, queries, transacciones, schema y migraciones.
+- Auth, sesiones, permisos, CORS, trusted-origin, cookies y rate limits.
+- Frontend, dependencias, lockfiles y CI.
+- Guard global application (M11) y thin-route completo (M15).
+
+## 5. Resolución de “asignación”
+
+No existe endpoint `/assign` en `logistics-field-visits.fastify.ts`. La asignación
+manual de una visita a una ruta se representa mediante route stops; la generación
+automática, mediante la generación heurística de stops. Esos flujos ya fueron
+extraídos en M08 y M07 respectivamente.
+
+M09 no agrega endpoints, reasignación, unassign, DELETE, unicidad, idempotencia ni
+código adicional de asignación.
+
+## 6. Significado preservado de estados
+
+Los valores continúan siendo exactamente `pending`, `scheduled`, `in_progress`,
+`done`, `canceled` y `no_show`. El PATCH sigue aceptando status junto con los
+demás campos actualizables y los envía en una única operación.
+
+No se agregó máquina de estados, transición permitida/prohibida, compare-and-set,
+optimistic locking, auditoría, route event, side-effect, sincronización con route
+stops, idempotencia ni rechazo del mismo estado.
+
+## 7. Diseño
+
+### Puerto
+
+`LogisticsFieldVisitUpdateRepository<TFieldVisit, TUpdateInput>` expone una sola
+operación:
+
+```text
+updateClinicScopedFieldVisit(id, clinicId, input)
+  -> Promise<TFieldVisit | null | undefined>
+```
+
+Es estructural y genérico: no importa Fastify, `db-logistics.ts`, Drizzle, schema
+ni infraestructura concreta.
+
+### Caso de uso
+
+`createUpdateFieldVisit(repository)` devuelve una función que recibe `id`,
+`clinicId` e input, delega exactamente una vez y devuelve la promesa del puerto
+sin transformar resultado ni error. No inspecciona ni fragmenta el input.
+
+### Composición y handler
+
+La ruta compone una vez:
+
+```text
+createUpdateFieldVisit({
+  updateClinicScopedFieldVisit: deps.updateClinicScopedFieldVisit
+})
+```
+
+El PATCH conserva la secuencia observable:
+
+```text
+trusted-origin -> auth/sesión -> permiso -> parse id -> parse body
+-> update clinic-scoped -> 404 o 200 -> mensaje -> serialización
+```
+
+La carga default desde `db-logistics.ts` y el tipo `Options` permanecen intactos.
+
+## 8. Archivos
+
+### Nuevos
+
+- `server/features/logistics/application/ports/logistics-field-visit-update-repository.ts`.
+- `server/features/logistics/application/update-field-visit.ts`.
+- `test/unit/application/logistics/update-field-visit.test.ts`.
+- `test/integration/adapters/controllers/logistics-field-visits-integration.fastify.test.ts`.
+- `docs/implementation/m09-logistics-field-visit-status-use-case.md`.
+
+### Modificados
+
+- `server/features/logistics/application/index.ts`.
+- `server/features/logistics/application/README.md`.
+- `server/routes/logistics-field-visits.fastify.ts`.
+- `test/integration/adapters/controllers/logistics-field-visits-api.test.ts`.
+- `docs/audit/backend-enterprise-modularization-program-audit.md`.
+
+## 9. Contratos preservados
+
+- Mismos endpoint, método, prefijo, payload y respuesta.
+- Mismos 400, 401, 403, 404 y 200 con los mismos mensajes.
+- Mismos trusted-origin, auth, sesión y permiso.
+- Mismo `clinicId` proveniente de la sesión y mismo 404 para resultado ausente.
+- Mismos parsing, validaciones y `serializeFieldVisit`.
+- Misma dependencia DB, query y ausencia de transacción en update.
+- Mismos estados y posibilidad de actualizar status junto con otros campos.
+
+## 10. Tests
+
+El unitario cubre forwarding exacto, llamada única, identidad, null, undefined,
+error original e input combinado. El contrato de fuente fija import, composición,
+delegación exclusiva del PATCH, persistencia de las dependencias directas fuera
+de scope y frontera de imports.
+
+El runtime Fastify cubre éxito status-only, éxito combinado, 400 por status/body/id,
+404 para null/undefined, 403 por permiso/origen, clinicId de sesión y dos PATCH
+iguales como dos delegaciones independientes. No usa DB real.
+
+## 11. Validaciones
+
+| Gate | Estado |
+|---|---|
+| Test dirigido M09 | PASSED — 98/98, exit code 0 |
+| `pnpm validate:local` | PASSED — 3205 tests, 3204 pass, 1 skipped, exit code 0 |
+| `pnpm security:public-surface` | PASSED — sin exposición pública, exit code 0 |
+| Diff/allowlist/denylist | PASSED — match exacto, índice vacío, exit code 0 |
+| Artefactos Playwright | BLOCKED — existen directorios ignorados preexistentes del 2026-07-18 bajo `frontend/`; la denylist M09 prohíbe modificarlos |
+
+## 12. Riesgos y mitigaciones
+
+- **Contrato HTTP:** mitigado al sustituir sólo la llamada persistente y cubrir
+  status/mensajes en runtime.
+- **Cross-tenant:** mitigado al reenviar el clinicId autenticado sin aceptar el
+  valor del body.
+- **Separación artificial de status:** evitada; el input completo se delega una
+  sola vez.
+- **Scope creep a asignación/M10/M11/M15:** bloqueado por allowlist y tests de
+  dependencias fuera de scope.
+- **Tests source-anchored:** realineados sin eliminar asserts de seguridad.
+
+## 13. Rollback independiente
+
+Un revert único restaura la llamada directa del PATCH, retira los dos archivos
+application M09 y sus tests, y revierte barrel/docs. No requiere revertir M06–M08.
+
+## 14. Estado final
+
+Implementación y gates funcionales completados dentro de la allowlist. La
+revisión final queda bloqueada únicamente por artefactos Playwright ignorados y
+preexistentes fuera de la autorización M09.

--- a/server/features/logistics/application/README.md
+++ b/server/features/logistics/application/README.md
@@ -3,7 +3,8 @@
 > Capa **application** del contexto Logistics. **Contiene código** desde M06
 > (SLA lectura/overdue), crece en M07 con las lecturas de planes de ruta y la
 > generación heurística, y en M08 con las escrituras de planes y stops
-> (create/update) y la cancelación de plan (lifecycle `cancel`).
+> (create/update) y la cancelación de plan (lifecycle `cancel`). M09 agrega la
+> actualización clinic-scoped de field visits detrás del PATCH existente.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -77,6 +78,26 @@ lifecycle y la serialización permanecen en la ruta. **`release`, `start` y
 `complete` quedan fuera de M08**: siguen usando la dep directa vía el default del
 helper de lifecycle compartido.
 
+## Qué vive aquí (M09)
+
+- **`update-field-visit.ts`** — `createUpdateFieldVisit`: recibe `id`,
+  `clinicId` y el input parcial completo ya autenticado y validado, delega una
+  vez y devuelve el resultado sin transformarlo.
+- **`ports/logistics-field-visit-update-repository.ts`** — puerto mínimo con
+  `updateClinicScopedFieldVisit`, derivado del seam
+  `LogisticsFieldVisitsNativeRoutesOptions`.
+
+Sólo `PATCH /:fieldVisitId` consume este caso de uso. Trusted-origin, auth,
+sesiones, permisos, parsing, validaciones, 404, mensaje, status HTTP y
+serialización permanecen en la ruta. El status sigue siendo un campo opcional
+del mismo PATCH junto con los demás campos actualizables: no se agrega máquina
+de estados, compare-and-set, auditoría, eventos, side-effects ni idempotencia.
+
+La asignación manual de una visita a un plan se representa mediante route
+stops, y la automática mediante generación heurística de stops; ambos flujos ya
+fueron extraídos en M07/M08. La ruta de field visits no tiene `/assign`, y M09
+no agrega reasignación, unassign, DELETE ni restricciones de unicidad.
+
 ## Regla de dependencia
 
 - **Puede importar:** `domain`, **puertos** (interfaces) y el shared kernel.
@@ -96,10 +117,11 @@ Frontera fijada por los tests unitarios de application en
 
 ## Qué vendrá después (no ahora)
 
-`release`/`start`/`complete` (resto del lifecycle) y M09–M11 (field-visits,
-route-events, guard de capa y closeout) **no están iniciados**. Cada puerto nuevo
-se introduce junto con su primer consumidor real — nunca como interfaz vacía
-anticipada.
+`release`/`start`/`complete` (resto del lifecycle), M10 route-events y M11
+(guard de capa y closeout) **no están iniciados**. GET/POST/location/time-windows
+de field visits permanecen fuera de M09 y se difieren al thin-route M15. Cada
+puerto nuevo se introduce junto con su primer consumidor real — nunca como
+interfaz vacía anticipada.
 
 ## Qué NO hacer
 

--- a/server/features/logistics/application/index.ts
+++ b/server/features/logistics/application/index.ts
@@ -1,6 +1,6 @@
 // Barrel público de la capa application de Logistics. Expone únicamente la
-// superficie ya materializada (M06 SLA overdue + M07 route-plans lectura y
-// generate-heuristic); sin exports preventivos para milestones futuros.
+// superficie ya materializada (M06-M09); sin exports preventivos para
+// milestones futuros.
 
 export {
   createListOverdueActiveSlaInstances,
@@ -40,3 +40,9 @@ export {
   type CancelRoutePlan,
 } from "./cancel-route-plan.ts";
 export type { LogisticsRoutePlanCancelRepository } from "./ports/logistics-route-plan-cancel-repository.ts";
+
+export {
+  createUpdateFieldVisit,
+  type UpdateFieldVisit,
+} from "./update-field-visit.ts";
+export type { LogisticsFieldVisitUpdateRepository } from "./ports/logistics-field-visit-update-repository.ts";

--- a/server/features/logistics/application/ports/logistics-field-visit-update-repository.ts
+++ b/server/features/logistics/application/ports/logistics-field-visit-update-repository.ts
@@ -1,0 +1,10 @@
+// Puerto mínimo de actualización de visitas de campo del contexto Logistics
+// (M09), derivado del seam `LogisticsFieldVisitsNativeRoutesOptions`.
+
+export type LogisticsFieldVisitUpdateRepository<TFieldVisit, TUpdateInput> = {
+  updateClinicScopedFieldVisit: (
+    id: number,
+    clinicId: number,
+    input: TUpdateInput,
+  ) => Promise<TFieldVisit | null | undefined>;
+};

--- a/server/features/logistics/application/update-field-visit.ts
+++ b/server/features/logistics/application/update-field-visit.ts
@@ -1,0 +1,17 @@
+import type { LogisticsFieldVisitUpdateRepository } from "./ports/logistics-field-visit-update-repository.ts";
+
+export type UpdateFieldVisit<TFieldVisit, TUpdateInput> = (
+  id: number,
+  clinicId: number,
+  input: TUpdateInput,
+) => Promise<TFieldVisit | null | undefined>;
+
+// Caso de uso M09: actualiza una visita clinic-scoped con el input completo ya
+// autenticado y validado por la ruta. Delega una vez y preserva el resultado y
+// los errores del puerto sin interpretar campos ni estados.
+export function createUpdateFieldVisit<TFieldVisit, TUpdateInput>(
+  repository: LogisticsFieldVisitUpdateRepository<TFieldVisit, TUpdateInput>,
+): UpdateFieldVisit<TFieldVisit, TUpdateInput> {
+  return (id, clinicId, input) =>
+    repository.updateClinicScopedFieldVisit(id, clinicId, input);
+}

--- a/server/routes/logistics-field-visits.fastify.ts
+++ b/server/routes/logistics-field-visits.fastify.ts
@@ -23,6 +23,7 @@ import type {
   UpsertVisitLocationInput,
   VisitLocation,
 } from "../db-logistics.ts";
+import { createUpdateFieldVisit } from "../features/logistics/application/index.ts";
 import {
   UNSAFE_METHODS,
   enforceTrustedOrigin,
@@ -976,6 +977,10 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       defaultDeps!.listTimeWindowsForClinicVisit,
   };
 
+  const updateFieldVisit = createUpdateFieldVisit({
+    updateClinicScopedFieldVisit: deps.updateClinicScopedFieldVisit,
+  });
+
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
 
@@ -1177,7 +1182,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const updated = await deps.updateClinicScopedFieldVisit(
+    const updated = await updateFieldVisit(
       fieldVisitId,
       auth.clinicId,
       parsed.input,

--- a/test/integration/adapters/controllers/logistics-field-visits-api.test.ts
+++ b/test/integration/adapters/controllers/logistics-field-visits-api.test.ts
@@ -44,7 +44,7 @@ test("logistics field visit API keeps all reads and writes clinic scoped", () =>
   assert.match(routeSource, /deps\.listClinicFieldVisits\(params\)/);
   assert.match(routeSource, /buildCreateFieldVisitInput\(request\.body, auth\.clinicId\)/);
   assert.match(routeSource, /deps\.createFieldVisit\(parsed\.input\)/);
-  assert.match(routeSource, /deps\.updateClinicScopedFieldVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*parsed\.input,\s*\)/);
+  assert.match(routeSource, /updateFieldVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*parsed\.input,\s*\)/);
 });
 
 test("logistics field visit API validates contracts and pagination before calling DB helpers", () => {
@@ -162,4 +162,86 @@ test("logistics field visit API enforces role-aware logistics field visit permis
   assert.match(routeSource, /getClinicPermissions\(auth\.role\)\.canManageLogisticsFieldVisits/);
   assert.match(routeSource, /UNSAFE_METHODS\.has\(request\.method\.toUpperCase\(\)\)/);
   assert.match(routeSource, /Permisos insuficientes para logistica/);
+});
+
+test("logistics field visit API delegates only PATCH update to the M09 application use case", () => {
+  assert.match(
+    routeSource,
+    /import \{ createUpdateFieldVisit \} from "\.\.\/features\/logistics\/application\/index\.ts";/,
+  );
+
+  const compositionPattern =
+    /const updateFieldVisit = createUpdateFieldVisit\(\{\s*updateClinicScopedFieldVisit: deps\.updateClinicScopedFieldVisit,\s*\}\);/;
+  assert.match(routeSource, compositionPattern);
+
+  const handlersStart = routeSource.indexOf("app.options(");
+  assert.ok(handlersStart > 0, "no se encontró la región de handlers");
+  assert.ok(
+    routeSource.search(compositionPattern) < handlersStart,
+    "la composición M09 debe ocurrir antes de los handlers",
+  );
+  assert.ok(
+    routeSource.lastIndexOf("deps.updateClinicScopedFieldVisit") < handlersStart,
+    "PATCH no debe invocar directamente deps.updateClinicScopedFieldVisit",
+  );
+  assert.match(
+    routeSource,
+    /const updated = await updateFieldVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*parsed\.input,\s*\);/,
+  );
+  assert.match(routeSource, /dbLogistics\.updateClinicScopedFieldVisit/);
+});
+
+test("M09 preserves direct dependencies for out-of-scope field visit handlers", () => {
+  for (const marker of [
+    "deps.listClinicFieldVisits(params)",
+    "deps.createFieldVisit(parsed.input)",
+    "deps.getVisitLocationForClinicVisit(",
+    "deps.upsertVisitLocationForClinicVisit(parsed.input)",
+    "deps.listTimeWindowsForClinicVisit(",
+    "deps.createTimeWindowForClinicVisit(parsed.input)",
+  ]) {
+    assert.ok(routeSource.includes(marker), `debe preservar ${marker}`);
+  }
+
+  assert.match(
+    routeSource,
+    /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)[\s\S]*?authenticateClinicUser\(request, reply, deps, now\)[\s\S]*?canManageLogisticsFieldVisits[\s\S]*?parseEntityId\(request\.params\.fieldVisitId\)[\s\S]*?buildUpdateFieldVisitInput\(request\.body\)[\s\S]*?updateFieldVisit\(/,
+  );
+});
+
+test("logistics field visit M09 application files stay free of HTTP and DB imports", () => {
+  const applicationFiles = [
+    "server/features/logistics/application/update-field-visit.ts",
+    "server/features/logistics/application/ports/logistics-field-visit-update-repository.ts",
+  ] as const;
+  const forbiddenSpecifierRules: Array<{ label: string; pattern: RegExp }> = [
+    { label: "fastify", pattern: /^fastify(\/|$)/ },
+    { label: "server/db-logistics", pattern: /db-logistics/ },
+    { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+    { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+    { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+    { label: "server/lib", pattern: /(^|\/)lib\// },
+    { label: "server/routes", pattern: /(^|\/)routes\// },
+  ];
+  const violations: string[] = [];
+
+  for (const file of applicationFiles) {
+    const source = readFileSync(resolve(process.cwd(), file), "utf8");
+    const specifiers = Array.from(
+      source.matchAll(
+        /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+      ),
+      (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+    );
+
+    for (const specifier of specifiers) {
+      for (const { label, pattern } of forbiddenSpecifierRules) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
 });

--- a/test/integration/adapters/controllers/logistics-field-visits-integration.fastify.test.ts
+++ b/test/integration/adapters/controllers/logistics-field-visits-integration.fastify.test.ts
@@ -1,0 +1,301 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import type { InjectOptions } from "light-my-request";
+
+import type {
+  FieldVisit,
+  UpdateFieldVisitInput,
+} from "../../../../server/db-logistics.ts";
+import type { ClinicUserRole } from "../../../../drizzle/schema.ts";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../../../../server/lib/env.ts");
+const { logisticsFieldVisitsNativeRoutes } = await import(
+  "../../../../server/routes/logistics-field-visits.fastify.ts"
+);
+
+const VALID_ORIGIN = "http://localhost:3000";
+const BLOCKED_ORIGIN = "https://evil.example.com";
+const SESSION_TOKEN = "field-visit-session";
+const SESSION_COOKIE = `${ENV.cookieName}=${SESSION_TOKEN}`;
+
+type UpdateCall = {
+  id: number;
+  clinicId: number;
+  input: UpdateFieldVisitInput;
+};
+
+function buildFieldVisit(overrides: Partial<FieldVisit> = {}): FieldVisit {
+  return {
+    id: 42,
+    clinicId: 7,
+    sourceType: "manual",
+    sourceId: null,
+    status: "pending",
+    priority: 0,
+    criticality: null,
+    serviceDurationMin: 30,
+    notes: null,
+    createdAt: new Date("2026-07-19T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-19T12:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+async function buildRuntimeApp(options: {
+  role?: ClinicUserRole;
+  updateClinicScopedFieldVisit?: (
+    id: number,
+    clinicId: number,
+    input: UpdateFieldVisitInput,
+  ) => Promise<FieldVisit | null | undefined>;
+} = {}): Promise<{ app: FastifyInstance; updateCalls: UpdateCall[] }> {
+  const app = Fastify();
+  const updateCalls: UpdateCall[] = [];
+
+  await app.register(logisticsFieldVisitsNativeRoutes, {
+    prefix: "/api/logistics/field-visits",
+    now: () => Date.UTC(2026, 6, 19, 12, 0, 0),
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async (tokenHash: string) =>
+      tokenHash === `hash:${SESSION_TOKEN}`
+        ? {
+            clinicUserId: 9,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            lastAccess: new Date("2026-07-19T11:59:00.000Z"),
+          }
+        : null,
+    getClinicUserById: async (clinicUserId: number) =>
+      clinicUserId === 9
+        ? {
+            id: 9,
+            clinicId: 7,
+            username: "clinic-owner",
+            authProId: null,
+            role: options.role ?? "clinic_owner",
+          }
+        : null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createFieldVisit: async () => null,
+    listClinicFieldVisits: async () => [],
+    updateClinicScopedFieldVisit: async (id, clinicId, input) => {
+      updateCalls.push({ id, clinicId, input });
+
+      if (options.updateClinicScopedFieldVisit) {
+        return options.updateClinicScopedFieldVisit(id, clinicId, input);
+      }
+
+      return buildFieldVisit({
+        id,
+        clinicId,
+        ...input,
+        updatedAt: new Date("2026-07-19T12:05:00.000Z"),
+      });
+    },
+    getVisitLocationForClinicVisit: async () => null,
+    upsertVisitLocationForClinicVisit: async () => null,
+    createTimeWindowForClinicVisit: async () => null,
+    listTimeWindowsForClinicVisit: async () => [],
+  });
+
+  return { app, updateCalls };
+}
+
+function patchInput(
+  fieldVisitId: string,
+  payload: Record<string, unknown>,
+  origin = VALID_ORIGIN,
+): InjectOptions {
+  return {
+    method: "PATCH",
+    url: `/api/logistics/field-visits/${fieldVisitId}`,
+    headers: {
+      cookie: SESSION_COOKIE,
+      origin,
+      "content-type": "application/json",
+    },
+    payload: JSON.stringify(payload),
+  };
+}
+
+test("PATCH field visit actualiza status y usa el clinicId autenticado", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      patchInput("42", { status: "in_progress", clinicId: 999 }),
+    );
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Visita de campo actualizada correctamente");
+    assert.equal(body.fieldVisit.status, "in_progress");
+    assert.equal(updateCalls.length, 1);
+    assert.deepEqual(updateCalls[0], {
+      id: 42,
+      clinicId: 7,
+      input: { status: "in_progress" },
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("PATCH field visit preserva status y otro campo en una sola delegación", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      patchInput("42", { status: "done", notes: "Visita completada" }),
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(updateCalls.length, 1);
+    assert.deepEqual(updateCalls[0]?.input, {
+      status: "done",
+      notes: "Visita completada",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("PATCH field visit rechaza status inválido antes del puerto", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(patchInput("42", { status: "unknown" }));
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "status invalido",
+    });
+    assert.deepEqual(updateCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
+test("PATCH field visit rechaza body vacío antes del puerto", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(patchInput("42", {}));
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No hay cambios para aplicar",
+    });
+    assert.deepEqual(updateCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
+test("PATCH field visit rechaza fieldVisitId inválido antes del puerto", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(patchInput("invalid", { status: "done" }));
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "fieldVisitId invalido",
+    });
+    assert.deepEqual(updateCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
+test("PATCH field visit mapea null y undefined a 404 sin cambiar el mensaje", async (t) => {
+  for (const [label, result] of [
+    ["null", null],
+    ["undefined", undefined],
+  ] as const) {
+    await t.test(label, async () => {
+      const { app, updateCalls } = await buildRuntimeApp({
+        updateClinicScopedFieldVisit: async () => result,
+      });
+
+      try {
+        const response = await app.inject(patchInput("42", { status: "done" }));
+
+        assert.equal(response.statusCode, 404);
+        assert.deepEqual(JSON.parse(response.body), {
+          success: false,
+          error: "Visita de campo no encontrada",
+        });
+        assert.equal(updateCalls.length, 1);
+      } finally {
+        await app.close();
+      }
+    });
+  }
+});
+
+test("PATCH field visit rechaza permiso insuficiente antes del puerto", async () => {
+  const { app, updateCalls } = await buildRuntimeApp({ role: "clinic_staff" });
+
+  try {
+    const response = await app.inject(patchInput("42", { status: "done" }));
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Permisos insuficientes para logistica",
+    });
+    assert.deepEqual(updateCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
+test("PATCH field visit rechaza origen no permitido antes del puerto", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      patchInput("42", { status: "done" }, BLOCKED_ORIGIN),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Origen no permitido",
+    });
+    assert.deepEqual(updateCalls, []);
+  } finally {
+    await app.close();
+  }
+});
+
+test("dos PATCH iguales producen dos delegaciones independientes", async () => {
+  const { app, updateCalls } = await buildRuntimeApp();
+
+  try {
+    const request = patchInput("42", { status: "scheduled" });
+    const first = await app.inject(request);
+    const second = await app.inject(request);
+
+    assert.equal(first.statusCode, 200);
+    assert.equal(second.statusCode, 200);
+    assert.equal(updateCalls.length, 2);
+    assert.deepEqual(updateCalls[0], updateCalls[1]);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/unit/application/logistics/update-field-visit.test.ts
+++ b/test/unit/application/logistics/update-field-visit.test.ts
@@ -1,0 +1,149 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createUpdateFieldVisit,
+  type LogisticsFieldVisitUpdateRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubFieldVisit = {
+  id: number;
+  clinicId: number;
+  status: string;
+  notes: string | null;
+};
+
+type StubUpdateInput = {
+  status?: string;
+  notes?: string | null;
+};
+
+type RepositoryResult = StubFieldVisit | null | undefined;
+
+function createRepositoryStub(behavior: {
+  result?: RepositoryResult;
+  error?: Error;
+}) {
+  const calls: Array<{
+    id: number;
+    clinicId: number;
+    input: StubUpdateInput;
+  }> = [];
+
+  const repository: LogisticsFieldVisitUpdateRepository<
+    StubFieldVisit,
+    StubUpdateInput
+  > = {
+    updateClinicScopedFieldVisit: (id, clinicId, input) => {
+      calls.push({ id, clinicId, input });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.result);
+    },
+  };
+
+  return { repository, calls };
+}
+
+test("updateFieldVisit reenvía id, clinicId e input combinado una vez y devuelve por identidad", async () => {
+  const input: StubUpdateInput = {
+    status: "in_progress",
+    notes: "Ingreso confirmado",
+  };
+  const result: StubFieldVisit = {
+    id: 42,
+    clinicId: 7,
+    status: "in_progress",
+    notes: "Ingreso confirmado",
+  };
+  const { repository, calls } = createRepositoryStub({ result });
+  const updateFieldVisit = createUpdateFieldVisit(repository);
+
+  const received = await updateFieldVisit(42, 7, input);
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { id: 42, clinicId: 7, input });
+  assert.strictEqual(calls[0]?.input, input);
+  assert.strictEqual(received, result);
+});
+
+test("updateFieldVisit preserva null", async () => {
+  const { repository, calls } = createRepositoryStub({ result: null });
+  const updateFieldVisit = createUpdateFieldVisit(repository);
+
+  const received = await updateFieldVisit(42, 7, { status: "done" });
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, null);
+});
+
+test("updateFieldVisit preserva undefined", async () => {
+  const { repository, calls } = createRepositoryStub({ result: undefined });
+  const updateFieldVisit = createUpdateFieldVisit(repository);
+
+  const received = await updateFieldVisit(42, 7, { status: "done" });
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, undefined);
+});
+
+test("updateFieldVisit propaga el error original del puerto sin envolverlo", async () => {
+  const originalError = new Error("fallo de actualización");
+  const { repository, calls } = createRepositoryStub({ error: originalError });
+  const updateFieldVisit = createUpdateFieldVisit(repository);
+  let caught: unknown;
+
+  await assert.rejects(
+    updateFieldVisit(42, 7, { status: "canceled" }),
+    (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    },
+  );
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(caught, originalError);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/update-field-visit.ts",
+  "server/features/logistics/application/ports/logistics-field-visit-update-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("el caso de uso update field visit de M09 no importa HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

Extracts the clinic-scoped field-visit update operation into the Logistics application layer.

The change introduces:

- a minimal `LogisticsFieldVisitUpdateRepository` port;
- the `createUpdateFieldVisit` application use case;
- composition from the existing `LogisticsFieldVisitsNativeRoutesOptions` seam;
- delegation exclusively from `PATCH /api/logistics/field-visits/:fieldVisitId`;
- focused unit, source-contract and Fastify runtime coverage.

The handler continues to own trusted-origin enforcement, authentication, sessions, permissions, parsing, validation, HTTP responses, messages and serialization.

## Scope

- [x] Backend runtime

Included:

- clinic-scoped update of an existing field visit;
- forwarding of the complete `UpdateFieldVisitInput` in one operation;
- preservation of the existing six field-visit statuses;
- application barrel and README updates;
- M09 implementation and program-status documentation;
- directed runtime coverage for success, mixed-field updates, validation, permissions, origin, tenant propagation, not-found and repeated updates.

## Assignment Resolution

M09 does not introduce a new assignment operation.

Assignment of a field visit to a route is already represented by route stops:

- heuristic assignment was extracted in M07;
- manual route-stop creation/update was extracted in M08.

No `/assign`, `/unassign`, reassignment, DELETE, uniqueness rule or new idempotency behavior was introduced.

## No-Scope

- `GET /api/logistics/field-visits`;
- `POST /api/logistics/field-visits`;
- location handlers;
- time-window handlers;
- route plans or route stops;
- route events or status side effects;
- state-machine or transition rules;
- optimistic locking or compare-and-set;
- M10 route-events;
- M11 application-layer closeout;
- M15 thin field-visits route;
- database queries or transaction boundaries;
- `server/db-logistics.ts`;
- schema or migrations;
- frontend;
- dependencies or lockfiles;
- workflows or CI configuration.

## Contract Preservation

The following remain unchanged:

- endpoint, method and route prefix;
- request payload and partial-update semantics;
- status codes and response messages;
- serialization;
- parsing and validation;
- authentication and session behavior;
- trusted-origin enforcement;
- permissions;
- clinic tenant scope;
- database query and persistence behavior;
- supported field-visit status values;
- behavior of repeated identical PATCH requests.

No field-visit state machine was added. Any currently valid status may continue to be written through the existing PATCH contract.

## Validation

- PASSED — directed M09 tests: 98/98.
- PASSED — `pnpm validate:local`: 3205 tests, 3204 passed, 0 failed, 1 skipped; typechecks and build completed.
- PASSED — `pnpm security:public-surface`.
- PASSED — `git diff --check`.
- PASSED — `git diff --cached --check`.
- PASSED — exact 10-file scope review.
- PASSED — denylist review.
- PASSED — zero Playwright artifacts and unchanged `frontend/next-env.d.ts`.

## Rollback

Revert this pull request.

The rollback restores the direct `deps.updateClinicScopedFieldVisit` invocation inside the existing PATCH handler and removes the M09 port, application use case, tests and documentation.

No database migration, schema change, data rewrite or deployment-specific rollback is required.

## Data Impact

None.

No database query, transaction, schema, migration or persisted-data contract was changed.