### PR TITLE
fix(security): patch brace-expansion advisory

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
   brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   esbuild: 0.28.1
   fast-uri@<=3.1.1: 3.1.2

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,7 +5,8 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@>=5.0.0 <5.0.6: 5.0.6
+  brace-expansion@<1.1.16: 1.1.16
+  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
   esbuild: 0.28.1
   fast-uri@<=3.1.1: 3.1.2
   postcss@<8.5.10: 8.5.14
@@ -1566,11 +1567,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.14:
-    resolution: {integrity: sha512-MWPGfDxnyzKU7rNOW9SP/c50vi3xrmrua/+6hfPbCS2ABNWfx24vPidzvC7krjU/RTo235sV776ymlsMtGKj8g==}
+  brace-expansion@1.1.16:
+    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
 
-  brace-expansion@5.0.6:
-    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+  brace-expansion@5.0.7:
+    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
     engines: {node: 18 || 20 || >=22}
 
   braces@3.0.3:
@@ -4431,12 +4432,12 @@ snapshots:
 
   baseline-browser-mapping@2.10.40: {}
 
-  brace-expansion@1.1.14:
+  brace-expansion@1.1.16:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
 
-  brace-expansion@5.0.6:
+  brace-expansion@5.0.7:
     dependencies:
       balanced-match: 4.0.4
 
@@ -5428,11 +5429,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.6
+      brace-expansion: 5.0.7
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.14
+      brace-expansion: 1.1.16
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -8,6 +8,7 @@ preferWorkspacePackages: true
 
 overrides:
   "brace-expansion@<1.1.16": "1.1.16"
+  "brace-expansion@>=2.0.0 <2.1.2": "2.1.2"
   "brace-expansion@>=3.0.0 <5.0.7": "5.0.7"
   esbuild: "0.28.1"
   "fast-uri@<=3.1.1": "3.1.2"

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,7 +7,8 @@ autoInstallPeers: true
 preferWorkspacePackages: true
 
 overrides:
-  "brace-expansion@>=5.0.0 <5.0.6": "5.0.6"
+  "brace-expansion@<1.1.16": "1.1.16"
+  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7"
   esbuild: "0.28.1"
   "fast-uri@<=3.1.1": "3.1.2"
   "postcss@<8.5.10": "8.5.14"

--- a/test/architecture/toolchain-contract.test.ts
+++ b/test/architecture/toolchain-contract.test.ts
@@ -18,6 +18,7 @@ const PNPM_WORKFLOW_FILES = [
 
 const SECURITY_OVERRIDE_LINES = [
   '  "brace-expansion@<1.1.16": "1.1.16"',
+  '  "brace-expansion@>=2.0.0 <2.1.2": "2.1.2"',
   '  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7"',
   '  esbuild: "0.28.1"',
   '  "fast-uri@<=3.1.1": "3.1.2"',

--- a/test/architecture/toolchain-contract.test.ts
+++ b/test/architecture/toolchain-contract.test.ts
@@ -17,7 +17,8 @@ const PNPM_WORKFLOW_FILES = [
 ] as const;
 
 const SECURITY_OVERRIDE_LINES = [
-  '  "brace-expansion@>=5.0.0 <5.0.6": "5.0.6"',
+  '  "brace-expansion@<1.1.16": "1.1.16"',
+  '  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7"',
   '  esbuild: "0.28.1"',
   '  "fast-uri@<=3.1.1": "3.1.2"',
   '  "postcss@<8.5.10": "8.5.14"',


### PR DESCRIPTION
## Summary
- Change type: Security dependency remediation
- Context / issue: GHSA-3jxr-9vmj-r5cp
- What changed: Replaced vulnerable brace-expansion resolutions with patched 1.1.16 and 5.0.7 overrides, regenerated the lockfile, and updated the exact toolchain guardrail.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [x] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

## Mixed-Scope Justification
Not applicable.

## Other Scope Detail
Not applicable.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [x] `pnpm --dir frontend lint` (if frontend affected)
- [x] `pnpm --dir frontend typecheck` (if frontend affected)
- [x] `pnpm --dir frontend build` (if frontend affected)
- [x] `pnpm audit --prod` (if dependencies affected)
- [x] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Local evidence:
- `pnpm audit --prod`: 0 vulnerabilities.
- `pnpm audit`: 0 vulnerabilities.
- `pnpm validate:local`: 3265 passed, 0 failed.
- `pnpm why brace-expansion -r`: only 1.1.16 and 5.0.7.
- Frontend lint, typecheck and build passed.
- `git diff --check` passed.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Rollback
- Trigger: Dependency resolution, lint, build or CI regression.
- Steps: Revert this pull request.
- Data impact: None. No runtime data or schema changes.