### PR TITLE
refactor(logistics): extract route-events application use cases (M10)

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -738,9 +738,24 @@ lifecycle (`cancel`) · **M09** UC field-visits (asignación + estados) · **M10
 > parcial, sin máquina de estados ni side-effects nuevos. La asignación manual
 > mediante route stops y la automática mediante generación heurística ya fueron
 > cubiertas por M08 y M07. `GET /`, `POST /`, location y time-windows permanecen
-> fuera; `db-logistics.ts`, schema y transacciones siguen intactos. M10+ — no
-> iniciado. Detalle en
+> fuera; `db-logistics.ts`, schema y transacciones siguen intactos. Detalle en
 > [`docs/implementation/m09-logistics-field-visit-status-use-case.md`](../implementation/m09-logistics-field-visit-status-use-case.md).
+>
+> **M10 — implementado / pendiente de merge (scope acotado por autorización).**
+> Los cuatro handlers de datos de `logistics-route-events` delegan en
+> `create-route-event.ts` (append explícito de `POST /`) y en
+> `route-events-read-use-cases.ts` (`listRouteEvents`, `listRoutePlanEvents`,
+> `pollRouteEvents`), mediante los puertos mínimos
+> `LogisticsRouteEventWriteRepository` y `LogisticsRouteEventsReadRepository`.
+> `OPTIONS` permanece íntegramente en Fastify. **No se agregó ningún productor
+> automático de eventos** (lifecycle, stop status, field-visit status,
+> heurística, `no_show`) ni event bus, outbox, retry, deduplicación,
+> idempotency keys u optimistic locking. El orden append → `writeAuditLog`, el
+> 404 sobre resultado ausente, la paginación, el cursor y la serialización
+> permanecen en la ruta; `db-logistics.ts`, schema y transacciones siguen
+> intactos. El mismatch preexistente `routePlanId`/`routeStopId` queda
+> documentado como deuda, no corregido. **M11 — pendiente.** Detalle en
+> [`docs/implementation/m10-logistics-route-events-use-cases.md`](../implementation/m10-logistics-route-events-use-cases.md).
 >
 > Estas anotaciones son status, no alteran el conteo recomendado, riesgos, grafo,
 > invariantes ni conclusiones.

--- a/docs/implementation/m10-logistics-route-events-use-cases.md
+++ b/docs/implementation/m10-logistics-route-events-use-cases.md
@@ -1,0 +1,178 @@
+# M10 — Casos de uso de route events (Fase B de Logistics)
+
+## 1. Baseline
+
+- Rama: `refactor/backend-modularization-m10-logistics-route-events-use-cases`
+- Base/HEAD al iniciar: `d9a210e08195e78774a72cd223bcbbcf2228dbee`
+  (`refactor(logistics): extract field-visit update use case (#1505)`)
+- Working tree inicial: limpio. Índice inicial: vacío.
+- Rama creada desde `main` limpio. PRs abiertos antes de iniciar: 0.
+
+## 2. Autorización R2
+
+Autorización explícita y acotada a la extracción hacia `application` de las
+**cuatro operaciones de datos ya existentes** en
+`server/routes/logistics-route-events.fastify.ts`, sin ampliación por
+inferencia y sin operaciones Git/GitHub de escritura.
+
+## 3. Scope incluido
+
+Cuatro handlers, cuatro operaciones, una delegación cada una:
+
+| Handler | Operación previa (dep directa) | Delegación M10 |
+| --- | --- | --- |
+| `POST /` | `deps.createRouteEvent(input)` | `createRouteEvent(input)` |
+| `GET /` | `deps.listClinicRouteEvents(params)` | `routeEventsRead.listRouteEvents(params)` |
+| `GET /poll` | `deps.listIncrementalClinicRouteEvents(clinicId, afterId, limit)` | `routeEventsRead.pollRouteEvents(clinicId, afterId, limit)` |
+| `GET /route-plans/:routePlanId` | `deps.listRouteEventsForClinicRoutePlan(routePlanId, clinicId, params)` | `routeEventsRead.listRoutePlanEvents(routePlanId, clinicId, params)` |
+
+## 4. Scope excluido
+
+`OPTIONS` permanece **íntegramente** en Fastify (no entra a application). Fuera
+de M10 y no implementados: eventos automáticos desde route-plan lifecycle,
+route-stop status, field-visit status o generación heurística; evento automático
+de `no_show`; extracción de `release`/`start`/`complete`; cambios en `cancel`;
+validación de pertenencia stop↔plan; orden por `eventTime`; update/delete de
+route events; endpoints nuevos; tipos de evento nuevos; sanitización funcional
+nueva; event bus, outbox, retry, deduplicación, idempotency keys y optimistic
+locking. Sin repository genérico, sin DI container, sin Unit of Work nueva.
+
+## 5. Auditoría previa
+
+- Las cuatro operaciones ya existían en el seam `Options`
+  (`LogisticsRouteEventsNativeRoutesOptions`) con default desde
+  `db-logistics.ts` en `loadDefaultDeps`; no hubo que crear dependencias nuevas.
+- `POST /` es un append explícito: no existe ningún productor automático de
+  route events en el resto del contexto Logistics. M10 **no** introduce uno.
+- La auditoría (`AUDIT_EVENTS.LOGISTICS_ROUTE_EVENT_CREATED`) ocurre **después**
+  del append y sólo si el append devolvió un evento; el aislamiento de errores
+  del audit writer no se modifica.
+- El RBAC (`canManageLogisticsRouteEvents`) sólo actúa sobre métodos unsafe, por
+  lo que en la práctica gobierna `POST /`; se preserva tal cual en los cuatro
+  handlers.
+
+## 6. Diseño
+
+### Puertos
+
+- `ports/logistics-route-event-write-repository.ts` —
+  `LogisticsRouteEventWriteRepository<TRouteEvent, TCreateInput>`, con la única
+  operación `createRouteEvent`.
+- `ports/logistics-route-events-read-repository.ts` —
+  `LogisticsRouteEventsReadRepository<TRouteEvent, TListParams, TRoutePlanListParams>`,
+  con `listClinicRouteEvents`, `listRouteEventsForClinicRoutePlan` y
+  `listIncrementalClinicRouteEvents`.
+
+Ambos son estrechos, genéricos y estructurales, derivados del seam `Options`. No
+importan Fastify, `db-logistics.ts`, Drizzle ni `drizzle/schema.ts`.
+
+### Casos de uso
+
+- `create-route-event.ts` — `createCreateRouteEvent` devuelve
+  `createRouteEvent(input)`: una sola delegación, resultado por identidad
+  (incluyendo `null`/`undefined`), errores propagados sin captura.
+- `route-events-read-use-cases.ts` — `createRouteEventsReadUseCases` agrupa
+  `listRouteEvents`, `listRoutePlanEvents` y `pollRouteEvents`, cada una con una
+  sola delegación, mismos argumentos y mismo orden, sin defaults propios
+  (`params`/`limit` ausentes se reenvían como `undefined`).
+
+### Composición
+
+En la ruta, una sola vez por registro del plugin, después de resolver `deps` y
+antes de los handlers. El seam `Options`, `loadDefaultDeps` y el resto de las
+dependencias quedan sin cambios.
+
+## 7. Contratos preservados
+
+Endpoints, métodos, prefijo, payloads, query/path params, status codes (200,
+201, 400, 401, 403, 404), mensajes, forma de respuestas (`pagination`,
+`polling`, `lastEventId`, `count`, `routePlanId`), `serializeRouteEvent`,
+conversión de fechas, event types y sources, payload libre, `eventTime`,
+`lat`/`lng`, `clinicId`, `routePlanId`, `routeStopId`, comportamiento
+append-only, orden `id` ASC, cursor `afterId`, `limit`/`offset`, nullability,
+tenant scope, queries, transacciones, atomicidad, comportamiento cross-tenant y
+para plan inexistente, idempotencia actual (duplicados permitidos) y
+comportamiento ante fallos de auditoría.
+
+Permanecen en Fastify: `OPTIONS`, CORS, trusted-origin, auth, cookie
+`app_session_id`, hash/lookup/refresh/borrado de sesión, RBAC, `clinicId`
+derivado de la sesión, parsing, validaciones, defaults, límites, paginación,
+mensajes, status, envelopes, serialización, `no-store`, `writeAuditLog` y el
+orden append → auditoría.
+
+## 8. Archivos
+
+### Nuevos
+
+- `server/features/logistics/application/create-route-event.ts`
+- `server/features/logistics/application/route-events-read-use-cases.ts`
+- `server/features/logistics/application/ports/logistics-route-event-write-repository.ts`
+- `server/features/logistics/application/ports/logistics-route-events-read-repository.ts`
+- `test/unit/application/logistics/create-route-event.test.ts`
+- `test/unit/application/logistics/route-events-read-use-cases.test.ts`
+- `test/integration/adapters/controllers/logistics-route-events-integration.fastify.test.ts`
+- `docs/implementation/m10-logistics-route-events-use-cases.md`
+
+### Modificados
+
+- `server/routes/logistics-route-events.fastify.ts` (import, composición única,
+  cuatro delegaciones)
+- `server/features/logistics/application/index.ts` (barrel M10)
+- `server/features/logistics/application/README.md`
+- `test/integration/adapters/controllers/logistics-route-events-api.test.ts`
+- `docs/audit/backend-enterprise-modularization-program-audit.md` (sólo estado
+  de M10)
+
+## 9. Tests
+
+- **Unitarios** (2 archivos): una llamada por operación, mismos argumentos y
+  orden, retorno por identidad, arrays vacíos, `null`/`undefined` preservados,
+  propagación del error original, ausencia de mutación de input, ausencia de
+  defaults, ausencia de llamadas adicionales, y frontera de imports.
+- **Contrato source-anchored**: imports application, composición desde las
+  cuatro deps, cuatro delegaciones, ausencia de las cuatro invocaciones directas
+  en los handlers, `OPTIONS`/auth/RBAC/trusted-origin/parsing/serialización
+  intactos, orden append → audit, y frontera de imports de los cuatro archivos
+  application. No se debilitó ninguna assertion de seguridad previa.
+- **Runtime Fastify nuevo**: los cuatro handlers extremo a extremo con fixture
+  local por el seam `Options` (sin tocar
+  `test/helpers/fastify-app-route-stubs.ts`), incluyendo 201/400/401/403/404,
+  tenant autenticado sobre `clinicId` del body, payload completo, serialización,
+  audit posterior, ausencia de audit ante fallo o ausencia del append,
+  propagación de error, ausencia de deduplicación, defaults y límites de
+  `GET`/`poll`/`route-plans`, listas vacías y `lastEventId`.
+
+## 10. Riesgos
+
+| Riesgo | Mitigación |
+| --- | --- |
+| Cambio silencioso de comportamiento en 4 handlers a la vez | Runtime test nuevo por handler + contrato source-anchored actualizado |
+| Defaults introducidos por la capa application | Tests unitarios que fijan `undefined` reenviado tal cual en `params` y `limit` |
+| Pérdida del orden append → auditoría | Assertion de orden observable en runtime y regex de secuencia en el contrato |
+| Frontera application contaminada | Guard de imports en los tests unitarios y en el contrato |
+
+## 11. Deuda preexistente (fuera de M10)
+
+`POST /` acepta `routePlanId` y `routeStopId` de forma independiente: **no** se
+valida que el stop informado pertenezca al plan informado. Este mismatch es
+**preexistente** y se documenta como deuda; corregirlo sería un cambio funcional
+y queda explícitamente fuera de esta autorización.
+
+## 12. Ausencia deliberada de automatismos
+
+M10 extrae exactamente lo que ya existía. No se agregó ningún productor
+automático de eventos (lifecycle, stop status, field-visit status, heurística,
+`no_show`), ni event bus, outbox, retry, deduplicación, idempotency keys u
+optimistic locking. El append sigue siendo explícito y provocado sólo por
+`POST /`.
+
+## 13. Rollback
+
+Revertir el commit del PR restaura las cuatro invocaciones directas: los
+archivos de application quedan huérfanos pero inertes, y el seam `Options`,
+`db-logistics.ts`, el schema y las transacciones nunca se tocaron.
+
+## 14. Estado final
+
+**M10 — implementado / pendiente de merge.** M11 (guard de capa application +
+suite de UCs + closeout) permanece pendiente.

--- a/server/features/logistics/application/README.md
+++ b/server/features/logistics/application/README.md
@@ -4,7 +4,8 @@
 > (SLA lectura/overdue), crece en M07 con las lecturas de planes de ruta y la
 > generación heurística, y en M08 con las escrituras de planes y stops
 > (create/update) y la cancelación de plan (lifecycle `cancel`). M09 agrega la
-> actualización clinic-scoped de field visits detrás del PATCH existente.
+> actualización clinic-scoped de field visits detrás del PATCH existente, y M10
+> el append explícito y las tres lecturas de route events.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -98,6 +99,25 @@ stops, y la automática mediante generación heurística de stops; ambos flujos 
 fueron extraídos en M07/M08. La ruta de field visits no tiene `/assign`, y M09
 no agrega reasignación, unassign, DELETE ni restricciones de unicidad.
 
+## Qué vive aquí (M10)
+
+- **`create-route-event.ts`** — `createCreateRouteEvent`: append explícito de un
+  evento de ruta con el input ya autenticado, validado y clinic-scoped; delega
+  una vez y devuelve el resultado sin transformarlo.
+- **`route-events-read-use-cases.ts`** — `createRouteEventsReadUseCases`:
+  `listRouteEvents`, `listRoutePlanEvents` y `pollRouteEvents`, consumidos por
+  `GET /`, `GET /route-plans/:routePlanId` y `GET /poll`.
+- **Puertos** — `ports/logistics-route-event-write-repository.ts` y
+  `ports/logistics-route-events-read-repository.ts`, genéricos, derivados del
+  seam `LogisticsRouteEventsNativeRoutesOptions`.
+
+Las lecturas no aplican defaults propios: `params` y `limit` ausentes se
+reenvían como `undefined`. `OPTIONS`, CORS, trusted-origin, auth, RBAC, parsing,
+paginación, `lastEventId`, serialización, el 404 sobre resultado ausente y
+`writeAuditLog` (posterior al append) permanecen en la ruta. **M10 no agrega
+ningún productor automático de eventos**: el append sigue provocado únicamente
+por `POST /`, sin event bus, outbox, retry, deduplicación ni idempotency keys.
+
 ## Regla de dependencia
 
 - **Puede importar:** `domain`, **puertos** (interfaces) y el shared kernel.
@@ -117,8 +137,8 @@ Frontera fijada por los tests unitarios de application en
 
 ## Qué vendrá después (no ahora)
 
-`release`/`start`/`complete` (resto del lifecycle), M10 route-events y M11
-(guard de capa y closeout) **no están iniciados**. GET/POST/location/time-windows
+`release`/`start`/`complete` (resto del lifecycle) y M11 (guard de capa y
+closeout) **no están iniciados**. GET/POST/location/time-windows
 de field visits permanecen fuera de M09 y se difieren al thin-route M15. Cada
 puerto nuevo se introduce junto con su primer consumidor real — nunca como
 interfaz vacía anticipada.

--- a/server/features/logistics/application/create-route-event.ts
+++ b/server/features/logistics/application/create-route-event.ts
@@ -1,0 +1,16 @@
+import type { LogisticsRouteEventWriteRepository } from "./ports/logistics-route-event-write-repository.ts";
+
+export type CreateRouteEvent<TRouteEvent, TCreateInput> = (
+  input: TCreateInput,
+) => Promise<TRouteEvent | null | undefined>;
+
+// Caso de uso M10: registra (append) un evento de ruta con el input completo ya
+// autenticado, validado y clinic-scoped por la ruta. Delega exactamente una vez
+// y devuelve el resultado del puerto sin mutarlo (incluyendo null/undefined),
+// propagando sus errores sin envolverlos. Cero HTTP, cero auditoría, cero
+// serialización: el orden append → writeAuditLog permanece en la ruta.
+export function createCreateRouteEvent<TRouteEvent, TCreateInput>(
+  repository: LogisticsRouteEventWriteRepository<TRouteEvent, TCreateInput>,
+): CreateRouteEvent<TRouteEvent, TCreateInput> {
+  return (input) => repository.createRouteEvent(input);
+}

--- a/server/features/logistics/application/index.ts
+++ b/server/features/logistics/application/index.ts
@@ -1,5 +1,5 @@
 // Barrel público de la capa application de Logistics. Expone únicamente la
-// superficie ya materializada (M06-M09); sin exports preventivos para
+// superficie ya materializada (M06-M10); sin exports preventivos para
 // milestones futuros.
 
 export {
@@ -46,3 +46,15 @@ export {
   type UpdateFieldVisit,
 } from "./update-field-visit.ts";
 export type { LogisticsFieldVisitUpdateRepository } from "./ports/logistics-field-visit-update-repository.ts";
+
+export {
+  createCreateRouteEvent,
+  type CreateRouteEvent,
+} from "./create-route-event.ts";
+export type { LogisticsRouteEventWriteRepository } from "./ports/logistics-route-event-write-repository.ts";
+
+export {
+  createRouteEventsReadUseCases,
+  type RouteEventsReadUseCases,
+} from "./route-events-read-use-cases.ts";
+export type { LogisticsRouteEventsReadRepository } from "./ports/logistics-route-events-read-repository.ts";

--- a/server/features/logistics/application/ports/logistics-route-event-write-repository.ts
+++ b/server/features/logistics/application/ports/logistics-route-event-write-repository.ts
@@ -1,0 +1,11 @@
+// Puerto mínimo de escritura de eventos de ruta del contexto Logistics (M10),
+// derivado del seam `LogisticsRouteEventsNativeRoutesOptions`
+// (server/routes/logistics-route-events.fastify.ts). Modela únicamente el append
+// explícito consumido por `POST /`. Los genéricos evitan filtrar tipos concretos
+// de DB o del schema hacia application.
+
+export type LogisticsRouteEventWriteRepository<TRouteEvent, TCreateInput> = {
+  createRouteEvent: (
+    input: TCreateInput,
+  ) => Promise<TRouteEvent | null | undefined>;
+};

--- a/server/features/logistics/application/ports/logistics-route-events-read-repository.ts
+++ b/server/features/logistics/application/ports/logistics-route-events-read-repository.ts
@@ -1,0 +1,25 @@
+// Puerto mínimo de lectura de eventos de ruta del contexto Logistics (M10).
+// Modela las tres lecturas consumidas por los handlers `GET /`, `GET /poll` y
+// `GET /route-plans/:routePlanId`, derivadas del seam
+// `LogisticsRouteEventsNativeRoutesOptions`
+// (server/routes/logistics-route-events.fastify.ts). Los genéricos mantienen la
+// inferencia estricta del adapter real sin filtrar tipos concretos de DB ni del
+// schema hacia application.
+
+export type LogisticsRouteEventsReadRepository<
+  TRouteEvent,
+  TListParams,
+  TRoutePlanListParams,
+> = {
+  listClinicRouteEvents: (params: TListParams) => Promise<TRouteEvent[]>;
+  listRouteEventsForClinicRoutePlan: (
+    routePlanId: number,
+    clinicId: number,
+    params?: TRoutePlanListParams,
+  ) => Promise<TRouteEvent[]>;
+  listIncrementalClinicRouteEvents: (
+    clinicId: number,
+    afterId: number,
+    limit?: number,
+  ) => Promise<TRouteEvent[]>;
+};

--- a/server/features/logistics/application/route-events-read-use-cases.ts
+++ b/server/features/logistics/application/route-events-read-use-cases.ts
@@ -1,0 +1,48 @@
+import type { LogisticsRouteEventsReadRepository } from "./ports/logistics-route-events-read-repository.ts";
+
+export type RouteEventsReadUseCases<
+  TRouteEvent,
+  TListParams,
+  TRoutePlanListParams,
+> = {
+  listRouteEvents: (params: TListParams) => Promise<TRouteEvent[]>;
+  listRoutePlanEvents: (
+    routePlanId: number,
+    clinicId: number,
+    params?: TRoutePlanListParams,
+  ) => Promise<TRouteEvent[]>;
+  pollRouteEvents: (
+    clinicId: number,
+    afterId: number,
+    limit?: number,
+  ) => Promise<TRouteEvent[]>;
+};
+
+// Casos de uso de lectura de eventos de ruta (M10). Cada método recibe datos ya
+// autenticados, validados y clinic-scoped desde la ruta, delega exactamente una
+// vez en el puerto de lectura y devuelve su resultado por identidad, sin
+// mutarlo ni aplicar defaults, propagando los errores del puerto sin
+// envolverlos. Cero HTTP, cero paginación, cero serialización.
+export function createRouteEventsReadUseCases<
+  TRouteEvent,
+  TListParams,
+  TRoutePlanListParams,
+>(
+  repository: LogisticsRouteEventsReadRepository<
+    TRouteEvent,
+    TListParams,
+    TRoutePlanListParams
+  >,
+): RouteEventsReadUseCases<TRouteEvent, TListParams, TRoutePlanListParams> {
+  return {
+    listRouteEvents: (params) => repository.listClinicRouteEvents(params),
+    listRoutePlanEvents: (routePlanId, clinicId, params) =>
+      repository.listRouteEventsForClinicRoutePlan(
+        routePlanId,
+        clinicId,
+        params,
+      ),
+    pollRouteEvents: (clinicId, afterId, limit) =>
+      repository.listIncrementalClinicRouteEvents(clinicId, afterId, limit),
+  };
+}

--- a/server/routes/logistics-route-events.fastify.ts
+++ b/server/routes/logistics-route-events.fastify.ts
@@ -29,6 +29,10 @@ import {
   type AuditWriteInput,
 } from "../lib/audit.ts";
 import {
+  createCreateRouteEvent,
+  createRouteEventsReadUseCases,
+} from "../features/logistics/application/index.ts";
+import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
@@ -726,6 +730,19 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
       (async () => undefined),
   };
 
+  // Adaptadores M10: append explícito y las tres lecturas de eventos de ruta.
+  // Se componen una sola vez por registro del plugin desde el seam de deps ya
+  // resuelto (no por request). La carga default desde db-logistics.ts sigue
+  // viviendo en loadDefaultDeps; audit, serialización y HTTP siguen en la ruta.
+  const createRouteEvent = createCreateRouteEvent({
+    createRouteEvent: deps.createRouteEvent,
+  });
+  const routeEventsRead = createRouteEventsReadUseCases({
+    listClinicRouteEvents: deps.listClinicRouteEvents,
+    listRouteEventsForClinicRoutePlan: deps.listRouteEventsForClinicRoutePlan,
+    listIncrementalClinicRouteEvents: deps.listIncrementalClinicRouteEvents,
+  });
+
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
 
@@ -798,7 +815,7 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routeEvents = await deps.listClinicRouteEvents(parsed.params);
+    const routeEvents = await routeEventsRead.listRouteEvents(parsed.params);
 
     return reply.code(200).send({
       success: true,
@@ -838,7 +855,7 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
 
     const afterId = parseAfterId(request.query.afterId);
     const limit = parsePositiveInt(request.query.limit, 50, 100);
-    const routeEvents = await deps.listIncrementalClinicRouteEvents(
+    const routeEvents = await routeEventsRead.pollRouteEvents(
       auth.clinicId,
       afterId,
       limit,
@@ -925,7 +942,7 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
       offset: parseOffset(request.query.offset),
     };
 
-    const routeEvents = await deps.listRouteEventsForClinicRoutePlan(
+    const routeEvents = await routeEventsRead.listRoutePlanEvents(
       routePlanId,
       auth.clinicId,
       params,
@@ -978,7 +995,7 @@ export const logisticsRouteEventsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const routeEvent = await deps.createRouteEvent(parsed.input);
+    const routeEvent = await createRouteEvent(parsed.input);
 
     if (!routeEvent) {
       return reply.code(404).send({

--- a/test/integration/adapters/controllers/logistics-route-events-api.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-events-api.test.ts
@@ -52,9 +52,9 @@ test("logistics route events API wires route event DB helpers through injectable
 
 test("logistics route events API keeps reads clinic scoped", () => {
   assert.match(routeSource, /buildListRouteEventsParams\(request\.query, auth\.clinicId\)/);
-  assert.match(routeSource, /deps\.listClinicRouteEvents\(parsed\.params\)/);
-  assert.match(routeSource, /deps\.listIncrementalClinicRouteEvents\(\s*auth\.clinicId,\s*afterId,\s*limit,\s*\)/);
-  assert.match(routeSource, /deps\.listRouteEventsForClinicRoutePlan\(\s*routePlanId,\s*auth\.clinicId,\s*params,\s*\)/);
+  assert.match(routeSource, /routeEventsRead\.listRouteEvents\(parsed\.params\)/);
+  assert.match(routeSource, /routeEventsRead\.pollRouteEvents\(\s*auth\.clinicId,\s*afterId,\s*limit,\s*\)/);
+  assert.match(routeSource, /routeEventsRead\.listRoutePlanEvents\(\s*routePlanId,\s*auth\.clinicId,\s*params,\s*\)/);
 });
 
 test("logistics route events API validates route event create payload before DB calls", () => {
@@ -119,4 +119,113 @@ test("logistics route events API audits route event creation", () => {
   assert.match(routeSource, /await deps\.writeAuditLog\(createAuditRequestLike\(request, auth\),/);
   assert.match(routeSource, /routeEventId: routeEvent\.id/);
   assert.match(routeSource, /eventType: routeEvent\.eventType/);
+});
+
+test("logistics route events API delegates the four data operations to M10 application use cases", () => {
+  assert.match(
+    routeSource,
+    /import \{\s*createCreateRouteEvent,\s*createRouteEventsReadUseCases,\s*\} from "\.\.\/features\/logistics\/application\/index\.ts";/,
+  );
+
+  const writeComposition =
+    /const createRouteEvent = createCreateRouteEvent\(\{\s*createRouteEvent: deps\.createRouteEvent,\s*\}\);/;
+  const readComposition =
+    /const routeEventsRead = createRouteEventsReadUseCases\(\{\s*listClinicRouteEvents: deps\.listClinicRouteEvents,\s*listRouteEventsForClinicRoutePlan: deps\.listRouteEventsForClinicRoutePlan,\s*listIncrementalClinicRouteEvents: deps\.listIncrementalClinicRouteEvents,\s*\}\);/;
+
+  assert.match(routeSource, writeComposition);
+  assert.match(routeSource, readComposition);
+
+  const handlersStart = routeSource.indexOf("app.options(");
+  assert.ok(handlersStart > 0, "no se encontró la región de handlers");
+  assert.ok(
+    routeSource.search(writeComposition) < handlersStart,
+    "la composición de escritura M10 debe ocurrir antes de los handlers",
+  );
+  assert.ok(
+    routeSource.search(readComposition) < handlersStart,
+    "la composición de lectura M10 debe ocurrir antes de los handlers",
+  );
+
+  assert.match(routeSource, /const routeEvent = await createRouteEvent\(parsed\.input\);/);
+  assert.match(routeSource, /await routeEventsRead\.listRouteEvents\(parsed\.params\)/);
+  assert.match(routeSource, /await routeEventsRead\.pollRouteEvents\(/);
+  assert.match(routeSource, /await routeEventsRead\.listRoutePlanEvents\(/);
+});
+
+test("logistics route events handlers no longer invoke the four deps directly", () => {
+  const handlersStart = routeSource.indexOf("app.options(");
+  assert.ok(handlersStart > 0, "no se encontró la región de handlers");
+
+  for (const dependency of [
+    "deps.createRouteEvent",
+    "deps.listClinicRouteEvents",
+    "deps.listRouteEventsForClinicRoutePlan",
+    "deps.listIncrementalClinicRouteEvents",
+  ]) {
+    assert.ok(
+      routeSource.lastIndexOf(dependency) < handlersStart,
+      `${dependency} no debe invocarse desde los handlers`,
+    );
+  }
+
+  assert.doesNotMatch(routeSource, /deps\.createRouteEvent\(parsed\.input\)/);
+  assert.doesNotMatch(routeSource, /deps\.listClinicRouteEvents\(parsed\.params\)/);
+  assert.doesNotMatch(routeSource, /deps\.listIncrementalClinicRouteEvents\(\s*auth\.clinicId/);
+  assert.doesNotMatch(routeSource, /deps\.listRouteEventsForClinicRoutePlan\(\s*routePlanId/);
+});
+
+test("M10 keeps OPTIONS, audit ordering and HTTP responsibilities inside Fastify", () => {
+  assert.match(routeSource, /app\.options\("\/", optionsHandler\)/);
+  assert.match(routeSource, /app\.options\("\/poll", optionsHandler\)/);
+  assert.match(routeSource, /app\.options\("\/route-plans\/:routePlanId", optionsHandler\)/);
+  assert.match(routeSource, /const optionsHandler = async \(/);
+  assert.match(routeSource, /reply\.header\("access-control-allow-methods", "GET,POST,OPTIONS"\)/);
+  assert.match(routeSource, /return reply\.code\(204\)\.send\(\)/);
+
+  assert.match(
+    routeSource,
+    /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)[\s\S]*?authenticateClinicUser\(request, reply, deps, now\)[\s\S]*?canManageLogisticsRouteEvents[\s\S]*?buildCreateRouteEventInput\(request\.body, auth\.clinicId\)[\s\S]*?await createRouteEvent\(parsed\.input\)[\s\S]*?Plan de ruta o parada no encontrada[\s\S]*?await deps\.writeAuditLog\([\s\S]*?reply\.code\(201\)/,
+  );
+
+  assert.match(routeSource, /function serializeRouteEvent/);
+  assert.match(routeSource, /routeEvents\.map\(\(routeEvent\) =>\s*serializeRouteEvent\(routeEvent\),\s*\)/);
+});
+
+test("logistics route events M10 application files stay free of HTTP and DB imports", () => {
+  const applicationFiles = [
+    "server/features/logistics/application/create-route-event.ts",
+    "server/features/logistics/application/route-events-read-use-cases.ts",
+    "server/features/logistics/application/ports/logistics-route-event-write-repository.ts",
+    "server/features/logistics/application/ports/logistics-route-events-read-repository.ts",
+  ] as const;
+  const forbiddenSpecifierRules: Array<{ label: string; pattern: RegExp }> = [
+    { label: "fastify", pattern: /^fastify(\/|$)/ },
+    { label: "server/db-logistics", pattern: /db-logistics/ },
+    { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+    { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+    { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+    { label: "server/lib", pattern: /(^|\/)lib\// },
+    { label: "server/routes", pattern: /(^|\/)routes\// },
+  ];
+  const violations: string[] = [];
+
+  for (const file of applicationFiles) {
+    const source = readFileSync(resolve(process.cwd(), file), "utf8");
+    const specifiers = Array.from(
+      source.matchAll(
+        /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+      ),
+      (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+    );
+
+    for (const specifier of specifiers) {
+      for (const { label, pattern } of forbiddenSpecifierRules) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
 });

--- a/test/integration/adapters/controllers/logistics-route-events-integration.fastify.test.ts
+++ b/test/integration/adapters/controllers/logistics-route-events-integration.fastify.test.ts
@@ -1,0 +1,756 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import Fastify, { type FastifyInstance } from "fastify";
+import type { InjectOptions } from "light-my-request";
+
+import type {
+  CreateRouteEventInput,
+  ListRouteEventsParams,
+  RouteEvent,
+} from "../../../../server/db-logistics.ts";
+import type { ClinicUserRole } from "../../../../drizzle/schema.ts";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../../../../server/lib/env.ts");
+const { logisticsRouteEventsNativeRoutes } = await import(
+  "../../../../server/routes/logistics-route-events.fastify.ts"
+);
+
+const VALID_ORIGIN = "http://localhost:3000";
+const BLOCKED_ORIGIN = "https://evil.example.com";
+const SESSION_TOKEN = "route-events-session";
+const SESSION_COOKIE = `${ENV.cookieName}=${SESSION_TOKEN}`;
+const CLINIC_ID = 7;
+
+type RoutePlanListParams = Omit<
+  ListRouteEventsParams,
+  "clinicId" | "routePlanId"
+>;
+
+type AuditCall = {
+  event: string;
+  clinicId?: number | null;
+  metadata?: unknown;
+};
+
+type Recorder = {
+  createCalls: CreateRouteEventInput[];
+  listCalls: ListRouteEventsParams[];
+  routePlanCalls: Array<{
+    routePlanId: number;
+    clinicId: number;
+    params?: RoutePlanListParams;
+  }>;
+  pollCalls: Array<{ clinicId: number; afterId: number; limit?: number }>;
+  auditCalls: AuditCall[];
+  order: string[];
+};
+
+function buildRouteEvent(overrides: Partial<RouteEvent> = {}): RouteEvent {
+  return {
+    id: 501,
+    clinicId: CLINIC_ID,
+    routePlanId: 11,
+    routeStopId: 22,
+    eventType: "stop.arrived",
+    eventTime: new Date("2026-07-20T10:00:00.000Z"),
+    payload: { note: "llegada" },
+    lat: -34.6,
+    lng: -58.4,
+    source: "clinic",
+    createdAt: new Date("2026-07-20T10:00:01.000Z"),
+    ...overrides,
+  } as RouteEvent;
+}
+
+async function buildRuntimeApp(
+  options: {
+    role?: ClinicUserRole;
+    createRouteEvent?: (
+      input: CreateRouteEventInput,
+    ) => Promise<RouteEvent | null | undefined>;
+    listClinicRouteEvents?: (
+      params: ListRouteEventsParams,
+    ) => Promise<RouteEvent[]>;
+    listRouteEventsForClinicRoutePlan?: (
+      routePlanId: number,
+      clinicId: number,
+      params?: RoutePlanListParams,
+    ) => Promise<RouteEvent[]>;
+    listIncrementalClinicRouteEvents?: (
+      clinicId: number,
+      afterId: number,
+      limit?: number,
+    ) => Promise<RouteEvent[]>;
+    writeAuditLog?: () => Promise<void>;
+  } = {},
+): Promise<{ app: FastifyInstance; recorder: Recorder }> {
+  const app = Fastify();
+  const recorder: Recorder = {
+    createCalls: [],
+    listCalls: [],
+    routePlanCalls: [],
+    pollCalls: [],
+    auditCalls: [],
+    order: [],
+  };
+
+  await app.register(logisticsRouteEventsNativeRoutes, {
+    prefix: "/api/logistics/route-events",
+    now: () => Date.UTC(2026, 6, 20, 12, 0, 0),
+    deleteActiveSession: async () => {},
+    getActiveSessionByToken: async (tokenHash: string) =>
+      tokenHash === `hash:${SESSION_TOKEN}`
+        ? {
+            clinicUserId: 9,
+            expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+            lastAccess: new Date("2026-07-20T11:59:00.000Z"),
+          }
+        : null,
+    getClinicUserById: async (clinicUserId: number) =>
+      clinicUserId === 9
+        ? {
+            id: 9,
+            clinicId: CLINIC_ID,
+            username: "clinic-owner",
+            authProId: null,
+            role: options.role ?? "clinic_owner",
+          }
+        : null,
+    updateSessionLastAccess: async () => {},
+    hashSessionToken: (token: string) => `hash:${token}`,
+    createRouteEvent: async (input) => {
+      recorder.createCalls.push(input);
+      recorder.order.push("createRouteEvent");
+
+      if (options.createRouteEvent) {
+        return options.createRouteEvent(input);
+      }
+
+      return buildRouteEvent({
+        clinicId: input.clinicId,
+        routePlanId: input.routePlanId ?? null,
+        routeStopId: input.routeStopId ?? null,
+        eventType: input.eventType,
+        eventTime: input.eventTime ?? new Date("2026-07-20T10:00:00.000Z"),
+        payload: input.payload ?? null,
+        lat: input.lat ?? null,
+        lng: input.lng ?? null,
+        source: input.source ?? "clinic",
+      });
+    },
+    listClinicRouteEvents: async (params) => {
+      recorder.listCalls.push(params);
+      return options.listClinicRouteEvents
+        ? options.listClinicRouteEvents(params)
+        : [];
+    },
+    listRouteEventsForClinicRoutePlan: async (
+      routePlanId,
+      clinicId,
+      params,
+    ) => {
+      recorder.routePlanCalls.push({ routePlanId, clinicId, params });
+      return options.listRouteEventsForClinicRoutePlan
+        ? options.listRouteEventsForClinicRoutePlan(
+            routePlanId,
+            clinicId,
+            params,
+          )
+        : [];
+    },
+    listIncrementalClinicRouteEvents: async (clinicId, afterId, limit) => {
+      recorder.pollCalls.push({ clinicId, afterId, limit });
+      return options.listIncrementalClinicRouteEvents
+        ? options.listIncrementalClinicRouteEvents(clinicId, afterId, limit)
+        : [];
+    },
+    writeAuditLog: async (_req, input) => {
+      recorder.auditCalls.push({
+        event: input.event,
+        clinicId: input.clinicId,
+        metadata: input.metadata,
+      });
+      recorder.order.push("writeAuditLog");
+
+      if (options.writeAuditLog) {
+        await options.writeAuditLog();
+      }
+    },
+  });
+
+  return { app, recorder };
+}
+
+function postInput(
+  payload: unknown,
+  overrides: { origin?: string; cookie?: string | null } = {},
+): InjectOptions {
+  const headers: Record<string, string> = {
+    origin: overrides.origin ?? VALID_ORIGIN,
+    "content-type": "application/json",
+  };
+
+  if (overrides.cookie !== null) {
+    headers.cookie = overrides.cookie ?? SESSION_COOKIE;
+  }
+
+  return {
+    method: "POST",
+    url: "/api/logistics/route-events/",
+    headers,
+    payload: JSON.stringify(payload),
+  };
+}
+
+function getInput(url: string): InjectOptions {
+  return {
+    method: "GET",
+    url,
+    headers: { cookie: SESSION_COOKIE, origin: VALID_ORIGIN },
+  };
+}
+
+const VALID_BODY = {
+  routePlanId: 11,
+  routeStopId: 22,
+  eventType: "stop.arrived",
+  eventTime: "2026-07-20T10:00:00.000Z",
+  payload: { note: "llegada", nested: { ok: true } },
+  lat: -34.6,
+  lng: -58.4,
+  source: "clinic",
+};
+
+// ---------------------------------------------------------------- POST /
+
+test("POST route event responde 201 y delega el input exacto en el puerto", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY));
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(body.success, true);
+    assert.equal(body.message, "Evento logistico registrado correctamente");
+    assert.equal(recorder.createCalls.length, 1);
+    assert.deepEqual(recorder.createCalls[0], {
+      clinicId: CLINIC_ID,
+      routePlanId: 11,
+      routeStopId: 22,
+      eventType: "stop.arrived",
+      eventTime: new Date("2026-07-20T10:00:00.000Z"),
+      payload: { note: "llegada", nested: { ok: true } },
+      lat: -34.6,
+      lng: -58.4,
+      source: "clinic",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event reemplaza el clinicId del body por el tenant autenticado", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      postInput({ ...VALID_BODY, clinicId: 999 }),
+    );
+
+    assert.equal(response.statusCode, 201);
+    assert.equal(recorder.createCalls[0]?.clinicId, CLINIC_ID);
+    assert.equal(JSON.parse(response.body).routeEvent.clinicId, CLINIC_ID);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event preserva el payload libre completo y la serialización", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY));
+    const { routeEvent } = JSON.parse(response.body);
+
+    assert.deepEqual(recorder.createCalls[0]?.payload, {
+      note: "llegada",
+      nested: { ok: true },
+    });
+    assert.deepEqual(Object.keys(routeEvent), [
+      "id",
+      "clinicId",
+      "routePlanId",
+      "routeStopId",
+      "eventType",
+      "eventTime",
+      "payload",
+      "lat",
+      "lng",
+      "source",
+      "createdAt",
+    ]);
+    assert.equal(routeEvent.eventTime, "2026-07-20T10:00:00.000Z");
+    assert.equal(routeEvent.createdAt, "2026-07-20T10:00:01.000Z");
+    assert.deepEqual(routeEvent.payload, { note: "llegada", nested: { ok: true } });
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event audita después del append y en ese orden", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY));
+
+    assert.equal(response.statusCode, 201);
+    assert.deepEqual(recorder.order, ["createRouteEvent", "writeAuditLog"]);
+    assert.equal(recorder.auditCalls.length, 1);
+    assert.equal(recorder.auditCalls[0]?.clinicId, CLINIC_ID);
+    assert.deepEqual(recorder.auditCalls[0]?.metadata, {
+      routeEventId: 501,
+      routePlanId: 11,
+      routeStopId: 22,
+      eventType: "stop.arrived",
+      source: "clinic",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event no audita cuando el append devuelve ausencia (404 actual)", async () => {
+  const { app, recorder } = await buildRuntimeApp({
+    createRouteEvent: async () => null,
+  });
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY));
+
+    assert.equal(response.statusCode, 404);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Plan de ruta o parada no encontrada",
+    });
+    assert.equal(recorder.createCalls.length, 1);
+    assert.equal(recorder.auditCalls.length, 0);
+    assert.deepEqual(recorder.order, ["createRouteEvent"]);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event propaga el error del puerto y no audita", async () => {
+  const { app, recorder } = await buildRuntimeApp({
+    createRouteEvent: async () => {
+      throw new Error("fallo de append");
+    },
+  });
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY));
+
+    assert.equal(response.statusCode, 500);
+    assert.equal(recorder.createCalls.length, 1);
+    assert.equal(recorder.auditCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event rechaza payload inválido con 400 antes del puerto", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const missingType = await app.inject(
+      postInput({ routePlanId: 11, source: "clinic" }),
+    );
+    const invalidPlan = await app.inject(
+      postInput({ eventType: "stop.arrived", routePlanId: 0 }),
+    );
+    const invalidPayload = await app.inject(
+      postInput({ eventType: "stop.arrived", payload: "texto" }),
+    );
+
+    assert.equal(missingType.statusCode, 400);
+    assert.deepEqual(JSON.parse(missingType.body), {
+      success: false,
+      error: "eventType es obligatorio",
+    });
+    assert.equal(invalidPlan.statusCode, 400);
+    assert.equal(
+      JSON.parse(invalidPlan.body).error,
+      "routePlanId debe ser un entero positivo",
+    );
+    assert.equal(invalidPayload.statusCode, 400);
+    assert.equal(
+      JSON.parse(invalidPayload.body).error,
+      "payload debe ser objeto o null",
+    );
+    assert.equal(recorder.createCalls.length, 0);
+    assert.equal(recorder.auditCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event responde 401 sin sesión", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY, { cookie: null }));
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "No autenticado",
+    });
+    assert.equal(recorder.createCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event responde 403 por trusted-origin antes de autenticar", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      postInput(VALID_BODY, { origin: BLOCKED_ORIGIN }),
+    );
+
+    assert.equal(response.statusCode, 403);
+    assert.equal(JSON.parse(response.body).error, "Origen no permitido");
+    assert.equal(recorder.createCalls.length, 0);
+    assert.equal(recorder.auditCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event responde 403 por RBAC insuficiente", async () => {
+  const { app, recorder } = await buildRuntimeApp({ role: "clinic_staff" });
+
+  try {
+    const response = await app.inject(postInput(VALID_BODY));
+
+    assert.equal(response.statusCode, 403);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Permisos insuficientes para logistica",
+    });
+    assert.equal(recorder.createCalls.length, 0);
+    assert.equal(recorder.auditCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+test("POST route event repetido no deduplica: cada request es un append nuevo", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const first = await app.inject(postInput(VALID_BODY));
+    const second = await app.inject(postInput(VALID_BODY));
+
+    assert.equal(first.statusCode, 201);
+    assert.equal(second.statusCode, 201);
+    assert.equal(recorder.createCalls.length, 2);
+    assert.deepEqual(recorder.createCalls[0], recorder.createCalls[1]);
+    assert.equal(recorder.auditCalls.length, 2);
+  } finally {
+    await app.close();
+  }
+});
+
+// ----------------------------------------------------------------- GET /
+
+test("GET route events usa el tenant autenticado y los filtros exactos", async () => {
+  const { app, recorder } = await buildRuntimeApp({
+    listClinicRouteEvents: async () => [buildRouteEvent()],
+  });
+
+  try {
+    const response = await app.inject(
+      getInput(
+        "/api/logistics/route-events/?routePlanId=11&routeStopId=22&eventType=stop.arrived&afterId=5&limit=25&offset=10&clinicId=999",
+      ),
+    );
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(recorder.listCalls.length, 1);
+    assert.deepEqual(recorder.listCalls[0], {
+      clinicId: CLINIC_ID,
+      routePlanId: 11,
+      routeStopId: 22,
+      eventType: "stop.arrived",
+      afterId: 5,
+      limit: 25,
+      offset: 10,
+    });
+    assert.equal(body.success, true);
+    assert.equal(body.count, 1);
+    assert.deepEqual(body.pagination, { limit: 25, offset: 10, afterId: 5 });
+    assert.equal(body.routeEvents[0].eventTime, "2026-07-20T10:00:00.000Z");
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET route events aplica defaults y el límite máximo actuales", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    await app.inject(getInput("/api/logistics/route-events/"));
+    await app.inject(getInput("/api/logistics/route-events/?limit=5000"));
+
+    assert.deepEqual(recorder.listCalls[0], {
+      clinicId: CLINIC_ID,
+      routePlanId: undefined,
+      routeStopId: undefined,
+      eventType: undefined,
+      afterId: 0,
+      limit: 50,
+      offset: 0,
+    });
+    assert.equal(recorder.listCalls[1]?.limit, 100);
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET route events devuelve lista vacía con la forma estable", async () => {
+  const { app } = await buildRuntimeApp({ listClinicRouteEvents: async () => [] });
+
+  try {
+    const response = await app.inject(getInput("/api/logistics/route-events/"));
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(body, {
+      success: true,
+      count: 0,
+      routeEvents: [],
+      pagination: { limit: 50, offset: 0, afterId: 0 },
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET route events responde 400 ante filtros inválidos sin llamar al puerto", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      getInput("/api/logistics/route-events/?eventType=inexistente"),
+    );
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "eventType invalido",
+    });
+    assert.equal(recorder.listCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+// ------------------------------------------------------------- GET /poll
+
+test("GET poll reenvía clinicId, afterId y limit exactos", async () => {
+  const { app, recorder } = await buildRuntimeApp({
+    listIncrementalClinicRouteEvents: async () => [
+      buildRouteEvent({ id: 77 }),
+      buildRouteEvent({ id: 78 }),
+    ],
+  });
+
+  try {
+    const response = await app.inject(
+      getInput("/api/logistics/route-events/poll?afterId=70&limit=10"),
+    );
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(recorder.pollCalls[0], {
+      clinicId: CLINIC_ID,
+      afterId: 70,
+      limit: 10,
+    });
+    assert.equal(body.count, 2);
+    assert.equal(body.lastEventId, 78);
+    assert.deepEqual(body.polling, { afterId: 70, limit: 10 });
+    assert.equal(body.routeEvents[1].id, 78);
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET poll aplica defaults y límite máximo actuales", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    await app.inject(getInput("/api/logistics/route-events/poll"));
+    await app.inject(getInput("/api/logistics/route-events/poll?limit=5000"));
+
+    assert.deepEqual(recorder.pollCalls[0], {
+      clinicId: CLINIC_ID,
+      afterId: 0,
+      limit: 50,
+    });
+    assert.equal(recorder.pollCalls[1]?.limit, 100);
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET poll con lista vacía preserva el cursor recibido", async () => {
+  const { app } = await buildRuntimeApp({
+    listIncrementalClinicRouteEvents: async () => [],
+  });
+
+  try {
+    const response = await app.inject(
+      getInput("/api/logistics/route-events/poll?afterId=42"),
+    );
+
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      count: 0,
+      lastEventId: 42,
+      routeEvents: [],
+      polling: { afterId: 42, limit: 50 },
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+// ------------------------------------------ GET /route-plans/:routePlanId
+
+test("GET route-plan events reenvía routePlanId, tenant y filtros", async () => {
+  const { app, recorder } = await buildRuntimeApp({
+    listRouteEventsForClinicRoutePlan: async () => [buildRouteEvent()],
+  });
+
+  try {
+    const response = await app.inject(
+      getInput(
+        "/api/logistics/route-events/route-plans/11?routeStopId=22&eventType=stop.arrived&afterId=3&limit=15&offset=5",
+      ),
+    );
+    const body = JSON.parse(response.body);
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(recorder.routePlanCalls.length, 1);
+    assert.equal(recorder.routePlanCalls[0]?.routePlanId, 11);
+    assert.equal(recorder.routePlanCalls[0]?.clinicId, CLINIC_ID);
+    assert.deepEqual(recorder.routePlanCalls[0]?.params, {
+      routeStopId: 22,
+      eventType: "stop.arrived",
+      afterId: 3,
+      limit: 15,
+      offset: 5,
+    });
+    assert.equal(body.routePlanId, 11);
+    assert.deepEqual(body.pagination, { limit: 15, offset: 5, afterId: 3 });
+    assert.equal(body.routeEvents[0].source, "clinic");
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET route-plan events devuelve lista vacía para un plan inexistente", async () => {
+  const { app, recorder } = await buildRuntimeApp({
+    listRouteEventsForClinicRoutePlan: async () => [],
+  });
+
+  try {
+    const response = await app.inject(
+      getInput("/api/logistics/route-events/route-plans/999999"),
+    );
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      count: 0,
+      routePlanId: 999999,
+      routeEvents: [],
+      pagination: { limit: 50, offset: 0, afterId: 0 },
+    });
+    assert.equal(recorder.routePlanCalls[0]?.routePlanId, 999999);
+  } finally {
+    await app.close();
+  }
+});
+
+test("GET route-plan events responde 400 ante routePlanId inválido sin llamar al puerto", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    const response = await app.inject(
+      getInput("/api/logistics/route-events/route-plans/abc"),
+    );
+
+    assert.equal(response.statusCode, 400);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "routePlanId invalido",
+    });
+    assert.equal(recorder.routePlanCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});
+
+// -------------------------------------------------------------- OPTIONS
+
+test("OPTIONS permanece íntegramente en Fastify para las tres rutas", async () => {
+  const { app, recorder } = await buildRuntimeApp();
+
+  try {
+    for (const url of [
+      "/api/logistics/route-events/",
+      "/api/logistics/route-events/poll",
+      "/api/logistics/route-events/route-plans/11",
+    ]) {
+      const response = await app.inject({
+        method: "OPTIONS",
+        url,
+        headers: { origin: VALID_ORIGIN },
+      });
+
+      assert.equal(response.statusCode, 204);
+      assert.equal(
+        response.headers["access-control-allow-methods"],
+        "GET,POST,OPTIONS",
+      );
+    }
+
+    const blocked = await app.inject({
+      method: "OPTIONS",
+      url: "/api/logistics/route-events/",
+      headers: { origin: BLOCKED_ORIGIN },
+    });
+
+    assert.equal(blocked.statusCode, 403);
+    assert.equal(recorder.createCalls.length, 0);
+    assert.equal(recorder.listCalls.length, 0);
+    assert.equal(recorder.pollCalls.length, 0);
+    assert.equal(recorder.routePlanCalls.length, 0);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/unit/application/logistics/create-route-event.test.ts
+++ b/test/unit/application/logistics/create-route-event.test.ts
@@ -1,0 +1,229 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createCreateRouteEvent,
+  type LogisticsRouteEventWriteRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubRouteEvent = {
+  id: number;
+  clinicId: number;
+  routePlanId: number | null;
+  routeStopId: number | null;
+  eventType: string;
+  payload: Record<string, unknown> | null;
+};
+
+type StubCreateInput = {
+  clinicId: number;
+  routePlanId?: number | null;
+  routeStopId?: number | null;
+  eventType: string;
+  eventTime?: Date;
+  payload?: Record<string, unknown> | null;
+  lat?: number | null;
+  lng?: number | null;
+  source?: string;
+};
+
+type RepositoryResult = StubRouteEvent | null | undefined;
+
+function createRepositoryStub(behavior: {
+  result?: RepositoryResult;
+  error?: Error;
+}) {
+  const calls: Array<{ args: unknown[]; input: StubCreateInput }> = [];
+
+  const repository: LogisticsRouteEventWriteRepository<
+    StubRouteEvent,
+    StubCreateInput
+  > = {
+    createRouteEvent: (...args: [StubCreateInput]) => {
+      calls.push({ args, input: args[0] });
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.result);
+    },
+  };
+
+  return { repository, calls };
+}
+
+function buildInput(overrides: Partial<StubCreateInput> = {}): StubCreateInput {
+  return {
+    clinicId: 7,
+    routePlanId: 11,
+    routeStopId: 22,
+    eventType: "stop_arrived",
+    eventTime: new Date("2026-07-20T10:00:00.000Z"),
+    payload: { note: "llegada" },
+    lat: -34.6,
+    lng: -58.4,
+    source: "manual",
+    ...overrides,
+  };
+}
+
+test("createRouteEvent delega exactamente una vez con el mismo input y devuelve por identidad", async () => {
+  const input = buildInput();
+  const result: StubRouteEvent = {
+    id: 501,
+    clinicId: 7,
+    routePlanId: 11,
+    routeStopId: 22,
+    eventType: "stop_arrived",
+    payload: { note: "llegada" },
+  };
+  const { repository, calls } = createRepositoryStub({ result });
+  const createRouteEvent = createCreateRouteEvent(repository);
+
+  const received = await createRouteEvent(input);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0]?.args.length, 1);
+  assert.strictEqual(calls[0]?.input, input);
+  assert.strictEqual(received, result);
+});
+
+test("createRouteEvent no muta el input ni aplica defaults", async () => {
+  const input = buildInput({
+    routePlanId: null,
+    routeStopId: null,
+    payload: null,
+    lat: null,
+    lng: null,
+  });
+  const snapshot = { ...input };
+  const { repository, calls } = createRepositoryStub({ result: undefined });
+  const createRouteEvent = createCreateRouteEvent(repository);
+
+  await createRouteEvent(input);
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(input, snapshot);
+  assert.deepEqual(calls[0]?.input, snapshot);
+  assert.equal(calls[0]?.input.source, "manual");
+});
+
+test("createRouteEvent preserva un input mínimo sin campos opcionales", async () => {
+  const input: StubCreateInput = { clinicId: 7, eventType: "note" };
+  const { repository, calls } = createRepositoryStub({ result: undefined });
+  const createRouteEvent = createCreateRouteEvent(repository);
+
+  await createRouteEvent(input);
+
+  assert.equal(calls.length, 1);
+  assert.deepEqual(Object.keys(calls[0]?.input ?? {}), [
+    "clinicId",
+    "eventType",
+  ]);
+  assert.equal("source" in (calls[0]?.input ?? {}), false);
+});
+
+test("createRouteEvent preserva null", async () => {
+  const { repository, calls } = createRepositoryStub({ result: null });
+  const createRouteEvent = createCreateRouteEvent(repository);
+
+  const received = await createRouteEvent(buildInput());
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, null);
+});
+
+test("createRouteEvent preserva undefined", async () => {
+  const { repository, calls } = createRepositoryStub({ result: undefined });
+  const createRouteEvent = createCreateRouteEvent(repository);
+
+  const received = await createRouteEvent(buildInput());
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, undefined);
+});
+
+test("createRouteEvent propaga el error original del puerto sin envolverlo", async () => {
+  const originalError = new Error("fallo de append");
+  const { repository, calls } = createRepositoryStub({ error: originalError });
+  const createRouteEvent = createCreateRouteEvent(repository);
+  let caught: unknown;
+
+  await assert.rejects(createRouteEvent(buildInput()), (error: unknown) => {
+    caught = error;
+    return error === originalError;
+  });
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(caught, originalError);
+});
+
+test("createRouteEvent no invoca ninguna otra operación adyacente del puerto", async () => {
+  const observed: string[] = [];
+  const repository: LogisticsRouteEventWriteRepository<
+    StubRouteEvent,
+    StubCreateInput
+  > & {
+    listClinicRouteEvents: () => Promise<StubRouteEvent[]>;
+    listIncrementalClinicRouteEvents: () => Promise<StubRouteEvent[]>;
+  } = {
+    createRouteEvent: async (input) => {
+      observed.push("createRouteEvent");
+      return { ...input, id: 1 } as unknown as StubRouteEvent;
+    },
+    listClinicRouteEvents: async () => {
+      observed.push("listClinicRouteEvents");
+      return [];
+    },
+    listIncrementalClinicRouteEvents: async () => {
+      observed.push("listIncrementalClinicRouteEvents");
+      return [];
+    },
+  };
+
+  const createRouteEvent = createCreateRouteEvent(repository);
+  await createRouteEvent(buildInput());
+
+  assert.deepEqual(observed, ["createRouteEvent"]);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/create-route-event.ts",
+  "server/features/logistics/application/ports/logistics-route-event-write-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("el caso de uso create route event de M10 no importa HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/route-events-read-use-cases.test.ts
+++ b/test/unit/application/logistics/route-events-read-use-cases.test.ts
@@ -1,0 +1,287 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createRouteEventsReadUseCases,
+  type LogisticsRouteEventsReadRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubRouteEvent = {
+  id: number;
+  clinicId: number;
+  routePlanId: number | null;
+  eventType: string;
+};
+
+type StubListParams = {
+  clinicId: number;
+  routePlanId?: number;
+  routeStopId?: number;
+  eventType?: string;
+  afterId?: number;
+  limit?: number;
+  offset?: number;
+};
+
+type StubRoutePlanListParams = Omit<StubListParams, "clinicId" | "routePlanId">;
+
+type ListCall = { args: unknown[]; params: StubListParams };
+type RoutePlanCall = {
+  args: unknown[];
+  routePlanId: number;
+  clinicId: number;
+  params?: StubRoutePlanListParams;
+};
+type PollCall = {
+  args: unknown[];
+  clinicId: number;
+  afterId: number;
+  limit?: number;
+};
+
+function createRepositoryStub(behavior: {
+  list?: StubRouteEvent[];
+  routePlan?: StubRouteEvent[];
+  poll?: StubRouteEvent[];
+  error?: Error;
+}) {
+  const listCalls: ListCall[] = [];
+  const routePlanCalls: RoutePlanCall[] = [];
+  const pollCalls: PollCall[] = [];
+
+  const reject = <T,>(): Promise<T> => Promise.reject(behavior.error);
+
+  const repository: LogisticsRouteEventsReadRepository<
+    StubRouteEvent,
+    StubListParams,
+    StubRoutePlanListParams
+  > = {
+    listClinicRouteEvents: (...args: [StubListParams]) => {
+      listCalls.push({ args, params: args[0] });
+      return behavior.error
+        ? reject<StubRouteEvent[]>()
+        : Promise.resolve(behavior.list ?? []);
+    },
+    listRouteEventsForClinicRoutePlan: (
+      ...args: [number, number, (StubRoutePlanListParams | undefined)?]
+    ) => {
+      routePlanCalls.push({
+        args,
+        routePlanId: args[0],
+        clinicId: args[1],
+        params: args[2],
+      });
+      return behavior.error
+        ? reject<StubRouteEvent[]>()
+        : Promise.resolve(behavior.routePlan ?? []);
+    },
+    listIncrementalClinicRouteEvents: (
+      ...args: [number, number, (number | undefined)?]
+    ) => {
+      pollCalls.push({
+        args,
+        clinicId: args[0],
+        afterId: args[1],
+        limit: args[2],
+      });
+      return behavior.error
+        ? reject<StubRouteEvent[]>()
+        : Promise.resolve(behavior.poll ?? []);
+    },
+  };
+
+  return { repository, listCalls, routePlanCalls, pollCalls };
+}
+
+test("listRouteEvents reenvía los params una vez y devuelve la lista por identidad", async () => {
+  const params: StubListParams = {
+    clinicId: 7,
+    routePlanId: 11,
+    routeStopId: 22,
+    eventType: "stop_arrived",
+    afterId: 0,
+    limit: 50,
+    offset: 0,
+  };
+  const list: StubRouteEvent[] = [
+    { id: 1, clinicId: 7, routePlanId: 11, eventType: "stop_arrived" },
+  ];
+  const { repository, listCalls, routePlanCalls, pollCalls } =
+    createRepositoryStub({ list });
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.listRouteEvents(params);
+
+  assert.equal(listCalls.length, 1);
+  assert.equal(listCalls[0]?.args.length, 1);
+  assert.strictEqual(listCalls[0]?.params, params);
+  assert.strictEqual(received, list);
+  assert.equal(routePlanCalls.length, 0);
+  assert.equal(pollCalls.length, 0);
+});
+
+test("listRouteEvents preserva array vacío y no muta los params", async () => {
+  const params: StubListParams = { clinicId: 7 };
+  const snapshot = { ...params };
+  const empty: StubRouteEvent[] = [];
+  const { repository, listCalls } = createRepositoryStub({ list: empty });
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.listRouteEvents(params);
+
+  assert.equal(listCalls.length, 1);
+  assert.strictEqual(received, empty);
+  assert.deepEqual(received, []);
+  assert.deepEqual(params, snapshot);
+});
+
+test("listRoutePlanEvents reenvía routePlanId, clinicId y params en orden", async () => {
+  const params: StubRoutePlanListParams = {
+    routeStopId: 22,
+    eventType: "stop_arrived",
+    afterId: 5,
+    limit: 25,
+    offset: 10,
+  };
+  const routePlan: StubRouteEvent[] = [
+    { id: 3, clinicId: 7, routePlanId: 11, eventType: "stop_arrived" },
+  ];
+  const { repository, routePlanCalls, listCalls, pollCalls } =
+    createRepositoryStub({ routePlan });
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.listRoutePlanEvents(11, 7, params);
+
+  assert.equal(routePlanCalls.length, 1);
+  assert.deepEqual(routePlanCalls[0]?.args, [11, 7, params]);
+  assert.strictEqual(routePlanCalls[0]?.params, params);
+  assert.strictEqual(received, routePlan);
+  assert.equal(listCalls.length, 0);
+  assert.equal(pollCalls.length, 0);
+});
+
+test("listRoutePlanEvents preserva params undefined sin sustituirlo por un default", async () => {
+  const { repository, routePlanCalls } = createRepositoryStub({});
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.listRoutePlanEvents(11, 7);
+
+  assert.equal(routePlanCalls.length, 1);
+  assert.strictEqual(routePlanCalls[0]?.params, undefined);
+  assert.deepEqual(routePlanCalls[0]?.args, [11, 7, undefined]);
+  assert.deepEqual(received, []);
+});
+
+test("listRoutePlanEvents devuelve lista vacía para un plan sin eventos", async () => {
+  const empty: StubRouteEvent[] = [];
+  const { repository, routePlanCalls } = createRepositoryStub({
+    routePlan: empty,
+  });
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.listRoutePlanEvents(9999, 7, {});
+
+  assert.equal(routePlanCalls.length, 1);
+  assert.equal(routePlanCalls[0]?.routePlanId, 9999);
+  assert.equal(routePlanCalls[0]?.clinicId, 7);
+  assert.strictEqual(received, empty);
+});
+
+test("pollRouteEvents reenvía clinicId, afterId y limit en orden", async () => {
+  const poll: StubRouteEvent[] = [
+    { id: 12, clinicId: 7, routePlanId: null, eventType: "note" },
+  ];
+  const { repository, pollCalls, listCalls, routePlanCalls } =
+    createRepositoryStub({ poll });
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.pollRouteEvents(7, 11, 50);
+
+  assert.equal(pollCalls.length, 1);
+  assert.deepEqual(pollCalls[0]?.args, [7, 11, 50]);
+  assert.strictEqual(received, poll);
+  assert.equal(listCalls.length, 0);
+  assert.equal(routePlanCalls.length, 0);
+});
+
+test("pollRouteEvents preserva limit undefined y afterId 0 sin aplicar defaults", async () => {
+  const { repository, pollCalls } = createRepositoryStub({});
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  const received = await useCases.pollRouteEvents(7, 0);
+
+  assert.equal(pollCalls.length, 1);
+  assert.deepEqual(pollCalls[0]?.args, [7, 0, undefined]);
+  assert.strictEqual(pollCalls[0]?.afterId, 0);
+  assert.strictEqual(pollCalls[0]?.limit, undefined);
+  assert.deepEqual(received, []);
+});
+
+test("cada lectura propaga el error original del puerto sin envolverlo", async () => {
+  const originalError = new Error("fallo de lectura");
+  const { repository, listCalls, routePlanCalls, pollCalls } =
+    createRepositoryStub({ error: originalError });
+  const useCases = createRouteEventsReadUseCases(repository);
+
+  for (const invoke of [
+    () => useCases.listRouteEvents({ clinicId: 7 }),
+    () => useCases.listRoutePlanEvents(11, 7, {}),
+    () => useCases.pollRouteEvents(7, 0, 50),
+  ]) {
+    let caught: unknown;
+
+    await assert.rejects(invoke(), (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    });
+
+    assert.strictEqual(caught, originalError);
+  }
+
+  assert.equal(listCalls.length, 1);
+  assert.equal(routePlanCalls.length, 1);
+  assert.equal(pollCalls.length, 1);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/route-events-read-use-cases.ts",
+  "server/features/logistics/application/ports/logistics-route-events-read-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("los casos de uso de lectura de route events de M10 no importan HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

Extracts the existing Logistics route-event append and read operations into the application layer.

The change introduces:

- a narrow write port for explicit route-event append;
- a narrow read port for clinic-scoped route-event queries;
- the `createCreateRouteEvent` application factory;
- grouped route-event read use cases;
- composition from the existing `LogisticsRouteEventsNativeRoutesOptions` seam;
- delegation from the four existing data handlers;
- focused unit, source-contract and Fastify runtime coverage.

The Fastify adapter continues to own HTTP behavior, authentication, sessions, RBAC, trusted-origin enforcement, CORS, parsing, validation, serialization and audit ordering.

## Scope

- [x] Backend runtime

Included handlers:

- `POST /api/logistics/route-events`;
- `GET /api/logistics/route-events`;
- `GET /api/logistics/route-events/poll`;
- `GET /api/logistics/route-events/route-plans/:routePlanId`.

Included application operations:

- explicit append through `createRouteEvent`;
- clinic-scoped listing through `listClinicRouteEvents`;
- incremental polling through `listIncrementalClinicRouteEvents`;
- clinic-scoped route-plan listing through `listRouteEventsForClinicRoutePlan`.

The three `OPTIONS` handlers remain entirely in Fastify.

## Contract Preservation

The following remain unchanged:

- endpoints, methods and route prefix;
- request payloads, query parameters and path parameters;
- status codes and response messages;
- response envelopes and serialization;
- event types and sources;
- `eventTime`, payload and coordinates;
- authentication and `app_session_id`;
- session lookup, refresh and deletion;
- trusted-origin enforcement and CORS;
- RBAC and `canManageLogisticsRouteEvents`;
- clinic tenant derivation and propagation;
- pagination, limits, offset and `afterId`;
- ordering by ascending event ID;
- append-only application behavior;
- nullability and error propagation;
- database queries and transactions;
- audit execution after a successful append;
- current audit-failure isolation;
- currently permitted duplicate events.

Application factories delegate exactly once and do not normalize results, catch errors, add defaults or mutate inputs.

## No-Scope

- automatic event creation;
- route-plan lifecycle producers;
- route-stop status producers;
- field-visit status producers;
- heuristic-generation producers;
- automatic `no_show` events;
- lifecycle `release`, `start` or `complete`;
- changes to `cancel`;
- event bus, outbox or unit of work;
- retries, deduplication or idempotency keys;
- optimistic locking;
- route-event update or deletion;
- new endpoints;
- new event types;
- ordering by `eventTime`;
- validation that `routeStopId` belongs to the supplied `routePlanId`;
- database queries or transaction boundaries;
- `server/db-logistics.ts`;
- schema or migrations;
- Fastify application registration;
- shared route stubs;
- frontend;
- dependencies or lockfiles;
- workflows or CI configuration;
- M11 application-layer closeout;
- later thin-route milestones.

## Preexisting Debt

The existing append operation validates `routePlanId` and `routeStopId` independently within the authenticated clinic, but does not verify that the stop belongs to the supplied plan.

M10 intentionally preserves that behavior. Correcting it would be a separate functional and persistence-contract change.

## Validation

- PASSED — M10 application unit tests: 17/17.
- PASSED — source contract, M10 runtime and existing audit runtime: 45/45.
- PASSED — RBAC, CSRF, auth boundary, production invariants and audit completeness: 43/43.
- PASSED — DB, schema and route-event aggregation regression tests: 40/40.
- PASSED — directed aggregate: 145/145.
- PASSED — `pnpm validate:local`: 3248 tests, 3247 passed, 0 failed, 1 preexisting skip; typechecks and build completed.
- PASSED — `pnpm security:public-surface`.
- PASSED — `git diff --check`.
- PASSED — `git diff --cached --check`.
- PASSED — exact 13-file scope review.
- PASSED — denylist review.
- PASSED — zero Playwright artifacts and unchanged `frontend/next-env.d.ts`.

## Rollback

Revert this pull request.

The rollback restores the four direct `deps.*` invocations in the existing route-event handlers and removes the M10 ports, application factories, tests and documentation.

No database migration, schema change, data rewrite or deployment-specific rollback is required.

## Data Impact

None.

No database query, transaction, schema, migration or persisted-data contract was changed.