### PR TITLE
refactor(public-professionals): move eligibility domain

### DIFF
--- a/docs/implementation/m21-public-professionals-domain.md
+++ b/docs/implementation/m21-public-professionals-domain.md
@@ -1,0 +1,214 @@
+# M21 · Mover el dominio de elegibilidad a Public Professionals
+
+## Base exacta
+
+- **Rama base:** `refactor/backend-modularization-m21-public-professionals-domain`.
+- **HEAD base:** `ed83ab3dc5a2757ee3168cf38e99ab3ca6daedc4`.
+- **Working tree inicial:** limpio. Índice limpio.
+- **AGENTS aplicable:** únicamente `AGENTS.md` raíz.
+- **Milestone:** Fase E — **M21** (apertura del contexto Public Professionals).
+- **Documento rector:** [Backend Enterprise Modularization Program — Audit](../audit/backend-enterprise-modularization-program-audit.md)
+  (fila 52 → **M21**: `professional-bank-eligibility` es dominio real).
+
+## Objetivo
+
+Materializar el dominio real de Public Professionals moviendo la regla pura de
+elegibilidad del banco de profesionales desde
+`server/lib/professional-bank-eligibility.ts` a
+`server/features/public-professionals/domain/professional-bank-eligibility.ts`,
+detrás de un barrel público, preservando todos los exports y el comportamiento
+observable. M21 crea la frontera real de dominio, reapunta el consumidor runtime
+y el test de dominio al barrel canónico, conserva el path legacy como shim
+temporal y agrega un guard arquitectónico. **No** mueve persistencia, rutas ni
+rate limiting.
+
+## Censo de consumidores (evidencia `grep`)
+
+Path legacy `server/lib/professional-bank-eligibility.ts`:
+
+- **Runtime:** `server/db-public-professionals.ts` (único importador). Importa
+  `HISTOPATHOLOGY_REPORT_STUDY_TYPE` y `PROFESSIONAL_BANK_ELIGIBILITY_MONTHS`.
+- **Test:** `test/unit/contracts/public-professionals/professional-bank-eligibility.test.ts`
+  (importa la superficie de comportamiento de la regla).
+
+Ambos se reapuntan al barrel canónico en este PR. Las referencias restantes al
+path legacy viven en documentos rectores / de auditoría
+(`docs/audit/...`, `docs/architecture/shared-lib-boundary-inventory.md`,
+`docs/pr-history/PR-feat-professional-bank-eligibility.md`) y **no se modifican**
+en este PR técnico: son baseline histórico, no rompen build/tests/guards. El
+shim conserva la compatibilidad de cualquier import legacy hasta M24.
+
+## Exports preservados
+
+Movidos íntegros al módulo canónico (misma superficie pública):
+
+- `PROFESSIONAL_BANK_ELIGIBILITY_MONTHS`
+- `HISTOPATHOLOGY_REPORT_STUDY_TYPE`
+- `ProfessionalBankReportDeliveryCandidate` (tipo)
+- `isHistopathologyReport`
+- `addMonths`
+- `getProfessionalBankEligibilityWindow`
+- `getEligibleUntil`
+- `isProfessionalBankEligible`
+- `getLastHistopathologyReportDeliveredAt`
+- `getProfessionalBankEligibility`
+
+Comportamiento preservado sin cambios: ventana rolling UTC de tres meses,
+inclusión exacta del límite, rechazo de fechas inválidas/ausentes, aritmética de
+fin de mes, selección de la última entrega admin, exigencia `deliveredByAdmin`,
+`eligibleUntil`, payload final y tipos públicos.
+
+## Contradicción detectada con `report-study-types.ts`
+
+El archivo legacy importaba del contexto Reports:
+
+```typescript
+import { isReportStudyType, type ReportStudyType } from "./report-study-types.ts";
+```
+
+`server/lib/report-study-types.ts` pertenece al contexto **Reports**, cuyo move
+está reservado para **M36**. El dominio canónico de Public Professionals **no
+debe depender en runtime de ese futuro contexto**. Se aplica una resolución
+comportamiento-equivalente que elimina la dependencia:
+
+```typescript
+export const HISTOPATHOLOGY_REPORT_STUDY_TYPE = "histopatologia" as const;
+
+export function isHistopathologyReport(input: {
+  studyType?: string | null;
+}): boolean {
+  return input.studyType === HISTOPATHOLOGY_REPORT_STUDY_TYPE;
+}
+```
+
+No se copia ni se mueve `REPORT_STUDY_TYPES`, y el dominio canónico no importa
+`server/lib/report-study-types.ts`.
+
+### Prueba de equivalencia
+
+El predicado histórico era `isReportStudyType(x) && x === HISTOPATHOLOGY_REPORT_STUDY_TYPE`
+con `HISTOPATHOLOGY_REPORT_STUDY_TYPE === "histopatologia"` e
+`isReportStudyType(x)` verdadero sii `x ∈ REPORT_STUDY_TYPES`
+(`["citologia", "histopatologia", "hemoparasitos"]`).
+
+- Si `x === "histopatologia"`: pertenece al catálogo ⇒ `isReportStudyType(x)` es
+  `true`, y la igualdad es `true` ⇒ predicado histórico `true`. El nuevo
+  predicado (`x === "histopatologia"`) también es `true`.
+- Si `x !== "histopatologia"`: la igualdad es `false` ⇒ predicado histórico
+  `false` (con o sin pertenencia). El nuevo predicado también `false`.
+
+El nuevo predicado es equivalente porque **el único valor que satisface
+simultáneamente la pertenencia al catálogo y la igualdad es `"histopatologia"`**.
+La relación contractual (histopatología ∈ catálogo) se preserva **por test**:
+`REPORT_STUDY_TYPES.includes(HISTOPATHOLOGY_REPORT_STUDY_TYPE) === true`.
+
+## Decisión shim
+
+Se conserva `server/lib/professional-bank-eligibility.ts` como **shim mínimo**
+(`export *` hacia el barrel canónico, sin lógica). Motivo: el programa exige
+compatibilidad temporal durante Fase E. Tras M21 el shim **no tiene consumidores
+runtime** (el único, `db-public-professionals.ts`, ya consume el barrel). El shim
+**expira en M24**, tras el censo final de Fase E. No se conserva lógica
+duplicada, wrappers, aliases ni defaults.
+
+## Allowlist (9 paths: 6 A + 3 M, 0 D, 0 R)
+
+```text
+A  docs/implementation/m21-public-professionals-domain.md
+A  server/features/public-professionals/README.md
+A  server/features/public-professionals/domain/README.md
+A  server/features/public-professionals/domain/index.ts
+A  server/features/public-professionals/domain/professional-bank-eligibility.ts
+A  test/architecture/public-professionals-domain-boundary-guard.test.ts
+M  server/lib/professional-bank-eligibility.ts
+M  server/db-public-professionals.ts
+M  test/unit/contracts/public-professionals/professional-bank-eligibility.test.ts
+```
+
+| Archivo | Cambio |
+| --- | --- |
+| `server/features/public-professionals/domain/professional-bank-eligibility.ts` | **CREATED.** Módulo canónico puro (cero imports); resuelve la dependencia con Reports. |
+| `server/features/public-professionals/domain/index.ts` | **CREATED.** Barrel público (`export *`). |
+| `server/lib/professional-bank-eligibility.ts` | **MODIFIED.** Reemplazado por shim `export *` hacia el barrel. |
+| `server/db-public-professionals.ts` | **MODIFIED.** Sólo el specifier del import (barrel canónico). |
+| `test/unit/contracts/public-professionals/professional-bank-eligibility.test.ts` | **MODIFIED.** Import reapuntado al barrel + caso de pertenencia al catálogo. |
+| `test/architecture/public-professionals-domain-boundary-guard.test.ts` | **CREATED.** Guard de frontera del dominio. |
+| `server/features/public-professionals/README.md` | **CREATED.** Frontera del contexto. |
+| `server/features/public-professionals/domain/README.md` | **CREATED.** Contrato del dominio puro. |
+| `docs/implementation/m21-public-professionals-domain.md` | **CREATED.** Este documento. |
+
+## Contratos preservados
+
+- **db-public-professionals.ts:** sólo cambia el specifier del import
+  (`HISTOPATHOLOGY_REPORT_STUDY_TYPE`, `PROFESSIONAL_BANK_ELIGIBILITY_MONTHS` por
+  el barrel). SQL, templates, nombres de constantes SQL, queries, mappings,
+  filtros, ordenamientos, límites, transacciones (cero), exports, tipos y el
+  comportamiento search/detail quedan **byte por byte** idénticos.
+- **Regla de elegibilidad:** cuerpo movido sin reescrituras cosméticas salvo la
+  eliminación de la dependencia con Reports ya especificada.
+
+## Tests anclados
+
+- `test/architecture/public-professionals-domain-boundary-guard.test.ts`
+  (**nuevo**) — existencia del dominio + módulo canónico + barrel, pureza
+  (sin db/env/fastify/infra/routes/supabase/fs/http/process/report-study-types
+  ni otros `server/lib/**`), cero imports en el canónico, re-export por barrel,
+  consumo runtime por barrel, shim sólo-re-export, consumidor apunta al barrel y
+  ausencia de copia del catálogo dentro del feature.
+- `test/unit/contracts/public-professionals/professional-bank-eligibility.test.ts`
+  — mismos casos de comportamiento, import reapuntado al barrel, **+1** caso:
+  `REPORT_STUDY_TYPES.includes(HISTOPATHOLOGY_REPORT_STUDY_TYPE)`.
+- `test/architecture/public-professionals-source-boundaries.test.ts` — verde sin
+  cambios (inspecciona la ruta pública, no el dominio).
+- `test/unit/contracts/public-professionals/public-professionals-db-contract.test.ts`,
+  `...-histopathology-eligibility.test.ts`,
+  `...-histopathology-sql-drift.test.ts` — verdes sin cambios: inspeccionan el
+  texto SQL y los nombres de constantes de `db-public-professionals.ts`, que no
+  cambian (sólo cambió el specifier del import).
+
+## Exclusiones
+
+Sin cambios en `server/lib/report-study-types.ts`,
+`server/lib/public-professionals-rate-limit.ts`,
+`server/routes/public-professionals.fastify.ts`, `server/fastify-app.ts`,
+`drizzle/**`, `migrations/**`, `supabase/**`, schema, auth/sesiones/cookies/CORS/
+CSP/rate-limits/headers, `frontend/**`, `package.json`, lockfiles, `.github/**`,
+`scripts/**`, `AGENTS.md`. No se movieron `server/db-public-professionals.ts`,
+`server/lib/report-study-types.ts`, `server/lib/public-professionals-rate-limit.ts`
+ni `server/routes/public-professionals.fastify.ts`. No se modificaron documentos
+rectores/auditoría. No se inició M22, M23 ni M24.
+
+## Validaciones
+
+Ver la sección de validaciones del reporte de ejecución (gates dirigidos con
+`pnpm exec tsx --test` sobre el guard nuevo, el guard de source boundaries y los
+cuatro contratos de public-professionals; luego `pnpm validate:local`,
+`pnpm security:public-surface` y `git diff --check`). Estados canónicos:
+`PASSED` / `FAILED` / `NOT_RUN` / `NOT_AVAILABLE` / `BLOCKED`.
+
+## Riesgos residuales
+
+- Bajo. El move preserva la superficie pública y el comportamiento; la única
+  divergencia (eliminación de la dependencia con Reports) es comportamiento-
+  equivalente y está anclada por test.
+- Referencias documentales al path legacy quedan en docs rectores/auditoría (no
+  modificables aquí): staleza documental, no rompe build/tests/guards. Se
+  reconcilia en el closeout documental posterior.
+
+## Rollback
+
+Revertir el PR restaura el módulo legacy con lógica propia y los imports de
+`db-public-professionals.ts` y del test. No hay cambios de schema, migraciones,
+rutas ni contratos HTTP que compliquen el revert.
+
+## Estado
+
+```text
+M20 cerrado
+M21 listo para integración
+Fase E abierta
+M22 no iniciado
+```
+
+El closeout documental posterior registrará la metadata real de merge (PR, SHA,
+timestamp, checks); este PR técnico no inventa esos datos.

--- a/server/db-public-professionals.ts
+++ b/server/db-public-professionals.ts
@@ -11,7 +11,7 @@ import {
 import {
   HISTOPATHOLOGY_REPORT_STUDY_TYPE,
   PROFESSIONAL_BANK_ELIGIBILITY_MONTHS,
-} from "./lib/professional-bank-eligibility.ts";
+} from "./features/public-professionals/domain/index.ts";
 
 const DEFAULT_LIMIT = 20;
 const MAX_LIMIT = 50;

--- a/server/features/public-professionals/README.md
+++ b/server/features/public-professionals/README.md
@@ -1,0 +1,90 @@
+# Public Professionals — bounded context
+
+> **Tipo:** Frontera de módulo del contexto Public Professionals. **Primera
+> materialización real** del contexto en M21: la regla pura de elegibilidad del
+> banco de profesionales pasa a vivir en `domain/`.
+> **Origen:** [ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md) · [ARCH-2](../../../docs/architecture/backend-boundary-adr.md) · [ARCH-3](../../../docs/architecture/shared-lib-boundary-inventory.md).
+> **ID:** **M21 (Fase E — apertura: dominio de elegibilidad)**.
+>
+> **Estado:** M21 **listo para integración** (no mergeado). **Fase E abierta.**
+> **M22 (persistencia) no iniciado.**
+
+Este directorio es la **frontera** del contexto Public Professionals: el
+directorio público de profesionales del portal (perfil público de clínica,
+búsqueda pública y detalle público, más la elegibilidad por actividad reciente
+de histopatología). Según
+[ARCH-1](../../../docs/audit/repository-domain-architecture-audit.md) es un
+**candidato temprano** de migración (cohesión alta, acoplamiento bajo, riesgo
+bajo).
+
+## 1. Qué materializa M21
+
+M21 mueve la **única regla de dominio real** del contexto —la elegibilidad del
+banco de profesionales— desde `server/lib/professional-bank-eligibility.ts` a
+`server/features/public-professionals/domain/professional-bank-eligibility.ts`,
+detrás de un barrel público, sin cambiar comportamiento observable.
+
+- **`domain/`** — reglas puras con barrel público (`index.ts`): ventana rolling
+  UTC de tres meses, semántica de histopatología, selección de la última entrega
+  admin y payload de elegibilidad. **Cero imports** (100% puro). Ver
+  [`domain/README.md`](./domain/README.md).
+
+## 2. Arquitectura actual
+
+```text
+db-public-professionals → domain barrel (features/public-professionals/domain/index.ts)
+```
+
+`server/db-public-professionals.ts` consume la elegibilidad **por el barrel
+canónico**, nunca por un archivo interno del dominio ni por el path legacy.
+
+## 3. Qué NO mueve M21
+
+- **Persistencia** — `server/db-public-professionals.ts` sigue en su path legacy
+  (queries, templates SQL, mappings y filtros intactos byte por byte). Su
+  traslado a `infrastructure/` está reservado para **M22 (no iniciado)**.
+- **Ruta y rate limit** — `server/routes/public-professionals.fastify.ts` y
+  `server/lib/public-professionals-rate-limit.ts` quedan **intactos** hasta
+  **M23**.
+- **Catálogo de Reports** — `server/lib/report-study-types.ts` pertenece al
+  contexto Reports (move reservado para **M36**). El dominio canónico **no**
+  depende de él en runtime; la relación contractual (histopatología ∈ catálogo)
+  se preserva por test.
+
+## 4. Shim legacy temporal
+
+`server/lib/professional-bank-eligibility.ts` se conserva como **shim mínimo**
+(`export *` hacia el barrel canónico), sólo por compatibilidad temporal del
+programa. Tras M21 **no tiene consumidores runtime**; **expira en M24**, tras el
+censo final de Fase E.
+
+## 5. Reglas de dependencia
+
+La dependencia **siempre apunta hacia adentro**. `domain/` es puro: no conoce
+transporte HTTP ni motor de persistencia.
+
+| Capa | Rol | Puede importar | No puede importar |
+| --- | --- | --- | --- |
+| **[domain](./domain/README.md)** | Reglas puras. | shared kernel (sólo tipos), utilidades puras relativas del propio contexto | `fastify`, Drizzle runtime, `env`, `http`, auth/CORS, `db-*`, `infrastructure`, `routes`, Supabase, I/O de Node, otros `server/lib/**`, `report-study-types` |
+
+Verificado por
+`test/architecture/public-professionals-domain-boundary-guard.test.ts`.
+
+## 6. Estado de la migración
+
+- **M21 — apertura de Fase E (listo para integración, no mergeado)** — move de
+  la regla de elegibilidad a `domain/` con barrel público, reapuntado del
+  consumidor runtime y del test de dominio al barrel, shim temporal en el path
+  legacy, guard de frontera nuevo y documentación. **Cero cambios** en SQL,
+  rutas, rate limits, schema, migraciones, auth ni CORS.
+- **M22 (no iniciado)** — persistencia de Public Professionals a
+  `infrastructure/`.
+- **M23 (no iniciado)** — ruta y rate limit.
+- **M24 (no iniciado)** — cierre de Fase E y retiro del shim legacy.
+
+## 7. Documentos rectores
+
+- [ARCH-1 — Repository Domain Architecture Audit](../../../docs/audit/repository-domain-architecture-audit.md) — clasifica Public Professionals como candidato temprano.
+- [ARCH-2 — Backend Domain Boundary ADR](../../../docs/architecture/backend-boundary-adr.md) — reglas de dependencia por capa.
+- [ARCH-3 — Shared / Lib Boundary Inventory](../../../docs/architecture/shared-lib-boundary-inventory.md) — inventario a nivel de archivo del terreno a migrar.
+- [Nota de implementación — M21](../../../docs/implementation/m21-public-professionals-domain.md) — mueve la regla de elegibilidad a `domain/` con shim temporal.

--- a/server/features/public-professionals/domain/README.md
+++ b/server/features/public-professionals/domain/README.md
@@ -1,0 +1,81 @@
+# Public Professionals · domain (reglas puras)
+
+> Capa **domain** del contexto Public Professionals. **Contiene código** desde
+> M21. Ver la frontera del contexto en [`../README.md`](../README.md) y el
+> contrato en [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
+
+## Responsabilidad
+
+Regla de negocio **pura** de elegibilidad del banco de profesionales: determina
+si una clínica figura en el directorio público según su **actividad reciente de
+histopatología**. Sin efectos secundarios, sin I/O, sin framework. Determinista
+y testeable en aislamiento.
+
+## Exports públicos
+
+`professional-bank-eligibility.ts` (consumido por el barrel `index.ts`):
+
+- **Constantes:** `PROFESSIONAL_BANK_ELIGIBILITY_MONTHS` (3),
+  `HISTOPATHOLOGY_REPORT_STUDY_TYPE` (`"histopatologia"`).
+- **Tipos:** `ProfessionalBankReportDeliveryCandidate`.
+- **Funciones:** `isHistopathologyReport`, `addMonths`,
+  `getProfessionalBankEligibilityWindow`, `getEligibleUntil`,
+  `isProfessionalBankEligible`, `getLastHistopathologyReportDeliveredAt`,
+  `getProfessionalBankEligibility`.
+
+## Semántica preservada (sin cambios de comportamiento)
+
+- **Ventana rolling UTC de tres meses.** `deliveredFrom = addMonths(now, -3)`,
+  toda la aritmética en UTC.
+- **Inclusión exacta del límite.** Elegible si `deliveredAt >= deliveredFrom`
+  (el instante límite incluye; un milisegundo antes, no).
+- **Rechazo de fechas inválidas / ausentes.** `null`, `undefined` y valores no
+  parseables no son elegibles.
+- **Aritmética de fin de mes estable.** Se recorta al último día del mes destino
+  (p. ej. 31-ene + 3 meses = 30-abr).
+- **Selección de la última entrega.** Sólo cuenta la histopatología entregada
+  por admin (`deliveredByAdmin`), tomando la más reciente.
+- **Payload final.** `{ eligible, lastHistopathologyReportDeliveredAt, eligibleUntil }`.
+
+## Semántica de histopatología y relación con el catálogo
+
+`isHistopathologyReport` evalúa
+`input.studyType === HISTOPATHOLOGY_REPORT_STUDY_TYPE`. Esto es equivalente al
+predicado histórico `isReportStudyType(x) && x === HISTOPATHOLOGY_...` porque el
+único valor que satisface la igualdad también pertenece al catálogo. La relación
+contractual **histopatología ∈ catálogo de Reports** se preserva **por test**
+(`REPORT_STUDY_TYPES.includes(HISTOPATHOLOGY_REPORT_STUDY_TYPE)`), **no por
+dependencia runtime**: `server/lib/report-study-types.ts` pertenece al contexto
+Reports (move reservado para M36) y el dominio canónico no lo importa.
+
+## Barrel obligatorio
+
+`index.ts` re-exporta la superficie completa (`export *`) sin transformarla y es
+el **único** punto de entrada del dominio. Consumidores runtime y tests deben
+importar el barrel, nunca el archivo interno (garantizado por el guard).
+
+## Regla de dependencia
+
+- **Puede importar:** el shared kernel (`drizzle/schema.ts`) **sólo como tipos**,
+  y utilidades puras relativas del propio contexto.
+- **No puede importar:** `fastify`, el runtime de Drizzle, `env`, `http`,
+  auth/CORS, ningún `db-*`, `infrastructure`, `routes`, Supabase, I/O de Node,
+  otros `server/lib/**` ni `report-study-types`.
+- La dependencia apunta hacia adentro: `domain` no conoce transporte HTTP ni
+  motor de persistencia.
+
+Verificado por
+`test/architecture/public-professionals-domain-boundary-guard.test.ts`, que
+además exige cero imports en el módulo canónico, consumo por barrel y que el path
+legacy quede como shim sólo-re-export.
+
+## Shim legacy temporal
+
+`server/lib/professional-bank-eligibility.ts` re-exporta este dominio por
+compatibilidad temporal (M21 → expira en M24). Sin consumidores runtime tras M21.
+
+## Qué NO hacer
+
+No importar `db-*`, Drizzle runtime, `fastify`, `env`, I/O ni `report-study-types`.
+No crear stubs, interfaces ni barrels vacíos. No copiar el catálogo de Reports
+dentro del feature.

--- a/server/features/public-professionals/domain/index.ts
+++ b/server/features/public-professionals/domain/index.ts
@@ -1,0 +1,14 @@
+// Public Professionals · domain (barrel público)
+//
+// Superficie pública del contexto `public-professionals/domain`: re-exporta la
+// regla pura de elegibilidad del banco de profesionales sin agregar lógica ni
+// cambiar su comportamiento. Es el único punto de entrada que el resto del
+// backend y los tests deben consumir; nadie fuera de `domain/` importa sus
+// archivos internos (garantizado por
+// `public-professionals-domain-boundary-guard`).
+//
+// - M21 · `professional-bank-eligibility.ts` (ventana rolling UTC de 3 meses,
+//          semántica de histopatología, selección de última entrega admin;
+//          cero imports, sólo cálculo puro).
+
+export * from "./professional-bank-eligibility.ts";

--- a/server/features/public-professionals/domain/professional-bank-eligibility.ts
+++ b/server/features/public-professionals/domain/professional-bank-eligibility.ts
@@ -1,0 +1,118 @@
+export const PROFESSIONAL_BANK_ELIGIBILITY_MONTHS = 3;
+export const HISTOPATHOLOGY_REPORT_STUDY_TYPE = "histopatologia" as const;
+
+export type ProfessionalBankReportDeliveryCandidate = {
+  studyType?: string | null;
+  deliveredAt?: Date | string | number | null;
+  deliveredByAdmin?: boolean | null;
+};
+
+export function isHistopathologyReport(input: {
+  studyType?: string | null;
+}): boolean {
+  return input.studyType === HISTOPATHOLOGY_REPORT_STUDY_TYPE;
+}
+
+function normalizeDate(value: Date | string | number | null | undefined): Date | null {
+  if (value == null) {
+    return null;
+  }
+
+  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
+  return Number.isNaN(date.getTime()) ? null : date;
+}
+
+function getDaysInUtcMonth(year: number, month: number): number {
+  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
+}
+
+export function addMonths(date: Date, months: number): Date {
+  const resultMonth = date.getUTCMonth() + months;
+  const resultYear = date.getUTCFullYear() + Math.floor(resultMonth / 12);
+  const normalizedMonth = ((resultMonth % 12) + 12) % 12;
+  const day = Math.min(
+    date.getUTCDate(),
+    getDaysInUtcMonth(resultYear, normalizedMonth),
+  );
+
+  return new Date(
+    Date.UTC(
+      resultYear,
+      normalizedMonth,
+      day,
+      date.getUTCHours(),
+      date.getUTCMinutes(),
+      date.getUTCSeconds(),
+      date.getUTCMilliseconds(),
+    ),
+  );
+}
+
+export function getProfessionalBankEligibilityWindow(now: Date) {
+  return {
+    now,
+    deliveredFrom: addMonths(now, -PROFESSIONAL_BANK_ELIGIBILITY_MONTHS),
+  };
+}
+
+export function getEligibleUntil(lastDeliveredAt: Date): Date {
+  return addMonths(lastDeliveredAt, PROFESSIONAL_BANK_ELIGIBILITY_MONTHS);
+}
+
+export function isProfessionalBankEligible(
+  lastDeliveredAt: Date | string | number | null | undefined,
+  now: Date,
+): boolean {
+  const deliveredAt = normalizeDate(lastDeliveredAt);
+
+  if (!deliveredAt) {
+    return false;
+  }
+
+  const { deliveredFrom } = getProfessionalBankEligibilityWindow(now);
+  return deliveredAt.getTime() >= deliveredFrom.getTime();
+}
+
+export function getLastHistopathologyReportDeliveredAt(
+  reports: readonly ProfessionalBankReportDeliveryCandidate[],
+): Date | null {
+  let latest: Date | null = null;
+
+  for (const report of reports) {
+    if (!report.deliveredByAdmin || !isHistopathologyReport(report)) {
+      continue;
+    }
+
+    const deliveredAt = normalizeDate(report.deliveredAt);
+
+    if (!deliveredAt) {
+      continue;
+    }
+
+    if (!latest || deliveredAt.getTime() > latest.getTime()) {
+      latest = deliveredAt;
+    }
+  }
+
+  return latest;
+}
+
+export function getProfessionalBankEligibility(
+  reports: readonly ProfessionalBankReportDeliveryCandidate[],
+  now: Date,
+) {
+  const lastHistopathologyReportDeliveredAt =
+    getLastHistopathologyReportDeliveredAt(reports);
+  const eligible = isProfessionalBankEligible(
+    lastHistopathologyReportDeliveredAt,
+    now,
+  );
+
+  return {
+    eligible,
+    lastHistopathologyReportDeliveredAt,
+    eligibleUntil: lastHistopathologyReportDeliveredAt
+      ? getEligibleUntil(lastHistopathologyReportDeliveredAt)
+      : null,
+  };
+}

--- a/server/lib/professional-bank-eligibility.ts
+++ b/server/lib/professional-bank-eligibility.ts
@@ -1,124 +1,13 @@
-import { isReportStudyType, type ReportStudyType } from "./report-study-types.ts";
+// Shim de compatibilidad temporal (M21).
+//
+// La regla de dominio de elegibilidad del banco de profesionales se materializó
+// en `server/features/public-professionals/domain/` (M21). Este path legacy se
+// conserva SÓLO por compatibilidad temporal requerida por el programa de
+// modularización backend: re-exporta la superficie pública completa desde el
+// barrel canónico, sin lógica propia.
+//
+// - No tiene consumidores runtime después de M21 (el único consumidor,
+//   `server/db-public-professionals.ts`, ya importa el barrel canónico).
+// - Expira en M24, tras el censo final de Fase E.
 
-export const PROFESSIONAL_BANK_ELIGIBILITY_MONTHS = 3;
-export const HISTOPATHOLOGY_REPORT_STUDY_TYPE =
-  "histopatologia" satisfies ReportStudyType;
-
-export type ProfessionalBankReportDeliveryCandidate = {
-  studyType?: string | null;
-  deliveredAt?: Date | string | number | null;
-  deliveredByAdmin?: boolean | null;
-};
-
-export function isHistopathologyReport(input: {
-  studyType?: string | null;
-}): boolean {
-  return (
-    isReportStudyType(input.studyType) &&
-    input.studyType === HISTOPATHOLOGY_REPORT_STUDY_TYPE
-  );
-}
-
-function normalizeDate(value: Date | string | number | null | undefined): Date | null {
-  if (value == null) {
-    return null;
-  }
-
-  const date = value instanceof Date ? new Date(value.getTime()) : new Date(value);
-  return Number.isNaN(date.getTime()) ? null : date;
-}
-
-function getDaysInUtcMonth(year: number, month: number): number {
-  return new Date(Date.UTC(year, month + 1, 0)).getUTCDate();
-}
-
-export function addMonths(date: Date, months: number): Date {
-  const resultMonth = date.getUTCMonth() + months;
-  const resultYear = date.getUTCFullYear() + Math.floor(resultMonth / 12);
-  const normalizedMonth = ((resultMonth % 12) + 12) % 12;
-  const day = Math.min(
-    date.getUTCDate(),
-    getDaysInUtcMonth(resultYear, normalizedMonth),
-  );
-
-  return new Date(
-    Date.UTC(
-      resultYear,
-      normalizedMonth,
-      day,
-      date.getUTCHours(),
-      date.getUTCMinutes(),
-      date.getUTCSeconds(),
-      date.getUTCMilliseconds(),
-    ),
-  );
-}
-
-export function getProfessionalBankEligibilityWindow(now: Date) {
-  return {
-    now,
-    deliveredFrom: addMonths(now, -PROFESSIONAL_BANK_ELIGIBILITY_MONTHS),
-  };
-}
-
-export function getEligibleUntil(lastDeliveredAt: Date): Date {
-  return addMonths(lastDeliveredAt, PROFESSIONAL_BANK_ELIGIBILITY_MONTHS);
-}
-
-export function isProfessionalBankEligible(
-  lastDeliveredAt: Date | string | number | null | undefined,
-  now: Date,
-): boolean {
-  const deliveredAt = normalizeDate(lastDeliveredAt);
-
-  if (!deliveredAt) {
-    return false;
-  }
-
-  const { deliveredFrom } = getProfessionalBankEligibilityWindow(now);
-  return deliveredAt.getTime() >= deliveredFrom.getTime();
-}
-
-export function getLastHistopathologyReportDeliveredAt(
-  reports: readonly ProfessionalBankReportDeliveryCandidate[],
-): Date | null {
-  let latest: Date | null = null;
-
-  for (const report of reports) {
-    if (!report.deliveredByAdmin || !isHistopathologyReport(report)) {
-      continue;
-    }
-
-    const deliveredAt = normalizeDate(report.deliveredAt);
-
-    if (!deliveredAt) {
-      continue;
-    }
-
-    if (!latest || deliveredAt.getTime() > latest.getTime()) {
-      latest = deliveredAt;
-    }
-  }
-
-  return latest;
-}
-
-export function getProfessionalBankEligibility(
-  reports: readonly ProfessionalBankReportDeliveryCandidate[],
-  now: Date,
-) {
-  const lastHistopathologyReportDeliveredAt =
-    getLastHistopathologyReportDeliveredAt(reports);
-  const eligible = isProfessionalBankEligible(
-    lastHistopathologyReportDeliveredAt,
-    now,
-  );
-
-  return {
-    eligible,
-    lastHistopathologyReportDeliveredAt,
-    eligibleUntil: lastHistopathologyReportDeliveredAt
-      ? getEligibleUntil(lastHistopathologyReportDeliveredAt)
-      : null,
-  };
-}
+export * from "../features/public-professionals/domain/index.ts";

--- a/test/architecture/public-professionals-domain-boundary-guard.test.ts
+++ b/test/architecture/public-professionals-domain-boundary-guard.test.ts
@@ -1,0 +1,398 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const repoRoot = process.cwd();
+
+const featureDir = "server/features/public-professionals";
+const domainDir = `${featureDir}/domain`;
+const domainIndexFile = `${domainDir}/index.ts`;
+const canonicalModuleFile = `${domainDir}/professional-bank-eligibility.ts`;
+
+// Path legacy conservado sólo como shim temporal (M21 → expira en M24). Se
+// construye por concatenación (no como literal fijo) para que el propio archivo
+// del guard no sea un falso positivo bajo ningún escaneo, y para comparar contra
+// specifiers de import ya resueltos, nunca contra texto libre.
+const legacyShimFile = ["server", "lib", "professional-bank-eligibility.ts"].join(
+  "/",
+);
+
+const runtimeConsumerFile = "server/db-public-professionals.ts";
+
+// Catálogo de Reports cuyo move está reservado para M36: el dominio canónico de
+// Public Professionals no debe depender de él en runtime (se preserva la
+// relación contractual por test, no por import).
+const REPORT_STUDY_TYPES_STEM = ["report", "study", "types"].join("-");
+
+function readText(relativePath: string) {
+  return readFileSync(join(repoRoot, relativePath), "utf8").replace(/\r\n/g, "\n");
+}
+
+function walkFiles(relativeDir: string, extension = ".ts"): string[] {
+  const absoluteDir = join(repoRoot, relativeDir);
+
+  if (!existsSync(absoluteDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath = `${relativeDir}/${entry.name}`;
+
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(relativePath, extension));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(extension)) {
+      files.push(relativePath);
+    }
+  }
+
+  return files;
+}
+
+// Parser robusto de imports: cubre `import ... from`, `require(...)`,
+// `import(...)` dinámico, `import "..."` de efecto lateral y `export ... from`.
+function listImportSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+function toRepoRelativePath(path: string) {
+  return path.replaceAll("\\", "/");
+}
+
+function resolveRelativeTsSpecifier(file: string, specifier: string) {
+  const resolvedPath = toRepoRelativePath(
+    relative(repoRoot, join(repoRoot, dirname(file), specifier)),
+  );
+
+  if (resolvedPath.endsWith(".ts")) {
+    return resolvedPath;
+  }
+
+  const tsFilePath = `${resolvedPath}.ts`;
+  if (existsSync(join(repoRoot, tsFilePath))) {
+    return tsFilePath;
+  }
+
+  const indexFilePath = `${resolvedPath}/index.ts`;
+  if (existsSync(join(repoRoot, indexFilePath))) {
+    return indexFilePath;
+  }
+
+  return resolvedPath;
+}
+
+function resolveSpecifier(file: string, specifier: string) {
+  return specifier.startsWith(".")
+    ? resolveRelativeTsSpecifier(file, specifier)
+    : toRepoRelativePath(specifier);
+}
+
+function stripComments(source: string) {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, "")
+    .replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+// Reglas de frontera de la capa domain (ADR ARCH-2): domain sólo importa el
+// shared kernel como tipos y utilidades puras relativas del propio contexto.
+const FORBIDDEN_SPECIFIER_RULES: Array<{ label: string; pattern: RegExp }> = [
+  {
+    label: "import de persistencia (server/db o db-*)",
+    pattern: /(^|\/)(db|database)([./-][\w-]*)?$/i,
+  },
+  {
+    label: "import directo de configuración de entorno (lib/env)",
+    pattern: /(^|\/)env(\.ts)?$/i,
+  },
+  {
+    label: "import hacia la capa infrastructure del propio contexto",
+    pattern: /(^|\/)infrastructure(\/|$)/,
+  },
+  {
+    label: "import hacia la capa routes del propio contexto",
+    pattern: /(^|\/)routes(\/|$)/,
+  },
+  {
+    label: "import de fastify",
+    pattern: /^fastify(\/|$)/,
+  },
+  {
+    label: "import del runtime de drizzle",
+    pattern: /^drizzle-orm(\/|$)/,
+  },
+  {
+    label: "import de auth/middleware",
+    pattern: /(^|\/)auth([-./]|$)/i,
+  },
+  {
+    label: "import relacionado con CORS",
+    pattern: /cors/i,
+  },
+  {
+    label: "import de node:process",
+    pattern: /^(node:)?process(\/|$)/,
+  },
+  {
+    label: "import de cliente supabase",
+    pattern: /supabase/i,
+  },
+  {
+    label: "import de módulos node de I/O (fs/http/https)",
+    pattern: /^(node:)?(fs|http|https)(\/|$)/,
+  },
+  {
+    label: "import del catálogo de Reports (report-study-types)",
+    pattern: new RegExp(REPORT_STUDY_TYPES_STEM),
+  },
+];
+
+const FORBIDDEN_SOURCE_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  {
+    label: "acceso directo a process.* (env, cwd, exit, etc.)",
+    pattern: /\bprocess\.\w+/,
+  },
+  {
+    label: "I/O de red explícito (fetch)",
+    pattern: /\bfetch\s*\(/,
+  },
+];
+
+// 1 + 2 + 3
+test("Public Professionals domain existe, contiene el módulo canónico y el barrel, con código real", () => {
+  assert.equal(
+    existsSync(join(repoRoot, domainDir)),
+    true,
+    `${domainDir} debe existir`,
+  );
+
+  assert.equal(
+    existsSync(join(repoRoot, domainIndexFile)),
+    true,
+    `${domainIndexFile} debe existir`,
+  );
+
+  assert.equal(
+    existsSync(join(repoRoot, canonicalModuleFile)),
+    true,
+    `${canonicalModuleFile} debe existir`,
+  );
+
+  const canonicalSource = readText(canonicalModuleFile);
+
+  assert.ok(
+    canonicalSource.length > 500,
+    "el módulo canónico debe contener código real, no un stub",
+  );
+
+  for (const requiredExport of [
+    "PROFESSIONAL_BANK_ELIGIBILITY_MONTHS",
+    "HISTOPATHOLOGY_REPORT_STUDY_TYPE",
+    "isHistopathologyReport",
+    "getProfessionalBankEligibility",
+  ]) {
+    assert.ok(
+      canonicalSource.includes(`export`) && canonicalSource.includes(requiredExport),
+      `el módulo canónico debe exportar ${requiredExport}`,
+    );
+  }
+});
+
+// 4
+test("Public Professionals domain permanece puro: sin db/env/fastify/infra/routes/supabase/fs/http/process/report-study-types", () => {
+  const violations: string[] = [];
+
+  for (const file of walkFiles(domainDir)) {
+    const content = readText(file);
+    const specifiers = listImportSpecifiers(content);
+
+    for (const specifier of specifiers) {
+      for (const { label, pattern } of FORBIDDEN_SPECIFIER_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+
+      // Ningún import a otros módulos de `server/lib/**`.
+      const resolved = resolveSpecifier(file, specifier);
+      if (resolved.startsWith("server/lib/")) {
+        violations.push(
+          `${file}: import a server/lib/** desde el dominio puro ("${specifier}" -> ${resolved})`,
+        );
+      }
+    }
+
+    for (const { label, pattern } of FORBIDDEN_SOURCE_PATTERNS) {
+      if (pattern.test(content)) {
+        violations.push(`${file}: ${label}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 4 (positivo): sólo imports relativos internos o tipos del shared kernel
+test("Public Professionals domain sólo importa dependencias relativas internas o el shared kernel de tipos", () => {
+  const violations: string[] = [];
+
+  for (const file of walkFiles(domainDir)) {
+    const content = readText(file);
+
+    for (const specifier of listImportSpecifiers(content)) {
+      const isRelativeImport = specifier.startsWith(".");
+      const isSharedKernelTypes = /drizzle\/schema(\.ts)?$/.test(specifier);
+
+      if (!isRelativeImport && !isSharedKernelTypes) {
+        violations.push(`${file}: import no permitido en domain puro ("${specifier}")`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 5
+test("El módulo canónico de elegibilidad tiene cero imports", () => {
+  const specifiers = listImportSpecifiers(readText(canonicalModuleFile));
+
+  assert.deepEqual(
+    specifiers,
+    [],
+    `${canonicalModuleFile} debe ser 100% puro (cero imports)`,
+  );
+});
+
+// 6
+test("El barrel de dominio re-exporta el módulo canónico", () => {
+  const barrelSource = readText(domainIndexFile);
+  const resolvedTargets = listImportSpecifiers(barrelSource).map((specifier) =>
+    resolveSpecifier(domainIndexFile, specifier),
+  );
+
+  assert.ok(
+    resolvedTargets.includes(canonicalModuleFile),
+    `${domainIndexFile} debe re-exportar ${canonicalModuleFile}`,
+  );
+
+  assert.ok(
+    /export\s+\*\s+from\s+["']\.\/professional-bank-eligibility\.ts["']/.test(
+      barrelSource,
+    ),
+    "el barrel debe re-exportar la superficie completa del módulo canónico",
+  );
+});
+
+// 7
+test("Los consumidores runtime de server/** importan el dominio por el barrel, no archivos internos", () => {
+  const violations: string[] = [];
+  const runtimeFiles = walkFiles("server").filter(
+    (file) => !file.startsWith(`${domainDir}/`),
+  );
+
+  for (const file of runtimeFiles) {
+    for (const specifier of listImportSpecifiers(readText(file))) {
+      const resolved = resolveSpecifier(file, specifier);
+
+      const importsDomainInternalFile =
+        resolved.startsWith(`${domainDir}/`) &&
+        resolved.endsWith(".ts") &&
+        resolved !== domainIndexFile;
+
+      if (importsDomainInternalFile) {
+        violations.push(
+          `${file}: import directo a archivo interno del dominio ("${specifier}" -> ${resolved})`,
+        );
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 8
+test("Ningún archivo runtime salvo el propio shim importa el path legacy", () => {
+  const violations: string[] = [];
+
+  for (const file of walkFiles("server")) {
+    if (file === legacyShimFile) {
+      continue;
+    }
+
+    for (const specifier of listImportSpecifiers(readText(file))) {
+      const resolved = resolveSpecifier(file, specifier);
+
+      if (resolved === legacyShimFile) {
+        violations.push(
+          `${file}: import al shim legacy ("${specifier}" -> ${resolved})`,
+        );
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 9
+test("server/db-public-professionals.ts importa el barrel canónico del dominio", () => {
+  const resolvedTargets = listImportSpecifiers(readText(runtimeConsumerFile)).map(
+    (specifier) => resolveSpecifier(runtimeConsumerFile, specifier),
+  );
+
+  assert.ok(
+    resolvedTargets.includes(domainIndexFile),
+    `${runtimeConsumerFile} debe importar ${domainIndexFile}`,
+  );
+
+  assert.ok(
+    !resolvedTargets.includes(legacyShimFile),
+    `${runtimeConsumerFile} no debe importar el shim legacy`,
+  );
+});
+
+// 10 + 11
+test("El shim legacy es sólo el re-export exacto hacia el barrel, sin lógica", () => {
+  const shimSource = readText(legacyShimFile);
+  const codeLines = stripComments(shimSource)
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  assert.deepEqual(
+    codeLines,
+    ['export * from "../features/public-professionals/domain/index.ts";'],
+    "el shim debe contener exactamente un re-export y ninguna lógica",
+  );
+
+  const resolvedTargets = listImportSpecifiers(shimSource).map((specifier) =>
+    resolveSpecifier(legacyShimFile, specifier),
+  );
+
+  assert.deepEqual(
+    resolvedTargets,
+    [domainIndexFile],
+    "el único re-export del shim debe resolver al barrel canónico",
+  );
+});
+
+// 12
+test("No existe una copia nueva de report-study-types dentro del feature", () => {
+  const copies = walkFiles(featureDir).filter((file) =>
+    file.endsWith(`/${REPORT_STUDY_TYPES_STEM}.ts`),
+  );
+
+  assert.deepEqual(
+    copies,
+    [],
+    "el catálogo de Reports (M36) no debe copiarse dentro de public-professionals",
+  );
+});

--- a/test/unit/contracts/public-professionals/professional-bank-eligibility.test.ts
+++ b/test/unit/contracts/public-professionals/professional-bank-eligibility.test.ts
@@ -2,6 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 
 import {
+  HISTOPATHOLOGY_REPORT_STUDY_TYPE,
   addMonths,
   getEligibleUntil,
   getLastHistopathologyReportDeliveredAt,
@@ -9,7 +10,8 @@ import {
   getProfessionalBankEligibilityWindow,
   isHistopathologyReport,
   isProfessionalBankEligible,
-} from "../../../../server/lib/professional-bank-eligibility.ts";
+} from "../../../../server/features/public-professionals/domain/index.ts";
+import { REPORT_STUDY_TYPES } from "../../../../server/lib/report-study-types.ts";
 
 const NOW = new Date("2026-06-03T12:00:00.000Z");
 
@@ -57,6 +59,19 @@ test("histopathology definition uses the report study type catalog", () => {
   assert.equal(isHistopathologyReport({ studyType: "citologia" }), false);
   assert.equal(isHistopathologyReport({ studyType: "Histopatologia" }), false);
   assert.equal(isHistopathologyReport({ studyType: null }), false);
+});
+
+test("histopathology study type stays a member of the report study type catalog", () => {
+  // Relación contractual preservada por test, no por dependencia runtime: el
+  // dominio canónico ya no importa `report-study-types.ts` (M21). El nuevo
+  // predicado `input.studyType === HISTOPATHOLOGY_REPORT_STUDY_TYPE` es
+  // equivalente al anterior `isReportStudyType(x) && x === HISTOPATHOLOGY...`
+  // exactamente porque el único valor que satisface la igualdad también
+  // pertenece al catálogo. Este assert ancla esa pertenencia.
+  assert.equal(
+    REPORT_STUDY_TYPES.includes(HISTOPATHOLOGY_REPORT_STUDY_TYPE),
+    true,
+  );
 });
 
 test("last histopathology delivery ignores non-admin, non-histopathology, and invalid rows", () => {


### PR DESCRIPTION
## Summary

Materializa el dominio real de Public Professionals para M21 moviendo la regla
pura de elegibilidad del banco profesional desde
`server/lib/professional-bank-eligibility.ts` hacia
`server/features/public-professionals/domain/`.

El nuevo módulo canónico queda detrás de un barrel de dominio, con cero imports,
sin DB, Fastify, HTTP, auth, infraestructura ni I/O. El path legacy se conserva
como shim temporal de re-export.

La dependencia runtime con `server/lib/report-study-types.ts`, reservada para el
futuro contexto Reports en M36, se elimina mediante una transformación
comportamiento-equivalente: la identificación de histopatología permanece como
igualdad exacta con `"histopatologia"`, y el test contractual verifica que esa
constante continúa perteneciendo al catálogo canónico.

`server/db-public-professionals.ts` sólo cambia el specifier del import. SQL,
queries, mappings, filtros, exports y comportamiento permanecen intactos.

M20 permanece cerrado. M21 queda listo para integración. Fase E continúa
abierta y M22 no se inicia.

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

El cambio afecta código bajo `server/`, tests y documentación. El validador
considera tests y documentación categorías de soporte cuando existe un scope
backend primario, por lo que se declara exclusivamente `backend runtime`.

No se modifican rutas, endpoints, rate limits, DB, schema, migraciones, frontend,
auth, CORS, CSP, dependencias, lockfiles ni CI. No corresponde mixed-scope.

Allowlist exacta:

- 6 archivos creados
- 3 archivos modificados
- 0 eliminados
- 0 renombrados

## Validation

- directed Public Professionals suite: PASSED — 35 tests
- `pnpm validate:local`: PASSED
- backend tests incluidos por `validate:local`: PASSED — 3375 passed, 1 skipped
- backend build incluido por `validate:local`: PASSED
- `pnpm security:public-surface`: PASSED
- `git diff --check`: PASSED
- exact nine-path allowlist: PASSED
- UTF-8 without BOM, no U+FFFD, no conflict markers: PASSED
- Playwright/E2E: NOT_RUN — no frontend change
- schema/migrations: NOT_RUN — no database change
- dependency audits: NOT_RUN — no manifest or lockfile change
- remote CI: NOT_RUN at PR creation; GitHub will execute applicable workflows

## Rollback

- Trigger: a regression is found in the domain move, import redirection, shim, or architectural guard.
- Steps: execute `git revert <squash SHA of this PR>` on `main`.
- Result: restore the implementation under `server/lib/`, remove the new Public Professionals domain files and guard, and restore the previous imports.
- Data impact: none; there are no schema, migration, persistence-data or endpoint changes.
- M20 does not need to be reverted.