### PR TITLE
refactor(logistics): thin field visits handlers

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -829,7 +829,8 @@ lifecycle (`cancel`) · **M09** UC field-visits (asignación + estados) · **M10
 > y migraciones. Detalle en
 > [`docs/implementation/m13-logistics-cache-infrastructure-move.md`](../implementation/m13-logistics-cache-infrastructure-move.md).
 >
-> **Status M14 — implementado / pendiente de merge.** Thin
+> **Status M14 — mergeado** (PR #1512, squash SHA
+> `c48791657a4c0eb9532d24df367cae8d18da3b7b`). Thin
 > `logistics-route-plans`: la ruta deja de importar y orquestar el cache
 > directamente. Se introduce el **puerto opaco**
 > `LogisticsRoutePlansCacheRepository` (application/ports) **junto con su primer
@@ -862,7 +863,43 @@ lifecycle (`cancel`) · **M09** UC field-visits (asignación + estados) · **M10
 > mitigado). Cero cambios de endpoints, contratos HTTP, schema y migraciones.
 > Detalle en
 > [`docs/implementation/m14-logistics-route-plans-thin-route.md`](../implementation/m14-logistics-route-plans-thin-route.md).
-> **M15 — pendiente** (thin `logistics-field-visits`). **Fase C no cerrada.**
+>
+> **Status M15 — implementado / pendiente de merge.** Thin
+> `logistics-field-visits`: los seis handlers que aún invocaban `deps.*`
+> directamente (`GET /` listado, `POST /` creación, `GET/PUT
+> /:fieldVisitId/location`, `GET/POST /:fieldVisitId/time-windows`) delegan en
+> casos de uso de application (`createListFieldVisits`,
+> `createCreateFieldVisit`, `createVisitLocationUseCases`,
+> `createTimeWindowUseCases`), cada uno compuesto **exactamente una vez** antes
+> de los handlers sobre puertos mínimos genéricos derivados del seam
+> `LogisticsFieldVisitsNativeRoutesOptions`
+> (`LogisticsFieldVisitsReadRepository`, `LogisticsFieldVisitCreateRepository`,
+> `LogisticsVisitLocationRepository`, `LogisticsTimeWindowsRepository`). Cada
+> operación delega una vez y preserva identidad, `null`/`undefined`, array
+> vacío y errores sin envolver. El PATCH conserva **intacto** el caso de uso
+> M09 (`createUpdateFieldVisit` y su puerto). La ruta queda **sin ninguna
+> referencia a `db-logistics`** (ni estática, ni dinámica, ni type-only, ni
+> textual): los 8 tipos de I/O y las 7 operaciones de persistencia llegan por
+> el adapter mínimo `logistics-field-visits-db-adapter.ts` (referencias
+> directas al canónico de M12, laziness de `loadDefaultDeps` preservada; el
+> guard fija superficie exacta de 7 operaciones, sin queries ni transacciones
+> propias). La ruta conserva sólo HTTP: CORS por-ruta, preflight,
+> trusted-origin, auth de sesión de clínica (`app_session_id` vía
+> `ENV.cookieName`), RBAC `canManageLogisticsFieldVisits`, parsing,
+> validaciones, serializers (location sin `createdAt`), paginación 50/100,
+> mensajes y status codes, carácter por carácter. **No se agregó** cache,
+> auditoría, máquina de estados, endpoints ni side-effects. El shim
+> `server/db-logistics.ts` **permanece intacto** (route-events y SLA lo
+> consumen hasta M16; retiro global en M17); el canónico M12 permanece
+> byte-idéntico con sus 7 transacciones. Contratos realineados in-PR sin
+> debilitar: `logistics-field-visits-api` (`dbLogistics.*` → `fieldVisitsDb.*`,
+> el contrato M09 de deps directas out-of-scope reemplazado por los contratos
+> M15 de delegación) y guard de infraestructura extendido (adapter M15 + ruta
+> sin `db-logistics`). Cero cambios de endpoints, contratos HTTP, schema y
+> migraciones. Detalle en
+> [`docs/implementation/m15-logistics-field-visits-thin-route.md`](../implementation/m15-logistics-field-visits-thin-route.md).
+> **M16 — pendiente** (thin `logistics-route-events` + `logistics-sla`).
+> **Fase C no cerrada.**
 
 **M12** mover `db-logistics.ts` completo → infrastructure (tx intactas; shim documentado) ·
 **M13** cache adapter · **M14** thin `logistics-route-plans` · **M15** thin

--- a/docs/implementation/m15-logistics-field-visits-thin-route.md
+++ b/docs/implementation/m15-logistics-field-visits-thin-route.md
@@ -1,0 +1,173 @@
+# M15 — Logistics: thin `logistics-field-visits` (casos de uso + adapter DB)
+
+**Estado:** implementado / **pendiente de merge**. Working tree listo para revisión
+manual de Nico; ninguna escritura Git/GitHub ejecutada por el agente.
+
+- **Rama:** `refactor/backend-modularization-m15-thin-logistics-field-visits`
+- **Base exacta:** `c48791657a4c0eb9532d24df367cae8d18da3b7b`
+  (`refactor(logistics): thin route plans handlers (#1512)` = **M14 ya mergeado**)
+- **Programa:** Fase C (Logistics infra + rutas), milestone **M15**
+- **Autorización:** refactor **R2 estructural backend**, autorizado específicamente
+  por Nico en la tarea actual (AGENTS.md §3), limitado al diseño, allowlist,
+  invariantes y validaciones de la auditoría R0 entregada en la misma sesión.
+
+## 1. Objetivo y alcance
+
+Adelgazar `server/routes/logistics-field-visits.fastify.ts`: los seis handlers
+que aún invocaban `deps.*` directamente delegan en casos de uso de application,
+y la ruta deja de tener **cualquier** referencia a `db-logistics` (la carga
+default de persistencia pasa por un adapter mínimo de infrastructure).
+
+**Incluido:** 4 puertos mínimos, 4 módulos de casos de uso, adapter DB de field
+visits, ruta delegando, realineación de contratos in-PR, documentación.
+**Excluido:** M16, M17; el UC/puerto M09 (intactos); el canónico M12 y el shim
+raíz (intactos); cache; auditoría; schema; migraciones; dependencias; auth
+global; CORS helpers; rutas de route-plans/route-events/SLA; frontend; CI.
+
+## 2. Baseline R0 (medido en HEAD `c487916`)
+
+| Métrica | Valor |
+| --- | --- |
+| LOC de la ruta (`wc -l`) | **1.427** → **1.453** tras M15 (+26 netas: zona de composición de los 4 UCs) |
+| Endpoints | 7 funcionales + 4 `OPTIONS` (sin cambios) |
+| Fuga de capa | shim `../db-logistics.ts`: 8 tipos estáticos + 7 operaciones vía import dinámico lazy |
+| Llamadas `deps.*` DB directas en handlers | **6** (la séptima, update, ya pasaba por el UC M09) |
+| Cache / auditoría / transacciones / queries inline | 0 / 0 / 0 / 0 |
+
+## 3. Diseño implementado
+
+```text
+route (HTTP: CORS, trusted-origin, auth cookie, RBAC, parsing, status codes, serialización)
+  -> createListFieldVisits          -> LogisticsFieldVisitsReadRepository
+  -> createCreateFieldVisit         -> LogisticsFieldVisitCreateRepository
+  -> createVisitLocationUseCases    -> LogisticsVisitLocationRepository
+  -> createTimeWindowUseCases       -> LogisticsTimeWindowsRepository
+  -> createUpdateFieldVisit (M09, intacto) -> LogisticsFieldVisitUpdateRepository
+  -> loadDefaultDeps (lazy, forma intacta)
+       -> createLogisticsFieldVisitsDbAdapter (infrastructure, M15)
+            -> db-logistics.ts (canónico M12, intacto)
+```
+
+- **Puertos** (application/ports, nuevos): estructurales, genéricos, derivados
+  del seam `LogisticsFieldVisitsNativeRoutesOptions`; sin Fastify, Drizzle,
+  schema, `db-logistics`, `server/lib` ni tipos concretos de infraestructura.
+- **Casos de uso**: cada operación recibe inputs ya autenticados, clinic-scoped
+  y validados; delega exactamente una vez; devuelve la misma promesa/resultado
+  (identidad, `null`, `undefined`, array vacío); propaga el mismo error sin
+  envolver; no serializa, no mapea status HTTP, no genera mensajes, no agrega
+  side-effects.
+- **Composición**: cada factory se compone **exactamente una vez** en la zona de
+  composición de la ruta, antes de los handlers (contrato M11 de completeness).
+- **Adapter DB** `createLogisticsFieldVisitsDbAdapter()`: referencias directas a
+  las 7 operaciones canónicas (`createFieldVisit`, `listClinicFieldVisits`,
+  `updateClinicScopedFieldVisit`, `getVisitLocationForClinicVisit`,
+  `upsertVisitLocationForClinicVisit`, `createTimeWindowForClinicVisit`,
+  `listTimeWindowsForClinicVisit`) + re-export de los 8 tipos de I/O. Sólo
+  importa `./db-logistics.ts`; sin queries, sin `.transaction`, sin wrappers,
+  sin captura de errores, sin imports de application/Fastify/`server/lib`.
+- **Ruta**: los tipos y la carga default llegan por el adapter (laziness de
+  `loadDefaultDeps` preservada: registrar el plugin con todas las deps
+  inyectadas sigue sin cargar `server/db.ts` ni la DB real). Cero referencias
+  estáticas, dinámicas, type-only o textuales a `db-logistics`. CORS, preflight,
+  trusted-origin, auth de sesión (`app_session_id` vía `ENV.cookieName`,
+  expiración, clear-cookie, refresh last-access), RBAC
+  `canManageLogisticsFieldVisits`, parsing, validaciones, serializers, mensajes
+  y status codes: carácter por carácter iguales.
+
+## 4. Archivos (allowlist ejecutada: 22 paths, 0 eliminados)
+
+| Archivo | Cambio |
+| --- | --- |
+| `server/features/logistics/application/ports/logistics-field-visits-read-repository.ts` | **NUEVO.** Puerto de listado. |
+| `server/features/logistics/application/ports/logistics-field-visit-create-repository.ts` | **NUEVO.** Puerto de creación. |
+| `server/features/logistics/application/ports/logistics-visit-location-repository.ts` | **NUEVO.** Puerto de ubicación (get + upsert). |
+| `server/features/logistics/application/ports/logistics-time-windows-repository.ts` | **NUEVO.** Puerto de ventanas horarias (list + create). |
+| `server/features/logistics/application/list-field-visits.ts` | **NUEVO.** UC `createListFieldVisits`. |
+| `server/features/logistics/application/create-field-visit.ts` | **NUEVO.** UC `createCreateFieldVisit`. |
+| `server/features/logistics/application/visit-location-use-cases.ts` | **NUEVO.** UCs `getVisitLocation`/`upsertVisitLocation`. |
+| `server/features/logistics/application/time-window-use-cases.ts` | **NUEVO.** UCs `listTimeWindows`/`createTimeWindow`. |
+| `server/features/logistics/application/index.ts` | **MODIFICADO.** Barrel: 4 factories + 4 tipos de UC + 4 puertos M15. |
+| `server/features/logistics/infrastructure/logistics-field-visits-db-adapter.ts` | **NUEVO.** Adapter DB mínimo (7 ops + 8 tipos). |
+| `server/routes/logistics-field-visits.fastify.ts` | **MODIFICADO.** Delegación de los 6 handlers; tipos y carga default vía adapter; cero referencias a `db-logistics`. |
+| `test/unit/application/logistics/list-field-visits.test.ts` | **NUEVO.** 5 tests (identidad, array vacío, llamadas independientes, error, frontera de imports). |
+| `test/unit/application/logistics/create-field-visit.test.ts` | **NUEVO.** 5 tests (identidad, null, undefined, error, frontera). |
+| `test/unit/application/logistics/visit-location-use-cases.test.ts` | **NUEVO.** 6 tests (get/upsert: identidad, null/undefined, errores independientes, frontera). |
+| `test/unit/application/logistics/time-window-use-cases.test.ts` | **NUEVO.** 6 tests (list/create: identidad, array vacío, null/undefined, errores, frontera). |
+| `test/integration/adapters/controllers/logistics-field-visits-api.test.ts` | **MODIFICADO.** Anclas realineadas (`dbLogistics.*` → `fieldVisitsDb.*`, `deps.*` directos → delegación UC) + 2 contratos M15 nuevos (composición única + adapter como única carga default + bloqueo textual de `db-logistics`). Sin debilitar reglas. |
+| `test/architecture/logistics-infrastructure-boundary-guard.test.ts` | **MODIFICADO.** 2 contratos M15: adapter de field visits (sólo canónico, sin queries/tx, superficie exacta de 7 ops) y ruta sin canónicos ni referencia textual a `db-logistics`. Reglas M12–M14 intactas. |
+| `server/features/logistics/README.md` | **MODIFICADO.** Estado M14 mergeado (#1512) + M15. |
+| `server/features/logistics/application/README.md` | **MODIFICADO.** Sección M15 + futuro (M16–M17). |
+| `server/features/logistics/infrastructure/README.md` | **MODIFICADO.** Adapter M15; shim consumido sólo por route-events/SLA. |
+| `docs/audit/backend-enterprise-modularization-program-audit.md` | **MODIFICADO.** Status M14 mergeado + Status M15. |
+| `docs/implementation/m15-logistics-field-visits-thin-route.md` | **NUEVO.** Este documento. |
+
+**Denylist respetada (cero cambios):** canónico M12
+(`infrastructure/db-logistics.ts`, byte-idéntico, 7 transacciones), shim
+`server/db-logistics.ts` (intacto; route-events y SLA lo consumen hasta M16),
+`update-field-visit.ts` + puerto M09, cache M13/M14 y sus adapters,
+`server/routes/logistics-{route-plans,route-events,sla}.fastify.ts`,
+`server/fastify-app.ts`, `server/db.ts`, `server/lib/**` (auth-security,
+cors-headers, env, permissions, session-last-access), `domain/**`, `drizzle/**`,
+migraciones, `package.json`/lockfiles/CI/`.github/**`, `frontend/**`, M16+.
+
+## 5. Invariantes preservadas (antes = después)
+
+- Métodos+paths de los 7 endpoints + 4 `OPTIONS`; prefijo
+  `/api/logistics/field-visits`; sin endpoints nuevos ni eliminados.
+- Status codes 200/201/400/401/403/404/500 y mensajes exactos; envelope y
+  serializers idénticos (location **sin** `createdAt`); paginación default 50 /
+  max 100; orden de resultados y semántica `null`/`undefined`.
+- Secuencia observable: trusted-origin → auth/sesión → RBAC → parse
+  path/query/body → operación → mapeo 404/500/2xx → serialización.
+- `app_session_id` (cookie `ENV.cookieName`); sin `admin_session_id`;
+  expiración con delete de sesión + clear-cookie; refresh de last-access;
+  `getClinicPermissions(auth.role).canManageLogisticsFieldVisits` en métodos
+  unsafe; CORS por-ruta sin wildcard; preflight intacto; `clinicId`
+  exclusivamente desde la sesión autenticada (nunca del body).
+- Persistencia: 7 operaciones canónicas con signatures, queries, transacciones
+  (upsert de location y create de time window incluidas), normalizaciones,
+  scoping y ordenamientos intactos — el adapter sólo referencia funciones
+  existentes; `git diff` vacío sobre canónico y shim.
+- Laziness: deps totalmente inyectadas siguen sin cargar `server/db.ts`.
+- Sin cache, auditoría, máquina de estados ni side-effects nuevos.
+
+## 6. Riesgo residual y rollback
+
+- **Riesgo de comportamiento: bajo.** Delegación 1:1 fijada por 22 tests
+  unitarios nuevos, el contrato de fuente realineado, el runtime de integración
+  M09 (sin cambios) y los contratos de seguridad (auth global, CSRF, RBAC,
+  production-invariants) verdes sin cambiar expectativas.
+- **Shim `server/db-logistics.ts`: intacto y sin consumo desde field-visits.**
+  Permanece sólo por route-events y SLA (M16); retiro global en M17.
+- LOC de la ruta sube levemente (1.427 → 1.453) por la zona de composición de
+  los 4 UCs; la lógica de persistencia directa en handlers queda en 0.
+
+Rollback independiente y sin efectos de datos: revertir la ruta al import
+directo del shim y a las 6 llamadas `deps.*`, borrar los 9 archivos nuevos de
+application/infrastructure y sus 4 tests, revertir barrel, las anclas del
+contrato API y del guard, y los 5 archivos documentales. No requiere revertir
+M09–M14.
+
+## 7. Validaciones
+
+| Gate | Estado |
+| --- | --- |
+| Cohorte 1 — 4 suites unitarias M15 | **PASSED** (22/22, exit code 0) |
+| Cohorte 2 — unitarios M09+M15 + completeness M11 + contrato API + runtime integración M09 + guards domain/application/infrastructure + auth global + CSRF + RBAC | **PASSED** (126/126, exit code 0) |
+| `pnpm validate:local` (`typecheck && typecheck:test && test && build`) | **PASSED** (3.327 tests: 3.326 pass, 1 skipped, 0 fail; build OK, exit code 0) |
+| `pnpm security:public-surface` | **PASSED** (sin exposición pública, exit code 0) |
+| `pnpm validate:local:schema` / `db:migrate` | **NOT_RUN** (sin schema/migraciones) |
+| E2E (Playwright) | **NOT_RUN** (sin frontend) |
+| Audits de dependencias | **NOT_RUN** (manifests/lockfile fuera de scope) |
+| Escrituras Git/GitHub | **BLOCKED** para el agente — **[MANUAL-NICO]** |
+
+## 8. Siguiente milestone
+
+**M16 — thin `logistics-route-events` + `logistics-sla`.** No adelantado aquí.
+Fase C **no cerrada**; M15 **no se declara cerrado hasta el merge**.
+
+## 9. Operaciones [MANUAL-NICO]
+
+El agente **no** ejecutó ninguna escritura Git/GitHub. Pendientes de Nico:
+`git add`, `git commit`, `git push`, creación de PR, `gh pr checks --watch` (en
+la rama del PR activo, sin número), merge.

--- a/server/features/logistics/README.md
+++ b/server/features/logistics/README.md
@@ -4,11 +4,12 @@
 > docs-only en ARCH-4; **desde ARCH-5 contiene código real** en `domain/` y, desde
 > M02b, también en `infrastructure/`.
 > **Origen:** [ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md) · [ARCH-2](../../../docs/architecture/backend-boundary-adr.md) · [ARCH-3](../../../docs/architecture/shared-lib-boundary-inventory.md).
-> **ID:** ARCH-4 (shell) → ARCH-5/7/8 (domain) → M02b (time-window + SLA) → M03 (route-planning) → M04 (metrics) → **M05 (cierre de Fase A)** → M06–M10 (casos de uso) → **M11 (cierre de Fase B)** → **M12 (Fase C: persistencia canónica en `infrastructure/`)** → **M13 (cache canónico en `infrastructure/`)** → **M14 (thin `logistics-route-plans` + puerto de cache)**.
+> **ID:** ARCH-4 (shell) → ARCH-5/7/8 (domain) → M02b (time-window + SLA) → M03 (route-planning) → M04 (metrics) → **M05 (cierre de Fase A)** → M06–M10 (casos de uso) → **M11 (cierre de Fase B)** → **M12 (Fase C: persistencia canónica en `infrastructure/`)** → **M13 (cache canónico en `infrastructure/`)** → **M14 (thin `logistics-route-plans` + puerto de cache)** → **M15 (thin `logistics-field-visits` + adapter DB de field visits)**.
 >
 > **Estado:** Fase A **cerrada** (M05) · Fase B **cerrada** (M11, PR #1507 merged) ·
 > Fase C **en curso**: M12 **mergeado** (PR #1509) · M13 **mergeado** (PR #1511) ·
-> M14 implementado / pendiente de merge.
+> M14 **mergeado** (PR #1512) · M15 implementado / pendiente de merge · M16–M17
+> pendientes.
 
 Este directorio es la **frontera** del contexto Logistics. Declara las reglas de
 dependencia del ADR ([ARCH-2](../../../docs/architecture/backend-boundary-adr.md))
@@ -26,13 +27,15 @@ y ya aloja código migrado, capa por capa, detrás de contratos con tests verdes
 - **`application/`** — casos de uso extraídos en M06–M10 y cerrados en M11.
 - **`routes/`** — todavía sólo README (sin código).
 
-El runtime legacy que queda fuera son las rutas de field-visits, route-events y
-SLA (`server/routes/logistics-*.fastify.ts`, thin routes en **M15–M16**, cierre en
-M17); `logistics-route-plans` quedó thin en **M14** (cache vía puerto de
-application + adapter de infrastructure). `server/db-logistics.ts` **ya no es
+El runtime legacy que queda fuera son las rutas de route-events y SLA
+(`server/routes/logistics-*.fastify.ts`, thin routes en **M16**, cierre en M17);
+`logistics-route-plans` quedó thin en **M14** (cache vía puerto de application +
+adapter de infrastructure) y `logistics-field-visits` en **M15** (seis handlers
+delegando en casos de uso y carga default por
+`logistics-field-visits-db-adapter.ts`). `server/db-logistics.ts` **ya no es
 implementación**: desde M12 es un **shim de compatibilidad** que sólo re-exporta el
 canónico de `features/logistics/infrastructure/`, conservado únicamente porque las
-rutas legacy restantes siguen importándolo. El shim del cache
+rutas legacy restantes (route-events y SLA) siguen importándolo. El shim del cache
 (`server/lib/logistics-route-plans-cache.ts`) fue **retirado en M14** (su único
 consumidor productivo era la ruta de route plans). **M05 cierra la Fase A**: el namespace de
 dominio legacy `server/lib/logistics/` queda **retirado** (cero archivos
@@ -98,9 +101,12 @@ Tras **M12** la persistencia ya no es legacy: vive en
 **M13** el cache tampoco: vive en
 `features/logistics/infrastructure/logistics-route-plans-cache.ts`; el shim de
 `server/lib` fue retirado en **M14**, cuando la ruta de route plans quedó thin y
-pasó a consumir el cache por puerto de application + adapter. Lo que **aún es
-legacy**: las rutas de field-visits, route-events y SLA (rutas delgadas en
-**M15–M16**, cierre en **M17**).
+pasó a consumir el cache por puerto de application + adapter. Tras **M15**,
+`logistics-field-visits` también quedó thin: sus siete handlers funcionales
+delegan en casos de uso de application y su carga default de persistencia pasa
+por `logistics-field-visits-db-adapter.ts`, sin ninguna referencia a
+`db-logistics`. Lo que **aún es legacy**: las rutas de route-events y SLA (rutas
+delgadas en **M16**, cierre en **M17**).
 
 Es una migración incremental y deliberada: se mueve código real capa por capa,
 detrás de los contratos por-ruta existentes y sólo con tests verdes.
@@ -170,7 +176,7 @@ verdes. Cada carpeta materializa código **sólo cuando hay algo real que la hab
   extendido (pureza del cache, shim sólo-re-export, infra no consume el shim).
   TTL, claves, invalidaciones y semántica HIT/MISS sin cambios; la ruta
   productiva queda byte-idéntica. Sin puerto de cache anticipado.
-- **M14 (este PR) — thin `logistics-route-plans`** — la ruta deja de orquestar el
+- **M14 (hecho, PR #1512) — thin `logistics-route-plans`** — la ruta deja de orquestar el
   cache directamente: se introduce el puerto opaco
   `LogisticsRoutePlansCacheRepository` (application/ports) **junto con su primer
   consumidor real**, el caso de uso `createRoutePlansCacheUseCases`
@@ -187,8 +193,22 @@ verdes. Cada carpeta materializa código **sólo cuando hay algo real que la hab
   `server/lib/logistics-route-plans-cache.ts` queda **retirado**; el shim
   `server/db-logistics.ts` permanece sólo para las rutas de M15/M16. Cero
   cambios de contrato HTTP, claves, TTL, invalidaciones, auth ni auditoría.
-  `M15–M16` (thin routes restantes) y `M17` (cierre de Logistics) permanecen
-  futuros.
+- **M15 (este PR) — thin `logistics-field-visits`** — los seis handlers que aún
+  llamaban `deps.*` directamente delegan en casos de uso de application
+  (`createListFieldVisits`, `createCreateFieldVisit`,
+  `createVisitLocationUseCases`, `createTimeWindowUseCases`), cada uno con su
+  puerto mínimo genérico derivado del seam
+  `LogisticsFieldVisitsNativeRoutesOptions`; el PATCH conserva el caso de uso
+  M09 intacto. La ruta queda **sin ninguna referencia a `db-logistics`**: los 8
+  tipos de I/O y las 7 operaciones de persistencia llegan por
+  `logistics-field-visits-db-adapter.ts` (referencias directas al DB canónico de
+  M12, laziness de `loadDefaultDeps` preservada). La ruta conserva sólo HTTP:
+  CORS por-ruta, trusted-origin, auth de sesión de clínica, RBAC, parsing,
+  validaciones, serializers, mensajes y status codes, carácter por carácter. El
+  shim `server/db-logistics.ts` permanece sólo para route-events y SLA (M16;
+  retiro global en M17). Cero cambios de contrato HTTP, schema, migraciones,
+  auth ni CORS. `M16` (thin route-events + SLA) y `M17` (cierre de Logistics)
+  permanecen futuros.
 
 ## 5. Qué NO se mueve en M12
 
@@ -229,3 +249,5 @@ la red de seguridad que habilita reorganizar sin cambiar comportamiento.
 - [Nota de implementación — M05](../../../docs/implementation/m05-logistics-domain-phase-closeout.md) — cierre de la Fase A: censo legacy, endurecimiento del guard y reconciliación documental, sin cambios runtime.
 - [Nota de implementación — M12](../../../docs/implementation/m12-logistics-db-infrastructure-move.md) — mueve `db-logistics.ts` completo a `infrastructure/` con shim en el root.
 - [Nota de implementación — M13](../../../docs/implementation/m13-logistics-cache-infrastructure-move.md) — mueve el cache de route plans a `infrastructure/` con shim en `server/lib`.
+- [Nota de implementación — M14](../../../docs/implementation/m14-logistics-route-plans-thin-route.md) — thin `logistics-route-plans`: puerto de cache + adapter DB; retira el shim del cache.
+- [Nota de implementación — M15](../../../docs/implementation/m15-logistics-field-visits-thin-route.md) — thin `logistics-field-visits`: casos de uso + adapter DB de field visits.

--- a/server/features/logistics/application/README.md
+++ b/server/features/logistics/application/README.md
@@ -9,7 +9,9 @@
 > código productivo**: cierra la capa con el guard global de frontera y el
 > contrato global de inventario de casos de uso. **M14** agrega el caso de uso
 > de cache de route plans (read-through + invalidaciones) con su puerto opaco,
-> introducido junto con su primer consumidor real.
+> introducido junto con su primer consumidor real. **M15** agrega los casos de
+> uso restantes de field visits (listado, creación, ubicación y ventanas
+> horarias) con sus puertos mínimos, dejando thin la ruta de field visits.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -152,6 +154,35 @@ serialización concreta (dentro del callback puro), el mapeo de errores a status
 codes y la escritura del header `X-Logistics-Cache` a partir del `cacheStatus`
 retornado. TTL, Maps y expiración siguen en infrastructure.
 
+## Qué vive aquí (M15)
+
+- **`list-field-visits.ts`** — `createListFieldVisits`: listado clinic-scoped de
+  visitas de campo consumido por `GET /`; reenvía los params ya autenticados y
+  validados por identidad.
+- **`create-field-visit.ts`** — `createCreateFieldVisit`: creación de una visita
+  de campo consumida por `POST /`; el 500 sobre resultado ausente permanece en
+  la ruta.
+- **`visit-location-use-cases.ts`** — `createVisitLocationUseCases`:
+  `getVisitLocation` y `upsertVisitLocation`, consumidos por
+  `GET/PUT /:fieldVisitId/location`.
+- **`time-window-use-cases.ts`** — `createTimeWindowUseCases`:
+  `listTimeWindows` y `createTimeWindow`, consumidos por
+  `GET/POST /:fieldVisitId/time-windows`.
+- **Puertos** — `ports/logistics-field-visits-read-repository.ts`,
+  `ports/logistics-field-visit-create-repository.ts`,
+  `ports/logistics-visit-location-repository.ts` y
+  `ports/logistics-time-windows-repository.ts`, estructurales y genéricos,
+  derivados del seam `LogisticsFieldVisitsNativeRoutesOptions`. El puerto M09
+  (`logistics-field-visit-update-repository.ts`) queda intacto: el PATCH sigue
+  siendo el único consumidor de `createUpdateFieldVisit`.
+
+Cada operación delega exactamente una vez y devuelve el resultado del puerto sin
+transformarlo (incluidos `null`/`undefined` y el array vacío). CORS, preflight,
+trusted-origin, auth de sesión, RBAC, parsing, validaciones, 400/404/500,
+mensajes, serialización y paginación permanecen en la ruta. La carga default de
+persistencia de la ruta pasa por el adapter
+`infrastructure/logistics-field-visits-db-adapter.ts` (M15), no por esta capa.
+
 ## Regla de dependencia
 
 - **Puede importar:** `domain`, **puertos** (interfaces) y el shared kernel.
@@ -205,8 +236,8 @@ intactos: el guard global los **subsume**, no los reemplaza.
 
 `release`/`start`/`complete` (resto del lifecycle) permanecen fuera de la capa y
 siguen usando el default del helper de lifecycle compartido.
-GET/POST/location/time-windows de field visits permanecen fuera de M09 y se
-difieren al thin-route M15. **M12** (mergeado en PR #1509) movió
+GET/POST/location/time-windows de field visits quedaron fuera de M09 y fueron
+extraídos en el thin-route M15 (este PR). **M12** (mergeado en PR #1509) movió
 `db-logistics.ts` completo a `infrastructure/db-logistics.ts` con las transacciones
 intactas, dejando un shim en el root. Es **infraestructura de persistencia** y **no
 cambia esta capa**: `application` sigue sin importar `db-*` — el guard de M11 lo
@@ -215,8 +246,10 @@ del move. **M13** movió el cache de route plans a
 `infrastructure/logistics-route-plans-cache.ts`, también sin tocar esta capa y
 sin puerto de cache anticipado. **M14** (este PR) materializó ese puerto junto
 con su primer consumidor real (`createRoutePlansCacheUseCases`), adelgazó
-`logistics-route-plans` y retiró el shim del cache de `server/lib`. Los
-siguientes milestones son **M15–M16** (thin field-visits / route-events + SLA) y
+`logistics-route-plans` y retiró el shim del cache de `server/lib`. **M15** (este
+PR) adelgazó `logistics-field-visits`: los seis handlers restantes delegan en
+los casos de uso de esta capa y la carga default pasa por el adapter DB de
+field visits. Los siguientes milestones son **M16** (thin route-events + SLA) y
 **M17** (cierre). Cada puerto nuevo se introduce junto con su primer consumidor
 real — nunca como interfaz vacía anticipada.
 

--- a/server/features/logistics/application/create-field-visit.ts
+++ b/server/features/logistics/application/create-field-visit.ts
@@ -1,0 +1,15 @@
+import type { LogisticsFieldVisitCreateRepository } from "./ports/logistics-field-visit-create-repository.ts";
+
+export type CreateFieldVisit<TFieldVisit, TCreateInput> = (
+  input: TCreateInput,
+) => Promise<TFieldVisit | null | undefined>;
+
+// Caso de uso M15: crea una visita de campo con el input completo ya
+// autenticado, clinic-scoped y validado por la ruta. Delega una vez y preserva
+// el resultado (incluido null/undefined) y los errores del puerto sin
+// transformarlos; el 500 sobre resultado ausente permanece en la ruta.
+export function createCreateFieldVisit<TFieldVisit, TCreateInput>(
+  repository: LogisticsFieldVisitCreateRepository<TFieldVisit, TCreateInput>,
+): CreateFieldVisit<TFieldVisit, TCreateInput> {
+  return (input) => repository.createFieldVisit(input);
+}

--- a/server/features/logistics/application/index.ts
+++ b/server/features/logistics/application/index.ts
@@ -1,6 +1,6 @@
 // Barrel público de la capa application de Logistics. Expone únicamente la
-// superficie ya materializada (M06-M10 y M14); sin exports preventivos para
-// milestones futuros.
+// superficie ya materializada (M06-M10, M14 y M15); sin exports preventivos
+// para milestones futuros.
 
 export {
   createListOverdueActiveSlaInstances,
@@ -46,6 +46,30 @@ export {
   type UpdateFieldVisit,
 } from "./update-field-visit.ts";
 export type { LogisticsFieldVisitUpdateRepository } from "./ports/logistics-field-visit-update-repository.ts";
+
+export {
+  createListFieldVisits,
+  type ListFieldVisits,
+} from "./list-field-visits.ts";
+export type { LogisticsFieldVisitsReadRepository } from "./ports/logistics-field-visits-read-repository.ts";
+
+export {
+  createCreateFieldVisit,
+  type CreateFieldVisit,
+} from "./create-field-visit.ts";
+export type { LogisticsFieldVisitCreateRepository } from "./ports/logistics-field-visit-create-repository.ts";
+
+export {
+  createVisitLocationUseCases,
+  type VisitLocationUseCases,
+} from "./visit-location-use-cases.ts";
+export type { LogisticsVisitLocationRepository } from "./ports/logistics-visit-location-repository.ts";
+
+export {
+  createTimeWindowUseCases,
+  type TimeWindowUseCases,
+} from "./time-window-use-cases.ts";
+export type { LogisticsTimeWindowsRepository } from "./ports/logistics-time-windows-repository.ts";
 
 export {
   createCreateRouteEvent,

--- a/server/features/logistics/application/list-field-visits.ts
+++ b/server/features/logistics/application/list-field-visits.ts
@@ -1,0 +1,14 @@
+import type { LogisticsFieldVisitsReadRepository } from "./ports/logistics-field-visits-read-repository.ts";
+
+export type ListFieldVisits<TFieldVisit, TListParams> = (
+  params: TListParams,
+) => Promise<TFieldVisit[]>;
+
+// Caso de uso M15: lista visitas de campo con params ya autenticados,
+// clinic-scoped y validados por la ruta. Delega una vez y preserva el
+// resultado y los errores del puerto sin transformarlos.
+export function createListFieldVisits<TFieldVisit, TListParams>(
+  repository: LogisticsFieldVisitsReadRepository<TFieldVisit, TListParams>,
+): ListFieldVisits<TFieldVisit, TListParams> {
+  return (params) => repository.listClinicFieldVisits(params);
+}

--- a/server/features/logistics/application/ports/logistics-field-visit-create-repository.ts
+++ b/server/features/logistics/application/ports/logistics-field-visit-create-repository.ts
@@ -1,0 +1,8 @@
+// Puerto mínimo de creación de visitas de campo del contexto Logistics (M15),
+// derivado del seam `LogisticsFieldVisitsNativeRoutesOptions`.
+
+export type LogisticsFieldVisitCreateRepository<TFieldVisit, TCreateInput> = {
+  createFieldVisit: (
+    input: TCreateInput,
+  ) => Promise<TFieldVisit | null | undefined>;
+};

--- a/server/features/logistics/application/ports/logistics-field-visits-read-repository.ts
+++ b/server/features/logistics/application/ports/logistics-field-visits-read-repository.ts
@@ -1,0 +1,6 @@
+// Puerto mínimo de lectura de visitas de campo del contexto Logistics (M15),
+// derivado del seam `LogisticsFieldVisitsNativeRoutesOptions`.
+
+export type LogisticsFieldVisitsReadRepository<TFieldVisit, TListParams> = {
+  listClinicFieldVisits: (params: TListParams) => Promise<TFieldVisit[]>;
+};

--- a/server/features/logistics/application/ports/logistics-time-windows-repository.ts
+++ b/server/features/logistics/application/ports/logistics-time-windows-repository.ts
@@ -1,0 +1,14 @@
+// Puerto mínimo de ventanas horarias del contexto Logistics (M15), derivado
+// del seam `LogisticsFieldVisitsNativeRoutesOptions`. Las dos operaciones son
+// clinic-scoped: el listado recibe el clinicId autenticado y la creación lo
+// recibe dentro del input ya construido por la ruta.
+
+export type LogisticsTimeWindowsRepository<TTimeWindow, TCreateInput> = {
+  listTimeWindowsForClinicVisit: (
+    fieldVisitId: number,
+    clinicId: number,
+  ) => Promise<TTimeWindow[]>;
+  createTimeWindowForClinicVisit: (
+    input: TCreateInput,
+  ) => Promise<TTimeWindow | null | undefined>;
+};

--- a/server/features/logistics/application/ports/logistics-visit-location-repository.ts
+++ b/server/features/logistics/application/ports/logistics-visit-location-repository.ts
@@ -1,0 +1,14 @@
+// Puerto mínimo de ubicación de visita del contexto Logistics (M15), derivado
+// del seam `LogisticsFieldVisitsNativeRoutesOptions`. Las dos operaciones son
+// clinic-scoped: la lectura recibe el clinicId autenticado y el upsert lo
+// recibe dentro del input ya construido por la ruta.
+
+export type LogisticsVisitLocationRepository<TVisitLocation, TUpsertInput> = {
+  getVisitLocationForClinicVisit: (
+    fieldVisitId: number,
+    clinicId: number,
+  ) => Promise<TVisitLocation | null | undefined>;
+  upsertVisitLocationForClinicVisit: (
+    input: TUpsertInput,
+  ) => Promise<TVisitLocation | null | undefined>;
+};

--- a/server/features/logistics/application/time-window-use-cases.ts
+++ b/server/features/logistics/application/time-window-use-cases.ts
@@ -1,0 +1,26 @@
+import type { LogisticsTimeWindowsRepository } from "./ports/logistics-time-windows-repository.ts";
+
+export type TimeWindowUseCases<TTimeWindow, TCreateInput> = {
+  listTimeWindows: (
+    fieldVisitId: number,
+    clinicId: number,
+  ) => Promise<TTimeWindow[]>;
+  createTimeWindow: (
+    input: TCreateInput,
+  ) => Promise<TTimeWindow | null | undefined>;
+};
+
+// Casos de uso M15 de ventanas horarias: listado y creación clinic-scoped con
+// inputs ya autenticados y validados por la ruta. Cada operación delega
+// exactamente una vez y preserva el resultado (incluido null/undefined) y los
+// errores del puerto sin transformarlos; el 404 permanece en la ruta.
+export function createTimeWindowUseCases<TTimeWindow, TCreateInput>(
+  repository: LogisticsTimeWindowsRepository<TTimeWindow, TCreateInput>,
+): TimeWindowUseCases<TTimeWindow, TCreateInput> {
+  return {
+    listTimeWindows: (fieldVisitId, clinicId) =>
+      repository.listTimeWindowsForClinicVisit(fieldVisitId, clinicId),
+    createTimeWindow: (input) =>
+      repository.createTimeWindowForClinicVisit(input),
+  };
+}

--- a/server/features/logistics/application/visit-location-use-cases.ts
+++ b/server/features/logistics/application/visit-location-use-cases.ts
@@ -1,0 +1,26 @@
+import type { LogisticsVisitLocationRepository } from "./ports/logistics-visit-location-repository.ts";
+
+export type VisitLocationUseCases<TVisitLocation, TUpsertInput> = {
+  getVisitLocation: (
+    fieldVisitId: number,
+    clinicId: number,
+  ) => Promise<TVisitLocation | null | undefined>;
+  upsertVisitLocation: (
+    input: TUpsertInput,
+  ) => Promise<TVisitLocation | null | undefined>;
+};
+
+// Casos de uso M15 de ubicación de visita: lectura y upsert clinic-scoped con
+// inputs ya autenticados y validados por la ruta. Cada operación delega
+// exactamente una vez y preserva el resultado (incluido null/undefined) y los
+// errores del puerto sin transformarlos; el 404 permanece en la ruta.
+export function createVisitLocationUseCases<TVisitLocation, TUpsertInput>(
+  repository: LogisticsVisitLocationRepository<TVisitLocation, TUpsertInput>,
+): VisitLocationUseCases<TVisitLocation, TUpsertInput> {
+  return {
+    getVisitLocation: (fieldVisitId, clinicId) =>
+      repository.getVisitLocationForClinicVisit(fieldVisitId, clinicId),
+    upsertVisitLocation: (input) =>
+      repository.upsertVisitLocationForClinicVisit(input),
+  };
+}

--- a/server/features/logistics/infrastructure/README.md
+++ b/server/features/logistics/infrastructure/README.md
@@ -3,8 +3,9 @@
 > Capa **infrastructure** del contexto Logistics. **Contiene código** desde M02b
 > (adaptador de DB para el breach de SLA); desde **M12 (mergeado en PR #1509)**,
 > la **persistencia canónica** del contexto; desde **M13 (mergeado en PR
-> #1511)**, el **cache de route plans**; y desde **M14**, el **adapter del
-> puerto de cache**.
+> #1511)**, el **cache de route plans**; desde **M14 (mergeado en PR #1512)**,
+> el **adapter del puerto de cache** y el **adapter DB de route plans**; y desde
+> **M15**, el **adapter DB de field visits**.
 > Ver la frontera del contexto en [`../README.md`](../README.md) y el contrato en
 > [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
 
@@ -65,6 +66,17 @@ de persistencia y el I/O real del contexto.
   `db-logistics`: sus tipos y su carga default (lazy, dentro de
   `loadDefaultDeps`) llegan por este adapter. El guard fija que sólo importa
   `./db-logistics.ts` y que no contiene queries ni transacciones propias.
+- **`logistics-field-visits-db-adapter.ts`** (M15) — **adapter DB de la ruta
+  thin de field visits**: factory `createLogisticsFieldVisitsDbAdapter()` con
+  **referencias directas** a las 7 operaciones del DB canónico consumidas por
+  `logistics-field-visits` (create/list/update de visitas, get/upsert de
+  ubicación, list/create de ventanas horarias; sin envolver resultados ni
+  alterar signatures, null/undefined, errores o transacciones) + re-export de
+  los 8 tipos de I/O. Desde M15 la ruta no contiene **ninguna** referencia a
+  `db-logistics`: sus tipos y su carga default (lazy, dentro de
+  `loadDefaultDeps`) llegan por este adapter. El guard fija que sólo importa
+  `./db-logistics.ts`, que no contiene queries ni transacciones propias y que
+  expone exactamente esa superficie de 7 operaciones.
 
 ## Shims de compatibilidad fuera de la capa
 
@@ -72,9 +84,10 @@ de persistencia y el I/O real del contexto.
 pública desde `./features/logistics/infrastructure/db-logistics.ts`. No importa
 Drizzle, ni `drizzle/schema.ts`, ni `server/db.ts`; no contiene funciones, queries ni
 transacciones, y no declara default export. Desde M14, `logistics-route-plans`
-**ya no lo consume** (usa el adapter DB de esta capa); el shim existe únicamente
-porque las rutas legacy restantes (field-visits, route-events, SLA) siguen
-importando `../db-logistics.ts` (estática y dinámicamente) hasta **M15–M16**. Su
+**ya no lo consume** (usa el adapter DB de esta capa) y desde M15 tampoco
+`logistics-field-visits` (usa `logistics-field-visits-db-adapter.ts`); el shim
+existe únicamente porque las rutas legacy restantes (route-events y SLA) siguen
+importando `../db-logistics.ts` (estática y dinámicamente) hasta **M16**. Su
 eliminación global sigue prevista para **M17**, o cuando desaparezca el último
 consumidor.
 
@@ -83,14 +96,16 @@ El **shim del cache** (`server/lib/logistics-route-plans-cache.ts`) fue
 que ahora consume el cache por el puerto de application y este adapter. El guard
 de frontera fija que el path retirado no se recree ni se importe.
 
-**Sin cambios de schema ni de migraciones**: M12–M14 no tocan `drizzle/schema.ts`,
+**Sin cambios de schema ni de migraciones**: M12–M15 no tocan `drizzle/schema.ts`,
 `drizzle/**`, `migrations/**`, endpoints ni contratos HTTP.
 
 ## Qué vivirá aquí (futuro, no ahora)
 
 - Nada nuevo planificado para esta capa: los siguientes milestones de la Fase C
-  (**M15–M16**, thin routes restantes, y **M17**, cierre) adelgazan
-  `server/routes/**` y retiran el shim de `db-logistics`; no añaden módulos aquí.
+  (**M16**, thin route-events + SLA, y **M17**, cierre) adelgazan
+  `server/routes/**` y retiran el shim de `db-logistics`; no añaden módulos aquí
+  salvo que M16 requiera su propio adapter DB mínimo, decidido en su propia
+  autorización.
 
 ## Qué NO hacer
 

--- a/server/features/logistics/infrastructure/logistics-field-visits-db-adapter.ts
+++ b/server/features/logistics/infrastructure/logistics-field-visits-db-adapter.ts
@@ -1,0 +1,43 @@
+// Adaptador de persistencia de field visits (M15). Expone, por composición
+// mínima sobre el DB canónico de su propia capa (`./db-logistics.ts`, intacto:
+// mismas queries, scoping por clínica, transacciones y semántica
+// null/undefined), únicamente las operaciones que
+// `server/routes/logistics-field-visits.fastify.ts` consume realmente, junto
+// con los tipos de I/O de esas operaciones. La factory retorna referencias
+// directas a las funciones canónicas: sin envolver resultados, sin alterar
+// signatures, null/undefined ni errores. Implementa estructuralmente los
+// puertos de application (read/create/update/location/time-windows); esta capa
+// no importa `application` (la dirección de dependencia no se invierte).
+
+import {
+  createFieldVisit,
+  createTimeWindowForClinicVisit,
+  getVisitLocationForClinicVisit,
+  listClinicFieldVisits,
+  listTimeWindowsForClinicVisit,
+  updateClinicScopedFieldVisit,
+  upsertVisitLocationForClinicVisit,
+} from "./db-logistics.ts";
+
+export type {
+  CreateFieldVisitInput,
+  CreateTimeWindowInput,
+  FieldVisit,
+  ListFieldVisitsParams,
+  TimeWindow,
+  UpdateFieldVisitInput,
+  UpsertVisitLocationInput,
+  VisitLocation,
+} from "./db-logistics.ts";
+
+export function createLogisticsFieldVisitsDbAdapter() {
+  return {
+    createFieldVisit,
+    listClinicFieldVisits,
+    updateClinicScopedFieldVisit,
+    getVisitLocationForClinicVisit,
+    upsertVisitLocationForClinicVisit,
+    createTimeWindowForClinicVisit,
+    listTimeWindowsForClinicVisit,
+  };
+}

--- a/server/routes/logistics-field-visits.fastify.ts
+++ b/server/routes/logistics-field-visits.fastify.ts
@@ -13,6 +13,13 @@ import {
   type FieldVisitStatus,
   type VisitLocationGeoQuality,
 } from "../../drizzle/schema.ts";
+import {
+  createCreateFieldVisit,
+  createListFieldVisits,
+  createTimeWindowUseCases,
+  createUpdateFieldVisit,
+  createVisitLocationUseCases,
+} from "../features/logistics/application/index.ts";
 import type {
   CreateFieldVisitInput,
   FieldVisit,
@@ -22,8 +29,7 @@ import type {
   UpdateFieldVisitInput,
   UpsertVisitLocationInput,
   VisitLocation,
-} from "../db-logistics.ts";
-import { createUpdateFieldVisit } from "../features/logistics/application/index.ts";
+} from "../features/logistics/infrastructure/logistics-field-visits-db-adapter.ts";
 import {
   UNSAFE_METHODS,
   enforceTrustedOrigin,
@@ -124,7 +130,11 @@ async function loadDefaultDeps(): Promise<NativeLogisticsFieldVisitsDeps> {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
-      const dbLogistics = await import("../db-logistics.ts");
+      const fieldVisitsDb = (
+        await import(
+          "../features/logistics/infrastructure/logistics-field-visits-db-adapter.ts"
+        )
+      ).createLogisticsFieldVisitsDbAdapter();
 
       return {
         deleteActiveSession: db.deleteActiveSession,
@@ -132,18 +142,18 @@ async function loadDefaultDeps(): Promise<NativeLogisticsFieldVisitsDeps> {
         getClinicUserById: db.getClinicUserById,
         updateSessionLastAccess: db.updateSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
-        createFieldVisit: dbLogistics.createFieldVisit,
-        listClinicFieldVisits: dbLogistics.listClinicFieldVisits,
+        createFieldVisit: fieldVisitsDb.createFieldVisit,
+        listClinicFieldVisits: fieldVisitsDb.listClinicFieldVisits,
         updateClinicScopedFieldVisit:
-          dbLogistics.updateClinicScopedFieldVisit,
+          fieldVisitsDb.updateClinicScopedFieldVisit,
         getVisitLocationForClinicVisit:
-          dbLogistics.getVisitLocationForClinicVisit,
+          fieldVisitsDb.getVisitLocationForClinicVisit,
         upsertVisitLocationForClinicVisit:
-          dbLogistics.upsertVisitLocationForClinicVisit,
+          fieldVisitsDb.upsertVisitLocationForClinicVisit,
         createTimeWindowForClinicVisit:
-          dbLogistics.createTimeWindowForClinicVisit,
+          fieldVisitsDb.createTimeWindowForClinicVisit,
         listTimeWindowsForClinicVisit:
-          dbLogistics.listTimeWindowsForClinicVisit,
+          fieldVisitsDb.listTimeWindowsForClinicVisit,
       };
     })();
   }
@@ -980,6 +990,20 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
   const updateFieldVisit = createUpdateFieldVisit({
     updateClinicScopedFieldVisit: deps.updateClinicScopedFieldVisit,
   });
+  const listFieldVisits = createListFieldVisits({
+    listClinicFieldVisits: deps.listClinicFieldVisits,
+  });
+  const createFieldVisitUseCase = createCreateFieldVisit({
+    createFieldVisit: deps.createFieldVisit,
+  });
+  const visitLocationUseCases = createVisitLocationUseCases({
+    getVisitLocationForClinicVisit: deps.getVisitLocationForClinicVisit,
+    upsertVisitLocationForClinicVisit: deps.upsertVisitLocationForClinicVisit,
+  });
+  const timeWindowUseCases = createTimeWindowUseCases({
+    listTimeWindowsForClinicVisit: deps.listTimeWindowsForClinicVisit,
+    createTimeWindowForClinicVisit: deps.createTimeWindowForClinicVisit,
+  });
 
   const now = options.now ?? (() => Date.now());
   const allowedOrigins = new Set(getAllowedOrigins());
@@ -1075,7 +1099,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       offset,
     };
 
-    const fieldVisits = await deps.listClinicFieldVisits(params);
+    const fieldVisits = await listFieldVisits(params);
 
     return reply.code(200).send({
       success: true,
@@ -1122,7 +1146,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const created = await deps.createFieldVisit(parsed.input);
+    const created = await createFieldVisitUseCase(parsed.input);
 
     if (!created) {
       return reply.code(500).send({
@@ -1232,7 +1256,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const location = await deps.getVisitLocationForClinicVisit(
+    const location = await visitLocationUseCases.getVisitLocation(
       fieldVisitId,
       auth.clinicId,
     );
@@ -1298,7 +1322,9 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const location = await deps.upsertVisitLocationForClinicVisit(parsed.input);
+    const location = await visitLocationUseCases.upsertVisitLocation(
+      parsed.input,
+    );
 
     if (!location) {
       return reply.code(404).send({
@@ -1345,7 +1371,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const timeWindows = await deps.listTimeWindowsForClinicVisit(
+    const timeWindows = await timeWindowUseCases.listTimeWindows(
       fieldVisitId,
       auth.clinicId,
     );
@@ -1407,7 +1433,7 @@ export const logisticsFieldVisitsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const timeWindow = await deps.createTimeWindowForClinicVisit(parsed.input);
+    const timeWindow = await timeWindowUseCases.createTimeWindow(parsed.input);
 
     if (!timeWindow) {
       return reply.code(404).send({

--- a/test/architecture/logistics-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/logistics-infrastructure-boundary-guard.test.ts
@@ -25,7 +25,20 @@ const canonicalSpecifierFromRoot =
 const canonicalCacheFile = `${infrastructureDir}/logistics-route-plans-cache.ts`;
 const cacheAdapterFile = `${infrastructureDir}/logistics-route-plans-cache-adapter.ts`;
 const dbAdapterFile = `${infrastructureDir}/logistics-route-plans-db-adapter.ts`;
+const fieldVisitsDbAdapterFile = `${infrastructureDir}/logistics-field-visits-db-adapter.ts`;
 const retiredCacheShimFile = "server/lib/logistics-route-plans-cache.ts";
+
+// Superficie de persistencia de field visits consumida por la ruta thin (M15):
+// exactamente las siete operaciones canónicas con call-site real.
+const FIELD_VISITS_ADAPTER_OPERATIONS = [
+  "createFieldVisit",
+  "listClinicFieldVisits",
+  "updateClinicScopedFieldVisit",
+  "getVisitLocationForClinicVisit",
+  "upsertVisitLocationForClinicVisit",
+  "createTimeWindowForClinicVisit",
+  "listTimeWindowsForClinicVisit",
+] as const;
 
 // Baseline R0 medido en HEAD 101731d, antes del move: `server/db-logistics.ts`
 // contenía exactamente 7 call-sites `db.transaction(`. M12 prohíbe
@@ -454,6 +467,95 @@ test("El adapter DB de route plans (M14) compone el canónico de su capa sin ree
     /db\.transaction\(|drizzle-orm/,
     `${dbAdapterFile} no puede contener queries ni transacciones propias`,
   );
+});
+
+// --- M15: adapter DB de field visits y ruta thin ---
+
+test("El adapter DB de field visits (M15) compone el canónico de su capa sin reescribirlo", () => {
+  assert.equal(
+    existsSync(join(repoRoot, fieldVisitsDbAdapterFile)),
+    true,
+    `${fieldVisitsDbAdapterFile} debe existir tras M15 (superficie DB consumida por la ruta thin)`,
+  );
+
+  const source = readText(fieldVisitsDbAdapterFile);
+
+  assert.match(
+    source,
+    /^export function createLogisticsFieldVisitsDbAdapter\b/m,
+    `${fieldVisitsDbAdapterFile} debe exportar la factory del adapter DB`,
+  );
+
+  // Composición mínima: sólo importa el DB canónico de su propia capa.
+  const specifiers = listImportSpecifiers(source);
+
+  assert.deepEqual(
+    Array.from(
+      new Set(
+        specifiers.map((specifier) =>
+          resolveSpecifier(fieldVisitsDbAdapterFile, specifier),
+        ),
+      ),
+    ),
+    [canonicalDbFile],
+    `${fieldVisitsDbAdapterFile} sólo puede importar ${canonicalDbFile}`,
+  );
+
+  // No re-implementa persistencia: sin Drizzle, sin transacciones propias.
+  assert.doesNotMatch(
+    source,
+    /db\.transaction\(|drizzle-orm/,
+    `${fieldVisitsDbAdapterFile} no puede contener queries ni transacciones propias`,
+  );
+
+  // Expone exactamente la superficie field-visits esperada: las siete
+  // operaciones canónicas, cada una como referencia directa dentro de la
+  // factory, sin operaciones extra.
+  const factoryBody = source.match(
+    /export function createLogisticsFieldVisitsDbAdapter\(\) \{\s*return \{([\s\S]*?)\};\s*\}/,
+  );
+  assert.ok(
+    factoryBody,
+    `${fieldVisitsDbAdapterFile} debe retornar un objeto literal de referencias directas`,
+  );
+
+  const returnedOperations = (factoryBody?.[1] ?? "")
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0)
+    .sort();
+
+  assert.deepEqual(
+    returnedOperations,
+    [...FIELD_VISITS_ADAPTER_OPERATIONS].sort(),
+    `${fieldVisitsDbAdapterFile} debe exponer exactamente las siete operaciones de field visits como referencias directas (sin wrappers)`,
+  );
+});
+
+test("La ruta de field visits no importa canónicos de infraestructura ni referencia db-logistics (M15)", () => {
+  const routeFile = "server/routes/logistics-field-visits.fastify.ts";
+  const routeSource = readText(routeFile);
+  const violations: string[] = [];
+
+  for (const specifier of listImportSpecifiers(routeSource)) {
+    const resolved = resolveSpecifier(routeFile, specifier);
+
+    if (resolved === canonicalDbFile || resolved === rootShimFile) {
+      violations.push(
+        `${routeFile}: import de db-logistics ("${specifier}"); usar el adapter ${fieldVisitsDbAdapterFile}`,
+      );
+    }
+  }
+
+  // Refuerzo textual M15: ni siquiera referencias type-only o en comentarios al
+  // módulo db-logistics dentro de la ruta thin.
+  assert.doesNotMatch(
+    routeSource,
+    /db-logistics/,
+    `${routeFile} no puede contener ninguna referencia textual a db-logistics`,
+  );
+
+  assert.deepEqual(violations, []);
 });
 
 test("El move de M12 conserva exactamente los call-sites transaccionales del baseline R0", () => {

--- a/test/integration/adapters/controllers/logistics-field-visits-api.test.ts
+++ b/test/integration/adapters/controllers/logistics-field-visits-api.test.ts
@@ -41,9 +41,9 @@ test("logistics field visit API authenticates clinic users with existing session
 
 test("logistics field visit API keeps all reads and writes clinic scoped", () => {
   assert.match(routeSource, /clinicId: auth\.clinicId/);
-  assert.match(routeSource, /deps\.listClinicFieldVisits\(params\)/);
+  assert.match(routeSource, /await listFieldVisits\(params\)/);
   assert.match(routeSource, /buildCreateFieldVisitInput\(request\.body, auth\.clinicId\)/);
-  assert.match(routeSource, /deps\.createFieldVisit\(parsed\.input\)/);
+  assert.match(routeSource, /await createFieldVisitUseCase\(parsed\.input\)/);
   assert.match(routeSource, /updateFieldVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*parsed\.input,\s*\)/);
 });
 
@@ -85,10 +85,10 @@ test("logistics field visit API exposes clinic-scoped location endpoints", () =>
 test("logistics field visit API wires visit location DB helpers through injectable deps", () => {
   assert.match(routeSource, /getVisitLocationForClinicVisit\?:/);
   assert.match(routeSource, /upsertVisitLocationForClinicVisit\?:/);
-  assert.match(routeSource, /dbLogistics\.getVisitLocationForClinicVisit/);
-  assert.match(routeSource, /dbLogistics\.upsertVisitLocationForClinicVisit/);
-  assert.match(routeSource, /deps\.getVisitLocationForClinicVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*\)/);
-  assert.match(routeSource, /deps\.upsertVisitLocationForClinicVisit\(parsed\.input\)/);
+  assert.match(routeSource, /fieldVisitsDb\.getVisitLocationForClinicVisit/);
+  assert.match(routeSource, /fieldVisitsDb\.upsertVisitLocationForClinicVisit/);
+  assert.match(routeSource, /visitLocationUseCases\.getVisitLocation\(\s*fieldVisitId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /visitLocationUseCases\.upsertVisitLocation\(\s*parsed\.input,\s*\)/);
 });
 
 test("logistics field visit API validates visit location payload before upsert", () => {
@@ -125,10 +125,10 @@ test("logistics field visit API exposes clinic-scoped time-window endpoints", ()
 test("logistics field visit API wires time-window DB helpers through injectable deps", () => {
   assert.match(routeSource, /createTimeWindowForClinicVisit\?:/);
   assert.match(routeSource, /listTimeWindowsForClinicVisit\?:/);
-  assert.match(routeSource, /dbLogistics\.createTimeWindowForClinicVisit/);
-  assert.match(routeSource, /dbLogistics\.listTimeWindowsForClinicVisit/);
-  assert.match(routeSource, /deps\.listTimeWindowsForClinicVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*\)/);
-  assert.match(routeSource, /deps\.createTimeWindowForClinicVisit\(parsed\.input\)/);
+  assert.match(routeSource, /fieldVisitsDb\.createTimeWindowForClinicVisit/);
+  assert.match(routeSource, /fieldVisitsDb\.listTimeWindowsForClinicVisit/);
+  assert.match(routeSource, /timeWindowUseCases\.listTimeWindows\(\s*fieldVisitId,\s*auth\.clinicId,\s*\)/);
+  assert.match(routeSource, /timeWindowUseCases\.createTimeWindow\(parsed\.input\)/);
 });
 
 test("logistics field visit API validates time-window payload before create", () => {
@@ -165,11 +165,6 @@ test("logistics field visit API enforces role-aware logistics field visit permis
 });
 
 test("logistics field visit API delegates only PATCH update to the M09 application use case", () => {
-  assert.match(
-    routeSource,
-    /import \{ createUpdateFieldVisit \} from "\.\.\/features\/logistics\/application\/index\.ts";/,
-  );
-
   const compositionPattern =
     /const updateFieldVisit = createUpdateFieldVisit\(\{\s*updateClinicScopedFieldVisit: deps\.updateClinicScopedFieldVisit,\s*\}\);/;
   assert.match(routeSource, compositionPattern);
@@ -188,25 +183,115 @@ test("logistics field visit API delegates only PATCH update to the M09 applicati
     routeSource,
     /const updated = await updateFieldVisit\(\s*fieldVisitId,\s*auth\.clinicId,\s*parsed\.input,\s*\);/,
   );
-  assert.match(routeSource, /dbLogistics\.updateClinicScopedFieldVisit/);
+  assert.match(routeSource, /fieldVisitsDb\.updateClinicScopedFieldVisit/);
 });
 
-test("M09 preserves direct dependencies for out-of-scope field visit handlers", () => {
-  for (const marker of [
-    "deps.listClinicFieldVisits(params)",
-    "deps.createFieldVisit(parsed.input)",
-    "deps.getVisitLocationForClinicVisit(",
-    "deps.upsertVisitLocationForClinicVisit(parsed.input)",
-    "deps.listTimeWindowsForClinicVisit(",
-    "deps.createTimeWindowForClinicVisit(parsed.input)",
-  ]) {
-    assert.ok(routeSource.includes(marker), `debe preservar ${marker}`);
+test("M15 delegates the six remaining handlers to application use cases composed once", () => {
+  // Import de las factories desde el barrel público de application.
+  assert.match(
+    routeSource,
+    /import \{\s*createCreateFieldVisit,\s*createListFieldVisits,\s*createTimeWindowUseCases,\s*createUpdateFieldVisit,\s*createVisitLocationUseCases,\s*\} from "\.\.\/features\/logistics\/application\/index\.ts";/,
+  );
+
+  const handlersStart = routeSource.indexOf("app.options(");
+  assert.ok(handlersStart > 0, "no se encontró la región de handlers");
+
+  // Composición exacta de cada factory M15, una sola vez y antes de los handlers.
+  const compositions: Array<{ name: string; pattern: RegExp }> = [
+    {
+      name: "createListFieldVisits",
+      pattern:
+        /const listFieldVisits = createListFieldVisits\(\{\s*listClinicFieldVisits: deps\.listClinicFieldVisits,\s*\}\);/,
+    },
+    {
+      name: "createCreateFieldVisit",
+      pattern:
+        /const createFieldVisitUseCase = createCreateFieldVisit\(\{\s*createFieldVisit: deps\.createFieldVisit,\s*\}\);/,
+    },
+    {
+      name: "createVisitLocationUseCases",
+      pattern:
+        /const visitLocationUseCases = createVisitLocationUseCases\(\{\s*getVisitLocationForClinicVisit: deps\.getVisitLocationForClinicVisit,\s*upsertVisitLocationForClinicVisit: deps\.upsertVisitLocationForClinicVisit,\s*\}\);/,
+    },
+    {
+      name: "createTimeWindowUseCases",
+      pattern:
+        /const timeWindowUseCases = createTimeWindowUseCases\(\{\s*listTimeWindowsForClinicVisit: deps\.listTimeWindowsForClinicVisit,\s*createTimeWindowForClinicVisit: deps\.createTimeWindowForClinicVisit,\s*\}\);/,
+    },
+  ];
+
+  for (const { name, pattern } of compositions) {
+    assert.match(routeSource, pattern);
+    assert.ok(
+      routeSource.search(pattern) < handlersStart,
+      `la composición de ${name} debe ocurrir antes de los handlers`,
+    );
+    assert.equal(
+      routeSource.match(new RegExp(`\\b${name}\\s*\\(`, "g"))?.length ?? 0,
+      1,
+      `${name} debe componerse exactamente una vez`,
+    );
   }
 
+  // Los seis handlers restantes delegan en los casos de uso M15.
+  for (const marker of [
+    "await listFieldVisits(params)",
+    "await createFieldVisitUseCase(parsed.input)",
+    "await visitLocationUseCases.getVisitLocation(",
+    "await visitLocationUseCases.upsertVisitLocation(",
+    "await timeWindowUseCases.listTimeWindows(",
+    "await timeWindowUseCases.createTimeWindow(parsed.input)",
+  ]) {
+    assert.ok(routeSource.includes(marker), `debe delegar mediante ${marker}`);
+  }
+
+  // Cero llamadas persistentes directas dentro de handlers: las deps de
+  // persistencia sólo pueden referenciarse (sin invocar) en las composiciones.
+  assert.doesNotMatch(
+    routeSource,
+    /deps\.(createFieldVisit|listClinicFieldVisits|updateClinicScopedFieldVisit|getVisitLocationForClinicVisit|upsertVisitLocationForClinicVisit|createTimeWindowForClinicVisit|listTimeWindowsForClinicVisit)\s*\(/,
+    "ningún handler puede invocar directamente una dependencia de persistencia",
+  );
+
+  // La secuencia observable del PATCH permanece intacta.
   assert.match(
     routeSource,
     /if \(!enforceTrustedOrigin\(request, reply, allowedOrigins\)\)[\s\S]*?authenticateClinicUser\(request, reply, deps, now\)[\s\S]*?canManageLogisticsFieldVisits[\s\S]*?parseEntityId\(request\.params\.fieldVisitId\)[\s\S]*?buildUpdateFieldVisitInput\(request\.body\)[\s\S]*?updateFieldVisit\(/,
   );
+});
+
+test("M15 loads default persistence only through the field visits DB adapter", () => {
+  // La ruta no contiene ninguna referencia a db-logistics: ni import estático,
+  // ni dinámico, ni type-only, ni textual.
+  assert.doesNotMatch(routeSource, /db-logistics/);
+
+  // Tipos de I/O provenientes del adapter de infrastructure.
+  assert.match(
+    routeSource,
+    /import type \{[\s\S]*?\} from "\.\.\/features\/logistics\/infrastructure\/logistics-field-visits-db-adapter\.ts";/,
+  );
+
+  // Carga default lazy vía la factory del adapter, dentro de loadDefaultDeps.
+  assert.match(
+    routeSource,
+    /const fieldVisitsDb = \(\s*await import\(\s*"\.\.\/features\/logistics\/infrastructure\/logistics-field-visits-db-adapter\.ts"\s*\)\s*\)\.createLogisticsFieldVisitsDbAdapter\(\);/,
+  );
+
+  // Las siete operaciones de persistencia provienen del adapter.
+  for (const operation of [
+    "createFieldVisit",
+    "listClinicFieldVisits",
+    "updateClinicScopedFieldVisit",
+    "getVisitLocationForClinicVisit",
+    "upsertVisitLocationForClinicVisit",
+    "createTimeWindowForClinicVisit",
+    "listTimeWindowsForClinicVisit",
+  ]) {
+    assert.ok(
+      routeSource.includes(`fieldVisitsDb.${operation}`),
+      `loadDefaultDeps debe componer ${operation} desde el adapter`,
+    );
+  }
 });
 
 test("logistics field visit M09 application files stay free of HTTP and DB imports", () => {

--- a/test/unit/application/logistics/create-field-visit.test.ts
+++ b/test/unit/application/logistics/create-field-visit.test.ts
@@ -1,0 +1,148 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createCreateFieldVisit,
+  type LogisticsFieldVisitCreateRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubFieldVisit = {
+  id: number;
+  clinicId: number;
+  status: string;
+  notes: string | null;
+};
+
+type StubCreateInput = {
+  clinicId: number;
+  status?: string;
+  priority?: number;
+  notes?: string | null;
+};
+
+type RepositoryResult = StubFieldVisit | null | undefined;
+
+function createRepositoryStub(behavior: {
+  result?: RepositoryResult;
+  error?: Error;
+}) {
+  const calls: StubCreateInput[] = [];
+
+  const repository: LogisticsFieldVisitCreateRepository<
+    StubFieldVisit,
+    StubCreateInput
+  > = {
+    createFieldVisit: (input) => {
+      calls.push(input);
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.result);
+    },
+  };
+
+  return { repository, calls };
+}
+
+test("createFieldVisit reenvía el input por identidad una vez y devuelve el resultado por identidad", async () => {
+  const input: StubCreateInput = {
+    clinicId: 7,
+    status: "pending",
+    priority: 2,
+    notes: "Visita programada",
+  };
+  const result: StubFieldVisit = {
+    id: 42,
+    clinicId: 7,
+    status: "pending",
+    notes: "Visita programada",
+  };
+  const { repository, calls } = createRepositoryStub({ result });
+  const createFieldVisitUseCase = createCreateFieldVisit(repository);
+
+  const received = await createFieldVisitUseCase(input);
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(calls[0], input);
+  assert.strictEqual(received, result);
+});
+
+test("createFieldVisit preserva null", async () => {
+  const { repository, calls } = createRepositoryStub({ result: null });
+  const createFieldVisitUseCase = createCreateFieldVisit(repository);
+
+  const received = await createFieldVisitUseCase({ clinicId: 7 });
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, null);
+});
+
+test("createFieldVisit preserva undefined", async () => {
+  const { repository, calls } = createRepositoryStub({ result: undefined });
+  const createFieldVisitUseCase = createCreateFieldVisit(repository);
+
+  const received = await createFieldVisitUseCase({ clinicId: 7 });
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, undefined);
+});
+
+test("createFieldVisit propaga el error original del puerto sin envolverlo", async () => {
+  const originalError = new Error("fallo de creación");
+  const { repository, calls } = createRepositoryStub({ error: originalError });
+  const createFieldVisitUseCase = createCreateFieldVisit(repository);
+  let caught: unknown;
+
+  await assert.rejects(
+    createFieldVisitUseCase({ clinicId: 7, status: "pending" }),
+    (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    },
+  );
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(caught, originalError);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/create-field-visit.ts",
+  "server/features/logistics/application/ports/logistics-field-visit-create-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("el caso de uso create field visit de M15 no importa HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/list-field-visits.test.ts
+++ b/test/unit/application/logistics/list-field-visits.test.ts
@@ -1,0 +1,150 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createListFieldVisits,
+  type LogisticsFieldVisitsReadRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubFieldVisit = {
+  id: number;
+  clinicId: number;
+  status: string;
+};
+
+type StubListParams = {
+  clinicId: number;
+  status?: string;
+  limit: number;
+  offset: number;
+};
+
+function createRepositoryStub(behavior: {
+  result?: StubFieldVisit[];
+  error?: Error;
+}) {
+  const calls: StubListParams[] = [];
+
+  const repository: LogisticsFieldVisitsReadRepository<
+    StubFieldVisit,
+    StubListParams
+  > = {
+    listClinicFieldVisits: (params) => {
+      calls.push(params);
+      return behavior.error
+        ? Promise.reject(behavior.error)
+        : Promise.resolve(behavior.result ?? []);
+    },
+  };
+
+  return { repository, calls };
+}
+
+test("listFieldVisits reenvía params por identidad una vez y devuelve el array por identidad", async () => {
+  const params: StubListParams = {
+    clinicId: 7,
+    status: "pending",
+    limit: 50,
+    offset: 0,
+  };
+  const result: StubFieldVisit[] = [
+    { id: 1, clinicId: 7, status: "pending" },
+    { id: 2, clinicId: 7, status: "pending" },
+  ];
+  const { repository, calls } = createRepositoryStub({ result });
+  const listFieldVisits = createListFieldVisits(repository);
+
+  const received = await listFieldVisits(params);
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(calls[0], params);
+  assert.strictEqual(received, result);
+});
+
+test("listFieldVisits preserva el array vacío del puerto", async () => {
+  const result: StubFieldVisit[] = [];
+  const { repository, calls } = createRepositoryStub({ result });
+  const listFieldVisits = createListFieldVisits(repository);
+
+  const received = await listFieldVisits({ clinicId: 7, limit: 50, offset: 0 });
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(received, result);
+  assert.deepEqual(received, []);
+});
+
+test("listFieldVisits realiza llamadas independientes sin memorizar resultados", async () => {
+  const { repository, calls } = createRepositoryStub({ result: [] });
+  const listFieldVisits = createListFieldVisits(repository);
+
+  const first: StubListParams = { clinicId: 7, limit: 50, offset: 0 };
+  const second: StubListParams = { clinicId: 7, limit: 50, offset: 50 };
+
+  await listFieldVisits(first);
+  await listFieldVisits(second);
+
+  assert.equal(calls.length, 2);
+  assert.strictEqual(calls[0], first);
+  assert.strictEqual(calls[1], second);
+});
+
+test("listFieldVisits propaga el error original del puerto sin envolverlo", async () => {
+  const originalError = new Error("fallo de listado");
+  const { repository, calls } = createRepositoryStub({ error: originalError });
+  const listFieldVisits = createListFieldVisits(repository);
+  let caught: unknown;
+
+  await assert.rejects(
+    listFieldVisits({ clinicId: 7, limit: 50, offset: 0 }),
+    (error: unknown) => {
+      caught = error;
+      return error === originalError;
+    },
+  );
+
+  assert.equal(calls.length, 1);
+  assert.strictEqual(caught, originalError);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/list-field-visits.ts",
+  "server/features/logistics/application/ports/logistics-field-visits-read-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("el caso de uso list field visits de M15 no importa HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/time-window-use-cases.test.ts
+++ b/test/unit/application/logistics/time-window-use-cases.test.ts
@@ -1,0 +1,178 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createTimeWindowUseCases,
+  type LogisticsTimeWindowsRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubTimeWindow = {
+  id: number;
+  fieldVisitId: number;
+  isHard: boolean;
+};
+
+type StubCreateInput = {
+  fieldVisitId: number;
+  clinicId: number;
+  isHard?: boolean;
+};
+
+type RepositoryResult = StubTimeWindow | null | undefined;
+
+function createRepositoryStub(behavior: {
+  listResult?: StubTimeWindow[];
+  createResult?: RepositoryResult;
+  listError?: Error;
+  createError?: Error;
+}) {
+  const listCalls: Array<{ fieldVisitId: number; clinicId: number }> = [];
+  const createCalls: StubCreateInput[] = [];
+
+  const repository: LogisticsTimeWindowsRepository<
+    StubTimeWindow,
+    StubCreateInput
+  > = {
+    listTimeWindowsForClinicVisit: (fieldVisitId, clinicId) => {
+      listCalls.push({ fieldVisitId, clinicId });
+      return behavior.listError
+        ? Promise.reject(behavior.listError)
+        : Promise.resolve(behavior.listResult ?? []);
+    },
+    createTimeWindowForClinicVisit: (input) => {
+      createCalls.push(input);
+      return behavior.createError
+        ? Promise.reject(behavior.createError)
+        : Promise.resolve(behavior.createResult);
+    },
+  };
+
+  return { repository, listCalls, createCalls };
+}
+
+test("listTimeWindows reenvía fieldVisitId y clinicId una vez y devuelve el array por identidad", async () => {
+  const result: StubTimeWindow[] = [
+    { id: 1, fieldVisitId: 42, isHard: true },
+    { id: 2, fieldVisitId: 42, isHard: false },
+  ];
+  const { repository, listCalls, createCalls } = createRepositoryStub({
+    listResult: result,
+  });
+  const timeWindowUseCases = createTimeWindowUseCases(repository);
+
+  const received = await timeWindowUseCases.listTimeWindows(42, 7);
+
+  assert.equal(listCalls.length, 1);
+  assert.deepEqual(listCalls[0], { fieldVisitId: 42, clinicId: 7 });
+  assert.equal(createCalls.length, 0);
+  assert.strictEqual(received, result);
+});
+
+test("listTimeWindows preserva el array vacío del puerto", async () => {
+  const result: StubTimeWindow[] = [];
+  const { repository, listCalls } = createRepositoryStub({
+    listResult: result,
+  });
+  const timeWindowUseCases = createTimeWindowUseCases(repository);
+
+  const received = await timeWindowUseCases.listTimeWindows(42, 7);
+
+  assert.equal(listCalls.length, 1);
+  assert.strictEqual(received, result);
+  assert.deepEqual(received, []);
+});
+
+test("createTimeWindow reenvía el input por identidad una vez y devuelve el resultado por identidad", async () => {
+  const input: StubCreateInput = { fieldVisitId: 42, clinicId: 7, isHard: true };
+  const result: StubTimeWindow = { id: 3, fieldVisitId: 42, isHard: true };
+  const { repository, listCalls, createCalls } = createRepositoryStub({
+    createResult: result,
+  });
+  const timeWindowUseCases = createTimeWindowUseCases(repository);
+
+  const received = await timeWindowUseCases.createTimeWindow(input);
+
+  assert.equal(createCalls.length, 1);
+  assert.strictEqual(createCalls[0], input);
+  assert.equal(listCalls.length, 0);
+  assert.strictEqual(received, result);
+});
+
+test("createTimeWindow preserva null y undefined", async () => {
+  const input: StubCreateInput = { fieldVisitId: 42, clinicId: 7 };
+
+  const nullStub = createRepositoryStub({ createResult: null });
+  const nullUseCases = createTimeWindowUseCases(nullStub.repository);
+  assert.strictEqual(await nullUseCases.createTimeWindow(input), null);
+  assert.equal(nullStub.createCalls.length, 1);
+
+  const undefinedStub = createRepositoryStub({ createResult: undefined });
+  const undefinedUseCases = createTimeWindowUseCases(undefinedStub.repository);
+  assert.strictEqual(await undefinedUseCases.createTimeWindow(input), undefined);
+  assert.equal(undefinedStub.createCalls.length, 1);
+});
+
+test("las operaciones de time windows propagan el error original del puerto sin envolverlo", async () => {
+  const listError = new Error("fallo de listado de ventanas");
+  const createError = new Error("fallo de creación de ventana");
+  const { repository, listCalls, createCalls } = createRepositoryStub({
+    listError,
+    createError,
+  });
+  const timeWindowUseCases = createTimeWindowUseCases(repository);
+
+  await assert.rejects(
+    timeWindowUseCases.listTimeWindows(42, 7),
+    (error: unknown) => error === listError,
+  );
+  await assert.rejects(
+    timeWindowUseCases.createTimeWindow({ fieldVisitId: 42, clinicId: 7 }),
+    (error: unknown) => error === createError,
+  );
+
+  assert.equal(listCalls.length, 1);
+  assert.equal(createCalls.length, 1);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/time-window-use-cases.ts",
+  "server/features/logistics/application/ports/logistics-time-windows-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("los casos de uso de time windows de M15 no importan HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});

--- a/test/unit/application/logistics/visit-location-use-cases.test.ts
+++ b/test/unit/application/logistics/visit-location-use-cases.test.ts
@@ -1,0 +1,200 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import {
+  createVisitLocationUseCases,
+  type LogisticsVisitLocationRepository,
+} from "../../../../server/features/logistics/application/index.ts";
+
+type StubVisitLocation = {
+  id: number;
+  fieldVisitId: number;
+  addressRaw: string;
+};
+
+type StubUpsertInput = {
+  fieldVisitId: number;
+  clinicId: number;
+  addressRaw: string;
+};
+
+type RepositoryResult = StubVisitLocation | null | undefined;
+
+function createRepositoryStub(behavior: {
+  getResult?: RepositoryResult;
+  upsertResult?: RepositoryResult;
+  getError?: Error;
+  upsertError?: Error;
+}) {
+  const getCalls: Array<{ fieldVisitId: number; clinicId: number }> = [];
+  const upsertCalls: StubUpsertInput[] = [];
+
+  const repository: LogisticsVisitLocationRepository<
+    StubVisitLocation,
+    StubUpsertInput
+  > = {
+    getVisitLocationForClinicVisit: (fieldVisitId, clinicId) => {
+      getCalls.push({ fieldVisitId, clinicId });
+      return behavior.getError
+        ? Promise.reject(behavior.getError)
+        : Promise.resolve(behavior.getResult);
+    },
+    upsertVisitLocationForClinicVisit: (input) => {
+      upsertCalls.push(input);
+      return behavior.upsertError
+        ? Promise.reject(behavior.upsertError)
+        : Promise.resolve(behavior.upsertResult);
+    },
+  };
+
+  return { repository, getCalls, upsertCalls };
+}
+
+test("getVisitLocation reenvía fieldVisitId y clinicId una vez y devuelve el resultado por identidad", async () => {
+  const result: StubVisitLocation = {
+    id: 3,
+    fieldVisitId: 42,
+    addressRaw: "Av. Siempreviva 742",
+  };
+  const { repository, getCalls, upsertCalls } = createRepositoryStub({
+    getResult: result,
+  });
+  const visitLocationUseCases = createVisitLocationUseCases(repository);
+
+  const received = await visitLocationUseCases.getVisitLocation(42, 7);
+
+  assert.equal(getCalls.length, 1);
+  assert.deepEqual(getCalls[0], { fieldVisitId: 42, clinicId: 7 });
+  assert.equal(upsertCalls.length, 0);
+  assert.strictEqual(received, result);
+});
+
+test("getVisitLocation preserva null y undefined", async () => {
+  const nullStub = createRepositoryStub({ getResult: null });
+  const nullUseCases = createVisitLocationUseCases(nullStub.repository);
+  assert.strictEqual(await nullUseCases.getVisitLocation(42, 7), null);
+  assert.equal(nullStub.getCalls.length, 1);
+
+  const undefinedStub = createRepositoryStub({ getResult: undefined });
+  const undefinedUseCases = createVisitLocationUseCases(
+    undefinedStub.repository,
+  );
+  assert.strictEqual(await undefinedUseCases.getVisitLocation(42, 7), undefined);
+  assert.equal(undefinedStub.getCalls.length, 1);
+});
+
+test("upsertVisitLocation reenvía el input por identidad una vez y devuelve el resultado por identidad", async () => {
+  const input: StubUpsertInput = {
+    fieldVisitId: 42,
+    clinicId: 7,
+    addressRaw: "Av. Siempreviva 742",
+  };
+  const result: StubVisitLocation = {
+    id: 3,
+    fieldVisitId: 42,
+    addressRaw: "Av. Siempreviva 742",
+  };
+  const { repository, getCalls, upsertCalls } = createRepositoryStub({
+    upsertResult: result,
+  });
+  const visitLocationUseCases = createVisitLocationUseCases(repository);
+
+  const received = await visitLocationUseCases.upsertVisitLocation(input);
+
+  assert.equal(upsertCalls.length, 1);
+  assert.strictEqual(upsertCalls[0], input);
+  assert.equal(getCalls.length, 0);
+  assert.strictEqual(received, result);
+});
+
+test("upsertVisitLocation preserva null y undefined", async () => {
+  const input: StubUpsertInput = {
+    fieldVisitId: 42,
+    clinicId: 7,
+    addressRaw: "Av. Siempreviva 742",
+  };
+
+  const nullStub = createRepositoryStub({ upsertResult: null });
+  const nullUseCases = createVisitLocationUseCases(nullStub.repository);
+  assert.strictEqual(await nullUseCases.upsertVisitLocation(input), null);
+  assert.equal(nullStub.upsertCalls.length, 1);
+
+  const undefinedStub = createRepositoryStub({ upsertResult: undefined });
+  const undefinedUseCases = createVisitLocationUseCases(
+    undefinedStub.repository,
+  );
+  assert.strictEqual(
+    await undefinedUseCases.upsertVisitLocation(input),
+    undefined,
+  );
+  assert.equal(undefinedStub.upsertCalls.length, 1);
+});
+
+test("las operaciones de visit location propagan el error original del puerto sin envolverlo", async () => {
+  const getError = new Error("fallo de lectura de ubicación");
+  const upsertError = new Error("fallo de upsert de ubicación");
+  const { repository, getCalls, upsertCalls } = createRepositoryStub({
+    getError,
+    upsertError,
+  });
+  const visitLocationUseCases = createVisitLocationUseCases(repository);
+
+  await assert.rejects(
+    visitLocationUseCases.getVisitLocation(42, 7),
+    (error: unknown) => error === getError,
+  );
+  await assert.rejects(
+    visitLocationUseCases.upsertVisitLocation({
+      fieldVisitId: 42,
+      clinicId: 7,
+      addressRaw: "Av. Siempreviva 742",
+    }),
+    (error: unknown) => error === upsertError,
+  );
+
+  assert.equal(getCalls.length, 1);
+  assert.equal(upsertCalls.length, 1);
+});
+
+const APPLICATION_FILES = [
+  "server/features/logistics/application/visit-location-use-cases.ts",
+  "server/features/logistics/application/ports/logistics-visit-location-repository.ts",
+] as const;
+
+function listImportSpecifiers(source: string): string[] {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+const FORBIDDEN_IMPORT_RULES: Array<{ label: string; pattern: RegExp }> = [
+  { label: "fastify", pattern: /^fastify(\/|$)/ },
+  { label: "server/db-logistics", pattern: /db-logistics/ },
+  { label: "server/db", pattern: /(^|\/)db(\.ts)?$/ },
+  { label: "drizzle-orm", pattern: /^drizzle-orm(\/|$)/ },
+  { label: "drizzle/schema", pattern: /drizzle\/schema/ },
+  { label: "server/lib", pattern: /(^|\/)lib\// },
+  { label: "server/routes", pattern: /(^|\/)routes\// },
+];
+
+test("los casos de uso de visit location de M15 no importan HTTP ni persistencia concreta", () => {
+  const violations: string[] = [];
+
+  for (const file of APPLICATION_FILES) {
+    const source = readFileSync(join(process.cwd(), ...file.split("/")), "utf8");
+    for (const specifier of listImportSpecifiers(source)) {
+      for (const { label, pattern } of FORBIDDEN_IMPORT_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});


### PR DESCRIPTION
## Summary

Implements M15 of the Logistics backend modularization program by removing direct `db-logistics` consumption from `logistics-field-visits.fastify.ts` and delegating the six remaining persistence flows to application use cases backed by minimal repository ports and an infrastructure DB adapter.

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception

## Mixed-Scope Justification

Not applicable. Tests and documentation support the backend runtime refactor.

## Other Scope Detail

Not applicable.

## Implementation

- Added four minimal application repository ports derived from `LogisticsFieldVisitsNativeRoutesOptions`.
- Added four application use-case modules for field-visit listing, creation, visit-location operations and time-window operations.
- Added `createLogisticsFieldVisitsDbAdapter()` over the canonical M12 persistence module.
- Re-exported the eight required persistence I/O types through the infrastructure adapter.
- Removed every static, dynamic, type-only and textual `db-logistics` reference from `logistics-field-visits.fastify.ts`.
- Preserved lazy default dependency loading through the infrastructure adapter.
- Replaced the six direct persistence calls in handlers with application use cases.
- Preserved the M09 `createUpdateFieldVisit` use case and its repository port without modification.
- Realigned the source contract without weakening HTTP, auth, CORS, RBAC or clinic-scoping assertions.
- Extended the Logistics infrastructure guard with executable M15 contracts.
- Updated the Logistics architecture and M15 implementation documentation.

Target dependency graph:

`route -> application use cases -> repository ports`

`route loadDefaultDeps -> infrastructure DB adapter -> canonical db-logistics`

## Preserved Invariants

- All seven functional endpoints and four OPTIONS handlers remain unchanged.
- The `/api/logistics/field-visits` prefix remains unchanged.
- HTTP methods, paths, response bodies, status codes and messages remain unchanged.
- Parsing, validation, pagination defaults and response serialization remain unchanged.
- Trusted-origin checks remain before authentication on unsafe operations.
- Clinic authentication, session expiration, clear-cookie and last-access refresh remain unchanged.
- RBAC continues to use `canManageLogisticsFieldVisits`.
- `clinicId` continues to come exclusively from the authenticated clinic session.
- `app_session_id` and the separation from `admin_session_id` remain unchanged.
- The canonical M12 DB implementation remains unchanged.
- All seven canonical transaction call-sites remain unchanged.
- The root `server/db-logistics.ts` compatibility shim remains unchanged for M16 consumers.
- `update-field-visit.ts` and its M09 repository port remain unchanged.
- Fully injected route registration continues without loading the real DB.
- No cache, audit, state machine, unit of work or new side effect was introduced.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build`
- [ ] `pnpm --dir frontend lint`
- [ ] `pnpm --dir frontend typecheck`
- [ ] `pnpm --dir frontend build`
- [ ] `pnpm audit --prod`
- [ ] `pnpm audit`
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Local evidence:

- Focused M15 application cohort: 22 passed, 0 failed.
- Focused integration, architecture and security cohort: 126 passed, 0 failed.
- `pnpm validate:local`: 3,327 tests, 3,326 passed, 1 skipped, 0 failed.
- Backend build passed; bundle size 849.4 kb.
- `pnpm security:public-surface` passed with no public exposure findings.
- `git diff --check` passed.
- Exact 22-path allowlist verified.
- Zero deleted files.
- Route contains zero `db-logistics` references.
- Route handlers contain zero direct persistence calls.
- All five field-visit application factories are composed exactly once.
- Canonical DB, compatibility shim and M09 files remain unchanged.
- Manifests, lockfiles, workflows and frontend remain unchanged.

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs or configuration.
- [x] AuthN/AuthZ and clinic data-access impact reviewed.
- [x] Cross-tenant isolation through authenticated `clinicId` reviewed.
- [x] Session, cookie, trusted-origin, CORS and RBAC behavior preserved.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact explicitly not applicable.

## No Scope

- No endpoint, HTTP contract or Fastify registration changes.
- No schema or migration changes.
- No dependency, manifest or lockfile changes.
- No frontend changes.
- No changes to auth, sessions, cookies, CORS, CSP or rate limits.
- No changes to the canonical Logistics persistence implementation.
- No changes to the root `server/db-logistics.ts` compatibility shim.
- No changes to M09 application code.
- No changes to route plans, route events or SLA routes.
- No M16 or M17 implementation.
- No DB, staging or production operation.

## Rollback

Revert this pull request.

This restores direct field-visit route composition through the compatibility shim and removes the M15 ports, use cases and DB adapter. No schema, database, migration or persistent-data rollback is required.