### PR TITLE
refactor(clinics): extract domain validations

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -1008,6 +1008,27 @@ mapping (SQL-drift alineado) · **M23** thin ruta + rate limit wiring · **M24**
 **M27** thin admin (consultas+comandos) · **M28** thin perfil público (disclosure verde) ·
 **M29** cierre + cross-tenant.
 
+> **Status M25 — apertura de Fase F con este cambio.** Se estableció el dominio
+> Clinics (`server/features/clinics/domain/`): `clinic-management-validation.ts`
+> (reglas puras, cero imports, con `ClinicUserRole` propio sin depender de
+> `drizzle/schema`) + barrel canónico. Las validaciones administrativas reales
+> (create/update/delete de clínicas) se extrajeron 1:1 desde
+> `server/routes/admin-clinics.fastify.ts` (987 → 695 LOC) hacia el dominio; la
+> ruta las consume por el barrel y se retiraron las 8 funciones inline migradas.
+>
+> Sin cambios de comportamiento: endpoints, status codes, payloads, mensajes en
+> español, precedencia de errores, trimming, defaults, CORS, trusted origin,
+> auth, auditoría, mapping de errores DB, transacciones y SQL permanecen
+> idénticos. La **persistencia sigue en `server/db-admin-clinics.ts` hasta M26**;
+> la **ruta admin sigue no-thin hasta M27**; el **perfil público sigue diferido
+> a M28**; el **cierre/cross-tenant sigue diferido a M29**. No se creó capa
+> `application` (guard lo prohíbe). Un guard dedicado
+> (`test/architecture/clinics-domain-boundary-guard.test.ts`) fija la pureza del
+> dominio y el consumo por barrel.
+>
+> Detalle:
+> [`docs/implementation/m25-clinics-domain-validations.md`](../implementation/m25-clinics-domain-validations.md).
+
 **Fase G — Study Tracking (5):** **M30** domain moves · **M31** UCs + puerto email + repo ·
 **M32** thin `study-tracking` + `particular-study-tracking` · **M32b** thin
 `admin-study-tracking` · **M35** cierre.

--- a/docs/implementation/m25-clinics-domain-validations.md
+++ b/docs/implementation/m25-clinics-domain-validations.md
@@ -1,0 +1,174 @@
+# M25 — Clinics domain / validaciones reales
+
+> **Fase F del programa de modularización backend — primer milestone.**
+> Extrae las reglas de dominio y validaciones reales de la administración de
+> clínicas desde la ruta legacy hacia un dominio puro, tipado, testeado y
+> protegido por un guard de arquitectura, sin cambiar ningún contrato HTTP ni
+> comportamiento observable.
+
+## Identificación
+
+- **Milestone:** M25 (abre Fase F — Clinics).
+- **Base exacta:** `0df8e07811add7e66b0748a8928428d01941df63`
+  (`refactor(public-professionals): close phase and remove legacy shims (#1528)`).
+- **Rama:** `refactor/backend-modularization-m25-clinics-domain-validations`.
+- **Documento rector:**
+  [backend-enterprise-modularization-program-audit](../audit/backend-enterprise-modularization-program-audit.md).
+
+## Objetivo
+
+Establecer la frontera canónica `server/features/clinics/domain/**` y hacer que
+la ruta administrativa consuma las validaciones canónicas. M25 **no** mueve
+persistencia (M26), **no** adelgaza la ruta (M27), **no** toca el perfil público
+(M28), **no** agrega capa `application` y **no** cambia comportamiento.
+
+## Arquitectura antes / después
+
+**Antes:**
+
+```
+admin-clinics.fastify.ts (987 LOC)
+  ├─ HTTP / CORS / auth / auditoría / error mapping
+  ├─ validaciones y normalización INLINE (8 funciones)
+  └─ db-admin-clinics.ts (persistencia)
+```
+
+**Después:**
+
+```
+admin-clinics.fastify.ts (695 LOC)
+  ├─ HTTP / CORS / auth / auditoría / error mapping   (sin cambios)
+  ├─ features/clinics/domain  → validación/normalización canónica
+  └─ db-admin-clinics.ts (persistencia)               (sin cambios)
+
+server/features/clinics/domain/
+  ├─ clinic-management-validation.ts  (reglas puras, cero imports)
+  └─ index.ts                         (barrel canónico)
+```
+
+## Matriz de reglas migradas
+
+### CREATE — `parseClinicCreateInput` (precedencia exacta)
+
+| # | Campo | Regla | Normalización | Mensaje / resultado |
+|---|---|---|---|---|
+| 1 | clinicName | requerido, string, ≤255 | trim | `Nombre de clínica es obligatorio.` / `Nombre de clínica excede 255 caracteres.` |
+| 2 | contactEmail | requerido, string, ≤255 | trim | `Email de contacto es obligatorio.` / `…excede 255 caracteres.` |
+| 3 | contactPhone | opcional, string si presente, ≤50 | trim, `""→null` | `Teléfono de contacto debe ser texto.` / `…excede 50 caracteres.` |
+| 4 | username | requerido, string, ≤100 | trim | `Usuario es obligatorio.` / `…excede 100 caracteres.` |
+| 5 | contactEmail | formato `^[^\s@]+@[^\s@]+\.[^\s@]+$` | — | `Email de contacto inválido.` |
+| 6 | username | mínimo 3 | — | `Usuario debe tener al menos 3 caracteres.` |
+| 7 | password | string ∧ `len≥8` ∧ `trim().len≥8` | **raw sin trim** | `La contraseña debe tener al menos 8 caracteres.` |
+| 8 | role | ausente/null/`""` → `clinic_owner`; válidos `clinic_owner`,`clinic_staff` | — | `role inválido. Debe ser clinic_owner o clinic_staff.` |
+
+### UPDATE — `parseClinicUpdateInput` (precedencia exacta)
+
+| # | Campo | Regla | Normalización | Mensaje / resultado |
+|---|---|---|---|---|
+| 1 | clinicName | `undefined→omitido`; si presente = requerido (no se puede vaciar), ≤255 | trim | `Nombre de clínica es obligatorio.` / `…excede 255 caracteres.` |
+| 2 | contactEmail | `undefined→omitido`; vacío/whitespace → `null`, ≤255 | trim, `""→null` | `Email de contacto debe ser texto.` / `…excede 255 caracteres.` |
+| 3 | contactPhone | `undefined→omitido`; vacío/whitespace → `null`, ≤50 | trim, `""→null` | `Teléfono de contacto debe ser texto.` / `…excede 50 caracteres.` |
+| 4 | contactEmail | formato, **sólo si queda string** (null no valida) | — | `Email de contacto inválido.` |
+| 5 | body sin campos | tras construir `updatedFields` | — | `Debe enviar al menos un dato de clínica para actualizar.` |
+
+`updatedFields` se construye en orden `clinicName, contactEmail, contactPhone`,
+sólo con los campos `!== undefined`.
+
+### DELETE — `parseClinicDeleteConfirmation` + `confirmClinicNameMatches`
+
+| # | Paso | Regla | Capa | Resultado |
+|---|---|---|---|---|
+| 1 | confirmClinicName | requerido, string, trim, ≤255 | dominio | `Confirmación de clínica es obligatorio.` / `…excede 255 caracteres.` → 400 |
+| 2 | lookup clínica | `getAdminClinicById` | ruta (IO) | `Clínica no encontrada.` → 404 |
+| 3 | match nombre | `confirm === clinic.clinicName` (case-sensitive, sin normalización extra) | dominio (predicado) + ruta (emisión) | `La confirmación no coincide con el nombre exacto de la clínica.` → 400 |
+
+Orden HTTP preservado: **parse 400 → lookup DB → not found 404 → mismatch 400 → delete**.
+
+## API canónica del dominio
+
+```ts
+export type ClinicUserRole = "clinic_owner" | "clinic_staff";
+export type ClinicValidationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+export type ClinicCreateInput = { clinicName; contactEmail; contactPhone: string|null; username; password; role: ClinicUserRole };
+export type ClinicUpdateInput = { clinicName?; contactEmail?: string|null; contactPhone?: string|null; updatedFields: string[] };
+
+export function parseClinicUserRole(value: unknown): ClinicUserRole | null;
+export function parseClinicCreateInput(body: unknown): ClinicValidationResult<ClinicCreateInput>;
+export function parseClinicUpdateInput(body: unknown): ClinicValidationResult<ClinicUpdateInput>;
+export function parseClinicDeleteConfirmation(body: unknown):
+  | { ok: true; confirmClinicName: string } | { ok: false; error: string };
+export function confirmClinicNameMatches(confirmation: string, actualClinicName: string): boolean;
+```
+
+## Frontera
+
+`test/architecture/clinics-domain-boundary-guard.test.ts` verifica, por censo
+estructural de imports y archivos:
+
+- dominio con código real + barrel; módulo canónico con **cero imports**;
+- prohibición de `fastify`, `drizzle`/`drizzle-orm` (incluso type-only),
+  `db`/`server/db-*`, `env`, `infrastructure`, `application`, `routes`,
+  `middlewares`, auth/CORS, Supabase, `fs/http/https/net/child_process`,
+  `process.*`, `fetch`;
+- ausencia de `FastifyRequest`/`FastifyReply`, `request`/`reply`, SQL,
+  `transaction` y status codes HTTP en el código del dominio;
+- la ruta importa el barrel (no el archivo interno);
+- ningún runtime importa el archivo interno del dominio;
+- las 8 funciones migradas no se redefinen inline en la ruta;
+- `server/features/clinics/application` no existe.
+
+## Invariantes preservados
+
+Endpoints, métodos, prefijo `/api/admin/clinics`, status codes, payloads de
+éxito y error, mensajes en español (tildes/signos intactos), orden de
+validación, trimming, defaults, `role` por defecto sin campo visible, CORS,
+trusted origin, auth admin, auditoría (orden y best-effort tras persistencia),
+mapping `23505/23502/23503`, comportamiento 409/500, transacciones, SQL, orden
+de delete, paginación, search, serialización ISO, no exposición de
+`passwordHash`/`password`/`authProId`, compatibilidad `clinic_id` legacy.
+
+## Exclusiones (no tocado en M25)
+
+`server/db-admin-clinics.ts` (runtime), `server/db.ts`, `server/index.ts`,
+`server/fastify-app.ts`, `admin-users-roles.fastify.ts`,
+`clinic-public-profile.fastify.ts` (M28), `clinic-audit.fastify.ts`,
+`server/lib/clinic-audit.ts`, `clinic-permissions.ts`, `frontend/**`,
+`drizzle/**`, `.github/**`, `package.json`, `pnpm-lock.yaml`.
+
+## Tests
+
+- **Dominio (nuevo):** `test/unit/domain/clinics/clinic-management-validation.test.ts`
+  (79 casos: create/update/delete, precedencia, normalización, límites, roles,
+  password raw, mismatch por casing/espacio).
+- **Guard (nuevo):** `test/architecture/clinics-domain-boundary-guard.test.ts`.
+- **Comportamiento HTTP (sin cambios, verde):**
+  `test/integration/adapters/controllers/admin-clinics.fastify.test.ts`.
+- **Contratos (sin cambios, verdes):** `admin-clinics-auth-contract`,
+  `admin-clinics-db-contract`, `security-csrf-mutating-route-coverage`,
+  `global-auth-boundary-contract`, `api-production-session-contract`.
+
+## Validación final
+
+`pnpm typecheck` · `pnpm typecheck:test` · suite dirigida (138 tests) ·
+`pnpm validate:local` · `pnpm build` · `pnpm security:public-surface` ·
+`git diff --check`. Resultados adjuntos en el PR.
+
+## Riesgos y rollback
+
+- **Riesgo:** cambio sutil de precedencia/mensajes. **Mitigación:** extracción
+  1:1 y tests de caracterización que fijan orden y texto exacto antes del cambio.
+- **Riesgo:** `ClinicUserRole` autónomo diverge del schema. **Mitigación:** unión
+  literal idéntica; `pnpm typecheck` garantiza asignabilidad con
+  `AdminClinicCreateInput.role`.
+- **Rollback:** revert del PR. El dominio es aditivo; la ruta vuelve a sus
+  funciones inline. Sin cambios de schema, migraciones, deps ni persistencia →
+  revert independiente y seguro.
+
+## Relación con M26–M29
+
+- **M26** · mover `db-admin-clinics.ts` a `clinics/infrastructure/` (tx exactas).
+- **M27** · adelgazar ruta admin (consultas + comandos) consumiendo el repo.
+- **M28** · adelgazar perfil público (disclosure verde).
+- **M29** · cierre de Fase F + cross-tenant.

--- a/server/features/clinics/README.md
+++ b/server/features/clinics/README.md
@@ -1,0 +1,42 @@
+# Clinics · bounded context
+
+> Contexto **Clinics** del backend. Abierto en **M25** (Fase F del programa de
+> modularización). Ver el contrato de fronteras en
+> [ARCH-2](../../../docs/architecture/backend-boundary-adr.md) y el estado del
+> programa en
+> [audit](../../../docs/audit/backend-enterprise-modularization-program-audit.md).
+
+## Estado por capas (M25)
+
+| Capa | Estado | Contenido |
+|---|---|---|
+| `domain/` | **con código** | Reglas puras de validación/normalización de administración de clínicas. |
+| `application/` | ausente | Diferido; no se anticipa capa (guard lo prohíbe). |
+| `infrastructure/` | ausente | Persistencia sigue en `server/db-admin-clinics.ts` hasta **M26**. |
+| `routes/` | ausente | La ruta admin sigue en `server/routes/admin-clinics.fastify.ts` (no-thin hasta **M27**). |
+
+## Topología actual de la administración de clínicas
+
+```
+admin-clinics.fastify.ts
+  ├─ HTTP / Fastify / CORS / auth / trusted-origin / auditoría / error mapping
+  ├─ features/clinics/domain  → validación y normalización semántica
+  └─ db-admin-clinics.ts (legacy)  → persistencia (tx, SQL, serialización)
+```
+
+La ruta convierte el resultado del dominio en las respuestas HTTP existentes; el
+dominio no conoce transporte ni persistencia.
+
+## Alcance del contexto en el programa
+
+- **M25** · domain / validaciones reales (este milestone).
+- **M26** · repositorio (mover `db-admin-clinics.ts` a `infrastructure/`, tx exactas).
+- **M27** · adelgazar ruta admin (consultas + comandos).
+- **M28** · adelgazar perfil público (`clinic-public-profile.fastify.ts`, disclosure).
+- **M29** · cierre + cross-tenant.
+
+## Qué NO vive aquí (todavía)
+
+Perfil público de clínica, avatar/uploads, `mapLink`, sync de búsqueda pública,
+auditoría de clínica y permisos: pertenecen a otras superficies/milestones y no
+se tocan en M25.

--- a/server/features/clinics/domain/README.md
+++ b/server/features/clinics/domain/README.md
@@ -1,0 +1,87 @@
+# Clinics · domain (reglas puras)
+
+> Capa **domain** del contexto Clinics. **Contiene código** desde M25. Ver la
+> frontera del contexto en [`../README.md`](../README.md) y el contrato en
+> [ARCH-2](../../../../docs/architecture/backend-boundary-adr.md).
+
+## Responsabilidad
+
+Validación y normalización semántica **pura** de la administración de clínicas:
+create, update y confirmación de borrado. Sin efectos secundarios, sin I/O, sin
+framework, sin DB. Recibe `unknown` o estructuras puras y devuelve datos
+normalizados o un error puro. Determinista y testeable en aislamiento.
+
+## Exports públicos
+
+`clinic-management-validation.ts` (consumido por el barrel `index.ts`):
+
+- **Tipos:** `ClinicUserRole`, `ClinicValidationResult<T>`, `ClinicCreateInput`,
+  `ClinicUpdateInput`.
+- **Funciones:** `parseClinicUserRole`, `parseClinicCreateInput`,
+  `parseClinicUpdateInput`, `parseClinicDeleteConfirmation`,
+  `confirmClinicNameMatches`.
+
+Los helpers `parseRequiredString`, `parseOptionalString`,
+`parseOptionalRequiredString` e `isValidEmail` son **privados** del módulo: no se
+exportan ni desde el archivo ni desde el barrel.
+
+## Tipo `ClinicUserRole` (autónomo, sin drizzle)
+
+El dominio define su propia unión literal:
+
+```ts
+export type ClinicUserRole = "clinic_owner" | "clinic_staff";
+```
+
+Es estructuralmente compatible con los consumidores actuales. **No** se importa
+desde `drizzle/schema` ni desde ningún módulo de persistencia — ni siquiera como
+tipo. El guard prohíbe todo import desde `drizzle/**`.
+
+## Semántica preservada (sin cambios de comportamiento)
+
+Extraída 1:1 desde `server/routes/admin-clinics.fastify.ts`. Se preservan
+mensajes exactos (con tildes y signos), precedencia de errores, trimming,
+defaults y la distinción entre campo ausente / null / vacío / tipo inválido.
+
+- **CREATE** · precedencia: `clinicName → contactEmail → contactPhone →
+  username → formato email → username mínimo (≥3) → password → role`.
+  `contactPhone` opcional (vacío → `null`, máx 50); `password` se valida
+  (`len ≥ 8` y `trim().length ≥ 8`) pero se devuelve **raw sin trim**; `role`
+  ausente/null/`""` → `clinic_owner`.
+- **UPDATE** · precedencia: `clinicName → contactEmail → contactPhone → formato
+  email → body sin campos`. `clinicName` presente **no puede quedar vacío**;
+  `contactEmail`/`contactPhone` vacíos → `null`; `updatedFields` en orden
+  `clinicName, contactEmail, contactPhone`.
+- **DELETE** · `parseClinicDeleteConfirmation` valida `confirmClinicName`
+  (requerido, trim, máx 255). `confirmClinicNameMatches` es la comparación
+  **case-sensitive** de la confirmación (ya trimmeada) contra el nombre real de
+  la clínica (sin normalización adicional). La lectura del body y la emisión de
+  400/404 quedan en la ruta.
+
+## Barrel obligatorio
+
+`index.ts` re-exporta únicamente la API canónica y es el **único** punto de
+entrada del dominio. Consumidores runtime y tests importan el barrel, nunca el
+archivo interno (garantizado por el guard).
+
+## Regla de dependencia
+
+- **Puede importar:** utilidades puras relativas del propio contexto (por ahora,
+  ninguna: el módulo canónico tiene cero imports).
+- **No puede importar:** `fastify`, `drizzle`/`drizzle-orm` (ni type-only),
+  cualquier `db-*` / `server/db`, `env`, `infrastructure`, `application`,
+  `routes`, `middlewares`, auth/CORS, Supabase, I/O de Node
+  (`fs/http/https/net/child_process`), `process.*` ni `fetch`.
+- El dominio no conoce `FastifyRequest`/`FastifyReply`, `request`/`reply`, SQL,
+  transacciones ni status codes HTTP.
+
+Verificado por
+`test/architecture/clinics-domain-boundary-guard.test.ts`, que exige cero imports
+en el módulo canónico, consumo por barrel, ausencia de capa `application` y que
+las 8 funciones migradas no se redefinan inline en la ruta.
+
+## Qué NO hacer
+
+No importar `db-*`, Drizzle (runtime ni tipos), `fastify`, `env` ni I/O. No
+exportar los helpers privados. No crear stubs, barrels vacíos ni capa
+`application` anticipada.

--- a/server/features/clinics/domain/clinic-management-validation.ts
+++ b/server/features/clinics/domain/clinic-management-validation.ts
@@ -1,0 +1,348 @@
+// Clinics · domain · validaciones de administración de clínicas (reglas puras)
+//
+// Reglas de dominio y normalización semántica de la administración de clínicas,
+// extraídas 1:1 desde `server/routes/admin-clinics.fastify.ts` (M25). Sin
+// framework, sin IO, sin DB, sin conocimiento de HTTP/Fastify: recibe `unknown`
+// o estructuras puras y devuelve datos normalizados o un error puro. La ruta
+// sigue siendo responsable de convertir el resultado a las respuestas HTTP
+// existentes (status codes, payloads, CORS, auth, auditoría, error mapping).
+//
+// El tipo `ClinicUserRole` se define aquí como unión literal canónica del
+// dominio (sin importar `drizzle/schema`), estructuralmente compatible con los
+// consumidores actuales. La pureza está garantizada por
+// `test/architecture/clinics-domain-boundary-guard.test.ts`.
+
+export type ClinicUserRole = "clinic_owner" | "clinic_staff";
+
+export type ClinicValidationResult<T> =
+  | { ok: true; data: T }
+  | { ok: false; error: string };
+
+export type ClinicCreateInput = {
+  clinicName: string;
+  contactEmail: string;
+  contactPhone: string | null;
+  username: string;
+  password: string;
+  role: ClinicUserRole;
+};
+
+export type ClinicUpdateInput = {
+  clinicName?: string;
+  contactEmail?: string | null;
+  contactPhone?: string | null;
+  updatedFields: string[];
+};
+
+type ClinicCreateBody = {
+  clinicName?: unknown;
+  contactEmail?: unknown;
+  contactPhone?: unknown;
+  username?: unknown;
+  password?: unknown;
+  role?: unknown;
+};
+
+type ClinicUpdateBody = {
+  clinicName?: unknown;
+  contactEmail?: unknown;
+  contactPhone?: unknown;
+};
+
+type ClinicDeleteBody = {
+  confirmClinicName?: unknown;
+};
+
+// --- Helpers privados de normalización/validación (no exportados) -----------
+
+function parseRequiredString(input: {
+  value: unknown;
+  field: string;
+  label: string;
+  maxLength: number;
+}) {
+  if (typeof input.value !== "string") {
+    return {
+      ok: false as const,
+      error: `${input.label} es obligatorio.`,
+    };
+  }
+
+  const trimmed = input.value.trim();
+
+  if (!trimmed) {
+    return {
+      ok: false as const,
+      error: `${input.label} es obligatorio.`,
+    };
+  }
+
+  if (trimmed.length > input.maxLength) {
+    return {
+      ok: false as const,
+      error: `${input.label} excede ${input.maxLength} caracteres.`,
+    };
+  }
+
+  return {
+    ok: true as const,
+    value: trimmed,
+  };
+}
+
+function parseOptionalString(input: {
+  value: unknown;
+  label: string;
+  maxLength: number;
+}) {
+  if (input.value === undefined) {
+    return {
+      ok: true as const,
+      value: undefined,
+    };
+  }
+
+  if (input.value === null) {
+    return {
+      ok: true as const,
+      value: null,
+    };
+  }
+
+  if (typeof input.value !== "string") {
+    return {
+      ok: false as const,
+      error: `${input.label} debe ser texto.`,
+    };
+  }
+
+  const trimmed = input.value.trim();
+
+  if (trimmed.length > input.maxLength) {
+    return {
+      ok: false as const,
+      error: `${input.label} excede ${input.maxLength} caracteres.`,
+    };
+  }
+
+  return {
+    ok: true as const,
+    value: trimmed || null,
+  };
+}
+
+function parseOptionalRequiredString(input: {
+  value: unknown;
+  label: string;
+  maxLength: number;
+}) {
+  if (input.value === undefined) {
+    return {
+      ok: true as const,
+      value: undefined,
+    };
+  }
+
+  return parseRequiredString({
+    value: input.value,
+    field: input.label,
+    label: input.label,
+    maxLength: input.maxLength,
+  });
+}
+
+function isValidEmail(value: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+// --- API canónica pública ---------------------------------------------------
+
+export function parseClinicUserRole(value: unknown): ClinicUserRole | null {
+  if (value === undefined || value === null || value === "") {
+    return "clinic_owner";
+  }
+
+  if (value === "clinic_owner" || value === "clinic_staff") {
+    return value;
+  }
+
+  return null;
+}
+
+export function parseClinicCreateInput(
+  body: unknown,
+): ClinicValidationResult<ClinicCreateInput> {
+  const input = (body ?? undefined) as ClinicCreateBody | undefined;
+
+  const clinicName = parseRequiredString({
+    value: input?.clinicName,
+    field: "clinicName",
+    label: "Nombre de clínica",
+    maxLength: 255,
+  });
+  const contactEmail = parseRequiredString({
+    value: input?.contactEmail,
+    field: "contactEmail",
+    label: "Email de contacto",
+    maxLength: 255,
+  });
+  const contactPhone = parseOptionalString({
+    value: input?.contactPhone,
+    label: "Teléfono de contacto",
+    maxLength: 50,
+  });
+  const username = parseRequiredString({
+    value: input?.username,
+    field: "username",
+    label: "Usuario",
+    maxLength: 100,
+  });
+
+  if (!clinicName.ok) return clinicName;
+  if (!contactEmail.ok) return contactEmail;
+  if (!contactPhone.ok) return contactPhone;
+  if (!username.ok) return username;
+
+  if (!isValidEmail(contactEmail.value)) {
+    return {
+      ok: false,
+      error: "Email de contacto inválido.",
+    };
+  }
+
+  if (username.value.length < 3) {
+    return {
+      ok: false,
+      error: "Usuario debe tener al menos 3 caracteres.",
+    };
+  }
+
+  if (
+    typeof input?.password !== "string" ||
+    input.password.length < 8 ||
+    input.password.trim().length < 8
+  ) {
+    return {
+      ok: false,
+      error: "La contraseña debe tener al menos 8 caracteres.",
+    };
+  }
+
+  const role = parseClinicUserRole(input.role);
+
+  if (!role) {
+    return {
+      ok: false,
+      error: "role inválido. Debe ser clinic_owner o clinic_staff.",
+    };
+  }
+
+  return {
+    ok: true,
+    data: {
+      clinicName: clinicName.value,
+      contactEmail: contactEmail.value,
+      contactPhone: contactPhone.value ?? null,
+      username: username.value,
+      password: input.password,
+      role,
+    },
+  };
+}
+
+export function parseClinicUpdateInput(
+  body: unknown,
+): ClinicValidationResult<ClinicUpdateInput> {
+  const input = (body ?? undefined) as ClinicUpdateBody | undefined;
+
+  const clinicName = parseOptionalRequiredString({
+    value: input?.clinicName,
+    label: "Nombre de clínica",
+    maxLength: 255,
+  });
+  const contactEmail = parseOptionalString({
+    value: input?.contactEmail,
+    label: "Email de contacto",
+    maxLength: 255,
+  });
+  const contactPhone = parseOptionalString({
+    value: input?.contactPhone,
+    label: "Teléfono de contacto",
+    maxLength: 50,
+  });
+
+  if (!clinicName.ok) return clinicName;
+  if (!contactEmail.ok) return contactEmail;
+  if (!contactPhone.ok) return contactPhone;
+
+  if (
+    typeof contactEmail.value === "string" &&
+    !isValidEmail(contactEmail.value)
+  ) {
+    return {
+      ok: false,
+      error: "Email de contacto inválido.",
+    };
+  }
+
+  const updatedFields: string[] = [];
+  const data: ClinicUpdateInput = {
+    updatedFields,
+  };
+
+  if (clinicName.value !== undefined) {
+    data.clinicName = clinicName.value;
+    updatedFields.push("clinicName");
+  }
+
+  if (contactEmail.value !== undefined) {
+    data.contactEmail = contactEmail.value;
+    updatedFields.push("contactEmail");
+  }
+
+  if (contactPhone.value !== undefined) {
+    data.contactPhone = contactPhone.value;
+    updatedFields.push("contactPhone");
+  }
+
+  if (updatedFields.length === 0) {
+    return {
+      ok: false,
+      error: "Debe enviar al menos un dato de clínica para actualizar.",
+    };
+  }
+
+  return {
+    ok: true,
+    data,
+  };
+}
+
+export function parseClinicDeleteConfirmation(
+  body: unknown,
+): { ok: true; confirmClinicName: string } | { ok: false; error: string } {
+  const input = (body ?? undefined) as ClinicDeleteBody | undefined;
+
+  const confirmClinicName = parseRequiredString({
+    value: input?.confirmClinicName,
+    field: "confirmClinicName",
+    label: "Confirmación de clínica",
+    maxLength: 255,
+  });
+
+  if (!confirmClinicName.ok) {
+    return confirmClinicName;
+  }
+
+  return {
+    ok: true,
+    confirmClinicName: confirmClinicName.value,
+  };
+}
+
+export function confirmClinicNameMatches(
+  confirmation: string,
+  actualClinicName: string,
+): boolean {
+  return confirmation === actualClinicName;
+}

--- a/server/features/clinics/domain/index.ts
+++ b/server/features/clinics/domain/index.ts
@@ -1,0 +1,26 @@
+// Clinics · domain (barrel público)
+//
+// Superficie pública del contexto `clinics/domain`: re-exporta las reglas puras
+// de validación y normalización de la administración de clínicas sin agregar
+// lógica ni cambiar comportamiento. Es el único punto de entrada que la ruta
+// admin y los tests deben consumir; nadie fuera de `domain/` importa el archivo
+// interno (garantizado por `clinics-domain-boundary-guard`).
+//
+// - M25 · `clinic-management-validation.ts` (validaciones create/update/delete,
+//          rol de usuario de clínica, comparación de confirmación de borrado;
+//          helpers internos privados, cero imports).
+
+export type {
+  ClinicUserRole,
+  ClinicValidationResult,
+  ClinicCreateInput,
+  ClinicUpdateInput,
+} from "./clinic-management-validation.ts";
+
+export {
+  parseClinicUserRole,
+  parseClinicCreateInput,
+  parseClinicUpdateInput,
+  parseClinicDeleteConfirmation,
+  confirmClinicNameMatches,
+} from "./clinic-management-validation.ts";

--- a/server/routes/admin-clinics.fastify.ts
+++ b/server/routes/admin-clinics.fastify.ts
@@ -24,7 +24,12 @@ import type {
   AdminClinicDeleteInput,
   AdminClinicUpdateInput,
 } from "../db-admin-clinics.ts";
-import type { ClinicUserRole } from "../../drizzle/schema.ts";
+import {
+  parseClinicCreateInput,
+  parseClinicUpdateInput,
+  parseClinicDeleteConfirmation,
+  confirmClinicNameMatches,
+} from "../features/clinics/domain/index.ts";
 
 type AdminSessionRecord = {
   id?: number;
@@ -116,22 +121,6 @@ type NativeAdminClinicsDeps = Required<
   >
 >;
 
-type ParsedCreateClinicPayload = {
-  clinicName: string;
-  contactEmail: string;
-  contactPhone: string | null;
-  username: string;
-  password: string;
-  role: ClinicUserRole;
-};
-
-type ParsedClinicUpdatePayload = {
-  clinicName?: string;
-  contactEmail?: string | null;
-  contactPhone?: string | null;
-  updatedFields: string[];
-};
-
 let defaultDepsPromise: Promise<NativeAdminClinicsDeps> | undefined;
 
 async function loadDefaultDeps(): Promise<NativeAdminClinicsDeps> {
@@ -197,18 +186,6 @@ function parsePositiveIntegerParam(value: string | undefined) {
   return parsed;
 }
 
-function parseClinicUserRole(value: unknown): ClinicUserRole | null {
-  if (value === undefined || value === null || value === "") {
-    return "clinic_owner";
-  }
-
-  if (value === "clinic_owner" || value === "clinic_staff") {
-    return value;
-  }
-
-  return null;
-}
-
 function applyCorsHeaders(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -223,275 +200,6 @@ function applyCorsHeaders(
   reply.header("vary", "Origin");
   reply.header("access-control-allow-origin", allowedOrigin);
   reply.header("access-control-allow-credentials", "true");
-}
-
-function parseRequiredString(input: {
-  value: unknown;
-  field: string;
-  label: string;
-  maxLength: number;
-}) {
-  if (typeof input.value !== "string") {
-    return {
-      ok: false as const,
-      error: `${input.label} es obligatorio.`,
-    };
-  }
-
-  const trimmed = input.value.trim();
-
-  if (!trimmed) {
-    return {
-      ok: false as const,
-      error: `${input.label} es obligatorio.`,
-    };
-  }
-
-  if (trimmed.length > input.maxLength) {
-    return {
-      ok: false as const,
-      error: `${input.label} excede ${input.maxLength} caracteres.`,
-    };
-  }
-
-  return {
-    ok: true as const,
-    value: trimmed,
-  };
-}
-
-function parseOptionalString(input: {
-  value: unknown;
-  label: string;
-  maxLength: number;
-}) {
-  if (input.value === undefined) {
-    return {
-      ok: true as const,
-      value: undefined,
-    };
-  }
-
-  if (input.value === null) {
-    return {
-      ok: true as const,
-      value: null,
-    };
-  }
-
-  if (typeof input.value !== "string") {
-    return {
-      ok: false as const,
-      error: `${input.label} debe ser texto.`,
-    };
-  }
-
-  const trimmed = input.value.trim();
-
-  if (trimmed.length > input.maxLength) {
-    return {
-      ok: false as const,
-      error: `${input.label} excede ${input.maxLength} caracteres.`,
-    };
-  }
-
-  return {
-    ok: true as const,
-    value: trimmed || null,
-  };
-}
-
-function parseOptionalRequiredString(input: {
-  value: unknown;
-  label: string;
-  maxLength: number;
-}) {
-  if (input.value === undefined) {
-    return {
-      ok: true as const,
-      value: undefined,
-    };
-  }
-
-  return parseRequiredString({
-    value: input.value,
-    field: input.label,
-    label: input.label,
-    maxLength: input.maxLength,
-  });
-}
-
-function isValidEmail(value: string) {
-  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
-}
-
-function parseCreateClinicBody(
-  body: AdminClinicCreateBody | undefined,
-):
-  | { ok: true; data: ParsedCreateClinicPayload }
-  | { ok: false; error: string } {
-  const clinicName = parseRequiredString({
-    value: body?.clinicName,
-    field: "clinicName",
-    label: "Nombre de clínica",
-    maxLength: 255,
-  });
-  const contactEmail = parseRequiredString({
-    value: body?.contactEmail,
-    field: "contactEmail",
-    label: "Email de contacto",
-    maxLength: 255,
-  });
-  const contactPhone = parseOptionalString({
-    value: body?.contactPhone,
-    label: "Teléfono de contacto",
-    maxLength: 50,
-  });
-  const username = parseRequiredString({
-    value: body?.username,
-    field: "username",
-    label: "Usuario",
-    maxLength: 100,
-  });
-
-  if (!clinicName.ok) return clinicName;
-  if (!contactEmail.ok) return contactEmail;
-  if (!contactPhone.ok) return contactPhone;
-  if (!username.ok) return username;
-
-  if (!isValidEmail(contactEmail.value)) {
-    return {
-      ok: false,
-      error: "Email de contacto inválido.",
-    };
-  }
-
-  if (username.value.length < 3) {
-    return {
-      ok: false,
-      error: "Usuario debe tener al menos 3 caracteres.",
-    };
-  }
-
-  if (
-    typeof body?.password !== "string" ||
-    body.password.length < 8 ||
-    body.password.trim().length < 8
-  ) {
-    return {
-      ok: false,
-      error: "La contraseña debe tener al menos 8 caracteres.",
-    };
-  }
-
-  const role = parseClinicUserRole(body.role);
-
-  if (!role) {
-    return {
-      ok: false,
-      error: "role inválido. Debe ser clinic_owner o clinic_staff.",
-    };
-  }
-
-  return {
-    ok: true,
-    data: {
-      clinicName: clinicName.value,
-      contactEmail: contactEmail.value,
-      contactPhone: contactPhone.value ?? null,
-      username: username.value,
-      password: body.password,
-      role,
-    },
-  };
-}
-
-function parseClinicUpdateBody(
-  body: AdminClinicUpdateBody | undefined,
-):
-  | { ok: true; data: ParsedClinicUpdatePayload }
-  | { ok: false; error: string } {
-  const clinicName = parseOptionalRequiredString({
-    value: body?.clinicName,
-    label: "Nombre de clínica",
-    maxLength: 255,
-  });
-  const contactEmail = parseOptionalString({
-    value: body?.contactEmail,
-    label: "Email de contacto",
-    maxLength: 255,
-  });
-  const contactPhone = parseOptionalString({
-    value: body?.contactPhone,
-    label: "Teléfono de contacto",
-    maxLength: 50,
-  });
-
-  if (!clinicName.ok) return clinicName;
-  if (!contactEmail.ok) return contactEmail;
-  if (!contactPhone.ok) return contactPhone;
-
-  if (
-    typeof contactEmail.value === "string" &&
-    !isValidEmail(contactEmail.value)
-  ) {
-    return {
-      ok: false,
-      error: "Email de contacto inválido.",
-    };
-  }
-
-  const updatedFields: string[] = [];
-  const data: ParsedClinicUpdatePayload = {
-    updatedFields,
-  };
-
-  if (clinicName.value !== undefined) {
-    data.clinicName = clinicName.value;
-    updatedFields.push("clinicName");
-  }
-
-  if (contactEmail.value !== undefined) {
-    data.contactEmail = contactEmail.value;
-    updatedFields.push("contactEmail");
-  }
-
-  if (contactPhone.value !== undefined) {
-    data.contactPhone = contactPhone.value;
-    updatedFields.push("contactPhone");
-  }
-
-  if (updatedFields.length === 0) {
-    return {
-      ok: false,
-      error: "Debe enviar al menos un dato de clínica para actualizar.",
-    };
-  }
-
-  return {
-    ok: true,
-    data,
-  };
-}
-
-function parseClinicDeleteBody(
-  body: AdminClinicDeleteBody | undefined,
-): { ok: true; confirmClinicName: string } | { ok: false; error: string } {
-  const confirmClinicName = parseRequiredString({
-    value: body?.confirmClinicName,
-    field: "confirmClinicName",
-    label: "Confirmación de clínica",
-    maxLength: 255,
-  });
-
-  if (!confirmClinicName.ok) {
-    return confirmClinicName;
-  }
-
-  return {
-    ok: true,
-    confirmClinicName: confirmClinicName.value,
-  };
 }
 
 function createAuditRequestLike(
@@ -718,7 +426,7 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
         return reply;
       }
 
-      const parsed = parseCreateClinicBody(request.body);
+      const parsed = parseClinicCreateInput(request.body);
 
       if (!parsed.ok) {
         return reply.code(400).send({
@@ -836,7 +544,7 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const parsed = parseClinicUpdateBody(request.body);
+    const parsed = parseClinicUpdateInput(request.body);
 
     if (!parsed.ok) {
       return reply.code(400).send({
@@ -908,7 +616,7 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const parsedDelete = parseClinicDeleteBody(request.body);
+    const parsedDelete = parseClinicDeleteConfirmation(request.body);
 
     if (!parsedDelete.ok) {
       return reply.code(400).send({
@@ -926,7 +634,7 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    if (parsedDelete.confirmClinicName !== clinic.clinicName) {
+    if (!confirmClinicNameMatches(parsedDelete.confirmClinicName, clinic.clinicName)) {
       return reply.code(400).send({
         success: false,
         error:

--- a/test/architecture/clinics-domain-boundary-guard.test.ts
+++ b/test/architecture/clinics-domain-boundary-guard.test.ts
@@ -1,0 +1,528 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+
+const repoRoot = process.cwd();
+
+const featureDir = "server/features/clinics";
+const domainDir = `${featureDir}/domain`;
+const domainIndexFile = `${domainDir}/index.ts`;
+const canonicalModuleFile = `${domainDir}/clinic-management-validation.ts`;
+const applicationDir = `${featureDir}/application`;
+
+// Ruta admin que consume el dominio (único consumidor runtime en M25).
+const routeConsumerFile = "server/routes/admin-clinics.fastify.ts";
+
+// Las 8 funciones extraídas del inline de la ruta hacia el dominio. El guard
+// verifica que no vuelvan a definirse dentro de la ruta.
+const MIGRATED_FUNCTION_NAMES = [
+  "parseClinicUserRole",
+  "parseRequiredString",
+  "parseOptionalString",
+  "parseOptionalRequiredString",
+  "isValidEmail",
+  "parseCreateClinicBody",
+  "parseClinicUpdateBody",
+  "parseClinicDeleteBody",
+];
+
+function readText(relativePath: string) {
+  return readFileSync(join(repoRoot, relativePath), "utf8").replace(/\r\n/g, "\n");
+}
+
+function walkFiles(relativeDir: string, extension = ".ts"): string[] {
+  const absoluteDir = join(repoRoot, relativeDir);
+
+  if (!existsSync(absoluteDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const relativePath = `${relativeDir}/${entry.name}`;
+
+    if (entry.isDirectory()) {
+      files.push(...walkFiles(relativePath, extension));
+      continue;
+    }
+
+    if (entry.isFile() && entry.name.endsWith(extension)) {
+      files.push(relativePath);
+    }
+  }
+
+  return files;
+}
+
+// Parser robusto de imports: cubre `import ... from`, `require(...)`,
+// `import(...)` dinámico, `import "..."` de efecto lateral y `export ... from`.
+// Al operar sobre specifiers cubre también los imports `import type`, de modo
+// que la prohibición de drizzle aplica incluso type-only.
+function listImportSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\brequire\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s*\(\s*["']([^"']+)["']\s*\)|\bimport\s+["']([^"']+)["']/g,
+    ),
+    (match) => match[1] ?? match[2] ?? match[3] ?? match[4] ?? "",
+  );
+}
+
+function toRepoRelativePath(path: string) {
+  return path.replaceAll("\\", "/");
+}
+
+function resolveRelativeTsSpecifier(file: string, specifier: string) {
+  const resolvedPath = toRepoRelativePath(
+    relative(repoRoot, join(repoRoot, dirname(file), specifier)),
+  );
+
+  if (resolvedPath.endsWith(".ts")) {
+    return resolvedPath;
+  }
+
+  const tsFilePath = `${resolvedPath}.ts`;
+  if (existsSync(join(repoRoot, tsFilePath))) {
+    return tsFilePath;
+  }
+
+  const indexFilePath = `${resolvedPath}/index.ts`;
+  if (existsSync(join(repoRoot, indexFilePath))) {
+    return indexFilePath;
+  }
+
+  return resolvedPath;
+}
+
+function resolveSpecifier(file: string, specifier: string) {
+  return specifier.startsWith(".")
+    ? resolveRelativeTsSpecifier(file, specifier)
+    : toRepoRelativePath(specifier);
+}
+
+// Elimina comentarios de línea/bloque y literales de string/template para que la
+// detección de redefiniciones no dispare falsos positivos sobre texto que
+// menciona un nombre sin declararlo. Es una aproximación léxica (no un parser
+// completo) pero cubre las formas relevantes de la ruta.
+function stripCommentsAndStrings(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ") // comentarios de bloque
+    .replace(/\/\/[^\n]*/g, " ") // comentarios de línea
+    .replace(/`(?:\\[\s\S]|[^\\`])*`/g, " ") // template literals
+    .replace(/"(?:\\.|[^"\\])*"/g, " ") // strings dobles
+    .replace(/'(?:\\.|[^'\\])*'/g, " "); // strings simples
+}
+
+// Detecta si `name` se *redefine* (declara) en el código, cubriendo:
+//   function name(...)            async function name(...)
+//   const name = (...) =>         const name = function (...)
+//   const name: Tipo = (...) =>   let/var name = (...) =>
+// Ignora imports, llamadas, propiedades de objeto y menciones en
+// strings/comentarios (removidos previamente).
+function definesSymbolInline(rawSource: string, name: string): boolean {
+  const source = stripCommentsAndStrings(rawSource);
+  const escaped = name.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+  // Declaración de función (con o sin async).
+  const functionDeclaration = new RegExp(
+    `(^|[^.\\w])(?:async\\s+)?function\\s+${escaped}\\s*\\(`,
+  );
+
+  // Binding const/let/var con inicializador de función:
+  //   name [: Tipo] = (async)? (...) =>   |   = (async)? function
+  const boundInitializer = new RegExp(
+    `(^|[^.\\w])(?:const|let|var)\\s+${escaped}\\s*(?::[^=;]+)?=\\s*(?:async\\s+)?(?:function\\b|\\([^)]*\\)\\s*(?::[^=>{;]+)?=>|[A-Za-z_$][\\w$]*\\s*=>)`,
+  );
+
+  return functionDeclaration.test(source) || boundInitializer.test(source);
+}
+
+// Reglas de frontera de la capa domain (ADR ARCH-2). El dominio Clinics es
+// autónomo: define su propio `ClinicUserRole` y no importa el shared kernel de
+// Drizzle ni siquiera como tipos (corrección aprobada en M25).
+const FORBIDDEN_SPECIFIER_RULES: Array<{ label: string; pattern: RegExp }> = [
+  {
+    label: "import de fastify",
+    pattern: /^fastify(\/|$)/,
+  },
+  {
+    label: "import de drizzle (schema u ORM), incluso type-only",
+    pattern: /(^|\/)drizzle(-orm)?(\/|$)/i,
+  },
+  {
+    label: "import de persistencia (server/db o db-*)",
+    pattern: /(^|\/)(db|database)([./-][\w-]*)?$/i,
+  },
+  {
+    label: "import directo de configuración de entorno (lib/env)",
+    pattern: /(^|\/)env(\.ts)?$/i,
+  },
+  {
+    label: "import hacia la capa infrastructure del propio contexto",
+    pattern: /(^|\/)infrastructure(\/|$)/,
+  },
+  {
+    label: "import hacia la capa application del propio contexto",
+    pattern: /(^|\/)application(\/|$)/,
+  },
+  {
+    label: "import hacia la capa routes del propio contexto",
+    pattern: /(^|\/)routes(\/|$)/,
+  },
+  {
+    label: "import hacia middlewares",
+    pattern: /(^|\/)middlewares?(\/|$)/i,
+  },
+  {
+    label: "import de auth/middleware",
+    pattern: /(^|\/)auth([-./]|$)/i,
+  },
+  {
+    label: "import relacionado con CORS",
+    pattern: /cors/i,
+  },
+  {
+    label: "import de cliente supabase",
+    pattern: /supabase/i,
+  },
+  {
+    label: "import de node:process",
+    pattern: /^(node:)?process(\/|$)/,
+  },
+  {
+    label: "import de módulos node de I/O (fs/http/https/net/child_process)",
+    pattern: /^(node:)?(fs|http|https|net|child_process)(\/|$)/,
+  },
+];
+
+const FORBIDDEN_SOURCE_PATTERNS: Array<{ label: string; pattern: RegExp }> = [
+  {
+    label: "acceso directo a process.* (env, cwd, exit, etc.)",
+    pattern: /\bprocess\.\w+/,
+  },
+  {
+    label: "I/O de red explícito (fetch)",
+    pattern: /\bfetch\s*\(/,
+  },
+  {
+    label: "acoplamiento a transporte Fastify (FastifyRequest)",
+    pattern: /\bFastifyRequest\b/,
+  },
+  {
+    label: "acoplamiento a transporte Fastify (FastifyReply)",
+    pattern: /\bFastifyReply\b/,
+  },
+  {
+    label: "referencia a request/reply de transporte",
+    pattern: /\b(request|reply)\b/,
+  },
+  {
+    label: "referencia a SQL crudo",
+    pattern: /\bsql`|\bSQL\b/,
+  },
+  {
+    label: "referencia a transacciones de persistencia",
+    pattern: /\btransaction\b/i,
+  },
+  {
+    label: "status codes HTTP en el dominio",
+    pattern: /\b(200|201|204|400|401|403|404|409|500)\b/,
+  },
+];
+
+// 1 + 2 + 3
+test("Clinics domain existe, contiene el módulo canónico y el barrel, con código real", () => {
+  assert.equal(
+    existsSync(join(repoRoot, domainDir)),
+    true,
+    `${domainDir} debe existir`,
+  );
+
+  assert.equal(
+    existsSync(join(repoRoot, domainIndexFile)),
+    true,
+    `${domainIndexFile} debe existir`,
+  );
+
+  assert.equal(
+    existsSync(join(repoRoot, canonicalModuleFile)),
+    true,
+    `${canonicalModuleFile} debe existir`,
+  );
+
+  const canonicalSource = readText(canonicalModuleFile);
+
+  assert.ok(
+    canonicalSource.length > 500,
+    "el módulo canónico debe contener código real, no un stub",
+  );
+
+  const sanitized = stripCommentsAndStrings(canonicalSource);
+
+  // Exports de tipo: `export type Nombre =` o `export interface Nombre`.
+  for (const typeExport of [
+    "ClinicUserRole",
+    "ClinicValidationResult",
+    "ClinicCreateInput",
+    "ClinicUpdateInput",
+  ]) {
+    const escaped = typeExport.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const typeExportPattern = new RegExp(
+      `\\bexport\\s+(?:type\\s+${escaped}\\s*(?:<[^=]*>)?\\s*=|interface\\s+${escaped}\\b)`,
+    );
+    assert.ok(
+      typeExportPattern.test(sanitized),
+      `el módulo canónico debe exportar el tipo ${typeExport}`,
+    );
+  }
+
+  // Exports runtime: `export function Nombre(` (con o sin async).
+  for (const runtimeExport of [
+    "parseClinicUserRole",
+    "parseClinicCreateInput",
+    "parseClinicUpdateInput",
+    "parseClinicDeleteConfirmation",
+    "confirmClinicNameMatches",
+  ]) {
+    const escaped = runtimeExport.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+    const runtimeExportPattern = new RegExp(
+      `\\bexport\\s+(?:async\\s+)?function\\s+${escaped}\\s*\\(`,
+    );
+    assert.ok(
+      runtimeExportPattern.test(sanitized),
+      `el módulo canónico debe exportar la función runtime ${runtimeExport}`,
+    );
+  }
+});
+
+// 4 (negativo): pureza del dominio por censo de imports resueltos
+test("Clinics domain permanece puro: sin fastify/drizzle/db/env/infra/application/routes/middlewares/auth/cors/supabase/fs/http/net/process", () => {
+  const violations: string[] = [];
+
+  for (const file of walkFiles(domainDir)) {
+    const content = readText(file);
+    const specifiers = listImportSpecifiers(content);
+
+    for (const specifier of specifiers) {
+      for (const { label, pattern } of FORBIDDEN_SPECIFIER_RULES) {
+        if (pattern.test(specifier)) {
+          violations.push(`${file}: ${label} ("${specifier}")`);
+        }
+      }
+
+      // Ningún import a otros módulos de `server/lib/**` ni a `server/db*`.
+      const resolved = resolveSpecifier(file, specifier);
+      if (resolved.startsWith("server/lib/")) {
+        violations.push(
+          `${file}: import a server/lib/** desde el dominio puro ("${specifier}" -> ${resolved})`,
+        );
+      }
+      if (/^server\/db(\.ts|-)/.test(resolved)) {
+        violations.push(
+          `${file}: import a persistencia desde el dominio puro ("${specifier}" -> ${resolved})`,
+        );
+      }
+    }
+
+    for (const { label, pattern } of FORBIDDEN_SOURCE_PATTERNS) {
+      if (pattern.test(content)) {
+        violations.push(`${file}: ${label}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 4 (positivo): el dominio sólo importa dependencias relativas internas
+test("Clinics domain sólo importa dependencias relativas internas del propio contexto", () => {
+  const violations: string[] = [];
+
+  for (const file of walkFiles(domainDir)) {
+    const content = readText(file);
+
+    for (const specifier of listImportSpecifiers(content)) {
+      const isRelativeImport = specifier.startsWith(".");
+
+      if (!isRelativeImport) {
+        violations.push(
+          `${file}: import no permitido en domain puro ("${specifier}")`,
+        );
+        continue;
+      }
+
+      const resolved = resolveSpecifier(file, specifier);
+      if (!resolved.startsWith(`${domainDir}/`)) {
+        violations.push(
+          `${file}: import relativo fuera del dominio ("${specifier}" -> ${resolved})`,
+        );
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 5
+test("El módulo canónico de validaciones tiene cero imports", () => {
+  const specifiers = listImportSpecifiers(readText(canonicalModuleFile));
+
+  assert.deepEqual(
+    specifiers,
+    [],
+    `${canonicalModuleFile} debe ser 100% puro (cero imports)`,
+  );
+});
+
+// 6
+test("El barrel de dominio re-exporta el módulo canónico", () => {
+  const barrelSource = readText(domainIndexFile);
+  const resolvedTargets = listImportSpecifiers(barrelSource).map((specifier) =>
+    resolveSpecifier(domainIndexFile, specifier),
+  );
+
+  assert.ok(
+    resolvedTargets.includes(canonicalModuleFile),
+    `${domainIndexFile} debe re-exportar ${canonicalModuleFile}`,
+  );
+
+  for (const publicExport of [
+    "parseClinicUserRole",
+    "parseClinicCreateInput",
+    "parseClinicUpdateInput",
+    "parseClinicDeleteConfirmation",
+    "confirmClinicNameMatches",
+  ]) {
+    assert.ok(
+      barrelSource.includes(publicExport),
+      `el barrel debe exportar ${publicExport}`,
+    );
+  }
+});
+
+// 7
+test("La ruta admin importa el dominio por el barrel, no el archivo interno", () => {
+  const resolvedTargets = listImportSpecifiers(readText(routeConsumerFile)).map(
+    (specifier) => resolveSpecifier(routeConsumerFile, specifier),
+  );
+
+  assert.ok(
+    resolvedTargets.includes(domainIndexFile),
+    `${routeConsumerFile} debe importar ${domainIndexFile}`,
+  );
+
+  assert.ok(
+    !resolvedTargets.includes(canonicalModuleFile),
+    `${routeConsumerFile} no debe importar el archivo interno del dominio`,
+  );
+});
+
+// 7 (global): ningún consumidor runtime importa el archivo interno del dominio
+test("Ningún runtime de server/** importa el archivo interno del dominio (sólo barrel)", () => {
+  const violations: string[] = [];
+  const runtimeFiles = walkFiles("server").filter(
+    (file) => !file.startsWith(`${domainDir}/`),
+  );
+
+  for (const file of runtimeFiles) {
+    for (const specifier of listImportSpecifiers(readText(file))) {
+      const resolved = resolveSpecifier(file, specifier);
+
+      const importsDomainInternalFile =
+        resolved.startsWith(`${domainDir}/`) &&
+        resolved.endsWith(".ts") &&
+        resolved !== domainIndexFile;
+
+      if (importsDomainInternalFile) {
+        violations.push(
+          `${file}: import directo a archivo interno del dominio ("${specifier}" -> ${resolved})`,
+        );
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 8
+test("Las 8 funciones migradas no vuelven a definirse inline en la ruta admin", () => {
+  const routeSource = readText(routeConsumerFile);
+  const violations: string[] = [];
+
+  for (const fnName of MIGRATED_FUNCTION_NAMES) {
+    if (definesSymbolInline(routeSource, fnName)) {
+      violations.push(`${routeConsumerFile}: redefine inline ${fnName}`);
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+// 8 (caracterización): el detector reconoce todas las formas de declaración y
+// no dispara sobre llamadas ni imports.
+test("definesSymbolInline detecta todas las formas de redefinición y evita falsos positivos", () => {
+  // 1 · function declaration
+  assert.equal(
+    definesSymbolInline("function parseRequiredString(input) { return input; }", "parseRequiredString"),
+    true,
+  );
+  // 2 · async function declaration
+  assert.equal(
+    definesSymbolInline("async function parseRequiredString(input) { return input; }", "parseRequiredString"),
+    true,
+  );
+  // 3 · const arrow
+  assert.equal(
+    definesSymbolInline("const parseRequiredString = (input) => input;", "parseRequiredString"),
+    true,
+  );
+  // 4 · const function expression
+  assert.equal(
+    definesSymbolInline("const parseRequiredString = function (input) { return input; };", "parseRequiredString"),
+    true,
+  );
+  // 5 · declaración tipada
+  assert.equal(
+    definesSymbolInline("const parseRequiredString: Parser = (input) => input;", "parseRequiredString"),
+    true,
+  );
+  // 6 · let / var
+  assert.equal(
+    definesSymbolInline("let parseRequiredString = (input) => input;", "parseRequiredString"),
+    true,
+  );
+  assert.equal(
+    definesSymbolInline("var parseRequiredString = function (input) { return input; };", "parseRequiredString"),
+    true,
+  );
+  // 7 · llamada legítima → no es redefinición
+  assert.equal(
+    definesSymbolInline("const parsed = parseRequiredString(request.body);", "parseRequiredString"),
+    false,
+  );
+  // 8 · import del símbolo → no es redefinición
+  assert.equal(
+    definesSymbolInline('import { parseRequiredString } from "../features/clinics/domain/index.ts";', "parseRequiredString"),
+    false,
+  );
+  // extra · mención sólo en comentario o string → no es redefinición
+  assert.equal(
+    definesSymbolInline("// function parseRequiredString(x) {}\nconst s = 'function parseRequiredString(x) {}';", "parseRequiredString"),
+    false,
+  );
+  // extra · propiedad de objeto homónima → no es redefinición
+  assert.equal(
+    definesSymbolInline("const deps = { parseRequiredString: other };", "parseRequiredString"),
+    false,
+  );
+});
+
+// 9
+test("No existe una capa application anticipada en el contexto Clinics", () => {
+  assert.equal(
+    existsSync(join(repoRoot, applicationDir)),
+    false,
+    `${applicationDir} no debe existir en M25 (application diferido)`,
+  );
+});

--- a/test/unit/domain/clinics/clinic-management-validation.test.ts
+++ b/test/unit/domain/clinics/clinic-management-validation.test.ts
@@ -1,0 +1,558 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseClinicUserRole,
+  parseClinicCreateInput,
+  parseClinicUpdateInput,
+  parseClinicDeleteConfirmation,
+  confirmClinicNameMatches,
+} from "../../../../server/features/clinics/domain/index.ts";
+
+// Fixture base válido para create. Cada test lo clona y muta un solo campo.
+function validCreateBody() {
+  return {
+    clinicName: "Clínica Demo",
+    contactEmail: "demo@clinic.test",
+    contactPhone: "1144556677",
+    username: "clinic-owner",
+    password: "claveSegura1",
+    role: "clinic_owner",
+  } as Record<string, unknown>;
+}
+
+/* ==========================================================================
+ * parseClinicUserRole
+ * ======================================================================== */
+
+test("parseClinicUserRole: undefined/null/'' → clinic_owner (default)", () => {
+  assert.equal(parseClinicUserRole(undefined), "clinic_owner");
+  assert.equal(parseClinicUserRole(null), "clinic_owner");
+  assert.equal(parseClinicUserRole(""), "clinic_owner");
+});
+
+test("parseClinicUserRole: valores válidos se preservan", () => {
+  assert.equal(parseClinicUserRole("clinic_owner"), "clinic_owner");
+  assert.equal(parseClinicUserRole("clinic_staff"), "clinic_staff");
+});
+
+test("parseClinicUserRole: valor inválido → null", () => {
+  assert.equal(parseClinicUserRole("admin"), null);
+  assert.equal(parseClinicUserRole("CLINIC_OWNER"), null);
+  assert.equal(parseClinicUserRole(123), null);
+  assert.equal(parseClinicUserRole({}), null);
+});
+
+/* ==========================================================================
+ * parseClinicCreateInput — camino feliz + normalización
+ * ======================================================================== */
+
+test("CREATE válido completo devuelve data normalizada", () => {
+  const result = parseClinicCreateInput(validCreateBody());
+  assert.equal(result.ok, true);
+  assert.ok(result.ok);
+  assert.deepEqual(result.data, {
+    clinicName: "Clínica Demo",
+    contactEmail: "demo@clinic.test",
+    contactPhone: "1144556677",
+    username: "clinic-owner",
+    password: "claveSegura1",
+    role: "clinic_owner",
+  });
+});
+
+test("CREATE aplica trim a clinicName, contactEmail, contactPhone y username", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "  Clínica Demo  ",
+    contactEmail: "  demo@clinic.test  ",
+    contactPhone: "  1144556677  ",
+    username: "  clinic-owner  ",
+    password: "claveSegura1",
+    role: "clinic_owner",
+  });
+  assert.ok(result.ok);
+  assert.equal(result.data.clinicName, "Clínica Demo");
+  assert.equal(result.data.contactEmail, "demo@clinic.test");
+  assert.equal(result.data.contactPhone, "1144556677");
+  assert.equal(result.data.username, "clinic-owner");
+});
+
+test("CREATE contactPhone omitido → null", () => {
+  const body = validCreateBody();
+  delete body.contactPhone;
+  const result = parseClinicCreateInput(body);
+  assert.ok(result.ok);
+  assert.equal(result.data.contactPhone, null);
+});
+
+test("CREATE contactPhone null → null", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactPhone: null });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactPhone, null);
+});
+
+test("CREATE contactPhone vacío/whitespace → null", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactPhone: "   " });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactPhone, null);
+});
+
+test("CREATE role omitido → clinic_owner", () => {
+  const body = validCreateBody();
+  delete body.role;
+  const result = parseClinicCreateInput(body);
+  assert.ok(result.ok);
+  assert.equal(result.data.role, "clinic_owner");
+});
+
+test("CREATE role null → clinic_owner", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), role: null });
+  assert.ok(result.ok);
+  assert.equal(result.data.role, "clinic_owner");
+});
+
+test("CREATE role '' → clinic_owner", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), role: "" });
+  assert.ok(result.ok);
+  assert.equal(result.data.role, "clinic_owner");
+});
+
+test("CREATE ambos roles válidos", () => {
+  const owner = parseClinicCreateInput({ ...validCreateBody(), role: "clinic_owner" });
+  const staff = parseClinicCreateInput({ ...validCreateBody(), role: "clinic_staff" });
+  assert.ok(owner.ok);
+  assert.ok(staff.ok);
+  assert.equal(owner.data.role, "clinic_owner");
+  assert.equal(staff.data.role, "clinic_staff");
+});
+
+test("CREATE role inválido → error exacto", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), role: "superadmin" });
+  assert.equal(result.ok, false);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "role inválido. Debe ser clinic_owner o clinic_staff.");
+});
+
+test("CREATE password raw se preserva sin trim", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), password: "  claveSegura1  " });
+  assert.ok(result.ok);
+  assert.equal(result.data.password, "  claveSegura1  ");
+});
+
+/* ==========================================================================
+ * parseClinicCreateInput — required ausentes / tipo inválido / vacío / máximos
+ * ======================================================================== */
+
+test("CREATE clinicName ausente → obligatorio", () => {
+  const body = validCreateBody();
+  delete body.clinicName;
+  const result = parseClinicCreateInput(body);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("CREATE clinicName tipo inválido → obligatorio", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), clinicName: 123 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("CREATE clinicName vacío → obligatorio", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), clinicName: "   " });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("CREATE clinicName excede 255 → error de longitud", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), clinicName: "a".repeat(256) });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica excede 255 caracteres.");
+});
+
+test("CREATE clinicName exactamente 255 es válido", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), clinicName: "a".repeat(255) });
+  assert.ok(result.ok);
+  assert.equal(result.data.clinicName.length, 255);
+});
+
+test("CREATE contactEmail ausente → obligatorio", () => {
+  const body = validCreateBody();
+  delete body.contactEmail;
+  const result = parseClinicCreateInput(body);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto es obligatorio.");
+});
+
+test("CREATE contactEmail tipo inválido → obligatorio", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactEmail: 42 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto es obligatorio.");
+});
+
+test("CREATE contactEmail excede 255 → error de longitud (antes que formato)", () => {
+  const longEmail = `${"a".repeat(256)}@x.io`; // 261 chars
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactEmail: longEmail });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto excede 255 caracteres.");
+});
+
+test("CREATE contactEmail inválido → formato", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactEmail: "no-es-email" });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto inválido.");
+});
+
+test("CREATE contactPhone tipo inválido → debe ser texto", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactPhone: 123 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Teléfono de contacto debe ser texto.");
+});
+
+test("CREATE contactPhone excede 50 → error de longitud", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), contactPhone: "9".repeat(51) });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Teléfono de contacto excede 50 caracteres.");
+});
+
+test("CREATE username ausente → obligatorio", () => {
+  const body = validCreateBody();
+  delete body.username;
+  const result = parseClinicCreateInput(body);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Usuario es obligatorio.");
+});
+
+test("CREATE username vacío → obligatorio", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), username: "  " });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Usuario es obligatorio.");
+});
+
+test("CREATE username excede 100 → error de longitud", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), username: "u".repeat(101) });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Usuario excede 100 caracteres.");
+});
+
+test("CREATE username menor a 3 → mínimo", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), username: "ab" });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Usuario debe tener al menos 3 caracteres.");
+});
+
+test("CREATE password ausente/no string → mínimo 8", () => {
+  const body = validCreateBody();
+  delete body.password;
+  const result = parseClinicCreateInput(body);
+  assert.ok(!result.ok);
+  assert.equal(result.error, "La contraseña debe tener al menos 8 caracteres.");
+});
+
+test("CREATE password menor a 8 raw → error", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), password: "abc123" });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "La contraseña debe tener al menos 8 caracteres.");
+});
+
+test("CREATE password con 8 raw pero <8 tras trim → error", () => {
+  const result = parseClinicCreateInput({ ...validCreateBody(), password: "  abcd  " });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "La contraseña debe tener al menos 8 caracteres.");
+});
+
+/* ==========================================================================
+ * parseClinicCreateInput — precedencia con múltiples errores
+ * ======================================================================== */
+
+test("CREATE precedencia: clinicName gana sobre email/username/password", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "",
+    contactEmail: "malo",
+    username: "a",
+    password: "x",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("CREATE precedencia: contactEmail (obligatorio) gana sobre username/password", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "Clínica Demo",
+    contactEmail: "",
+    username: "a",
+    password: "x",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto es obligatorio.");
+});
+
+test("CREATE precedencia: contactPhone inválido gana sobre username", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "Clínica Demo",
+    contactEmail: "demo@clinic.test",
+    contactPhone: 999,
+    username: "a",
+    password: "x",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Teléfono de contacto debe ser texto.");
+});
+
+test("CREATE precedencia: username (obligatorio) gana sobre formato email y password", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "Clínica Demo",
+    contactEmail: "malo",
+    username: "",
+    password: "x",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Usuario es obligatorio.");
+});
+
+test("CREATE precedencia: formato email gana sobre username-min y password", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "Clínica Demo",
+    contactEmail: "malo",
+    username: "ab",
+    password: "x",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto inválido.");
+});
+
+test("CREATE precedencia: username-min gana sobre password", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "Clínica Demo",
+    contactEmail: "demo@clinic.test",
+    username: "ab",
+    password: "x",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Usuario debe tener al menos 3 caracteres.");
+});
+
+test("CREATE precedencia: password gana sobre role inválido", () => {
+  const result = parseClinicCreateInput({
+    clinicName: "Clínica Demo",
+    contactEmail: "demo@clinic.test",
+    username: "clinic-owner",
+    password: "x",
+    role: "superadmin",
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "La contraseña debe tener al menos 8 caracteres.");
+});
+
+/* ==========================================================================
+ * parseClinicUpdateInput
+ * ======================================================================== */
+
+test("UPDATE completo devuelve data normalizada y updatedFields ordenado", () => {
+  const result = parseClinicUpdateInput({
+    clinicName: "  Clínica Nueva  ",
+    contactEmail: "  nueva@clinic.test  ",
+    contactPhone: "  555  ",
+  });
+  assert.ok(result.ok);
+  assert.equal(result.data.clinicName, "Clínica Nueva");
+  assert.equal(result.data.contactEmail, "nueva@clinic.test");
+  assert.equal(result.data.contactPhone, "555");
+  assert.deepEqual(result.data.updatedFields, [
+    "clinicName",
+    "contactEmail",
+    "contactPhone",
+  ]);
+});
+
+test("UPDATE clinicName individual", () => {
+  const result = parseClinicUpdateInput({ clinicName: "Solo Nombre" });
+  assert.ok(result.ok);
+  assert.equal(result.data.clinicName, "Solo Nombre");
+  assert.deepEqual(result.data.updatedFields, ["clinicName"]);
+  assert.equal("contactEmail" in result.data, false);
+  assert.equal("contactPhone" in result.data, false);
+});
+
+test("UPDATE contactEmail individual", () => {
+  const result = parseClinicUpdateInput({ contactEmail: "x@y.io" });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactEmail, "x@y.io");
+  assert.deepEqual(result.data.updatedFields, ["contactEmail"]);
+});
+
+test("UPDATE contactPhone individual", () => {
+  const result = parseClinicUpdateInput({ contactPhone: "123" });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactPhone, "123");
+  assert.deepEqual(result.data.updatedFields, ["contactPhone"]);
+});
+
+test("UPDATE clinicName vacío → error (no se puede vaciar)", () => {
+  const result = parseClinicUpdateInput({ clinicName: "   " });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("UPDATE clinicName tipo inválido → error", () => {
+  const result = parseClinicUpdateInput({ clinicName: 5 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("UPDATE clinicName excede 255 → error de longitud", () => {
+  const result = parseClinicUpdateInput({ clinicName: "a".repeat(256) });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica excede 255 caracteres.");
+});
+
+test("UPDATE contactEmail vacío → null y se incluye en updatedFields", () => {
+  const result = parseClinicUpdateInput({ contactEmail: "" });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactEmail, null);
+  assert.deepEqual(result.data.updatedFields, ["contactEmail"]);
+});
+
+test("UPDATE contactEmail whitespace → null", () => {
+  const result = parseClinicUpdateInput({ contactEmail: "   " });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactEmail, null);
+});
+
+test("UPDATE contactEmail null → null", () => {
+  const result = parseClinicUpdateInput({ contactEmail: null });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactEmail, null);
+  assert.deepEqual(result.data.updatedFields, ["contactEmail"]);
+});
+
+test("UPDATE contactEmail inválido (string no vacío) → formato", () => {
+  const result = parseClinicUpdateInput({ contactEmail: "malo" });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto inválido.");
+});
+
+test("UPDATE contactEmail tipo inválido → debe ser texto", () => {
+  const result = parseClinicUpdateInput({ contactEmail: 10 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto debe ser texto.");
+});
+
+test("UPDATE contactEmail excede 255 → error de longitud", () => {
+  const result = parseClinicUpdateInput({ contactEmail: `${"a".repeat(256)}@x.io` });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto excede 255 caracteres.");
+});
+
+test("UPDATE contactPhone vacío → null", () => {
+  const result = parseClinicUpdateInput({ contactPhone: "" });
+  assert.ok(result.ok);
+  assert.equal(result.data.contactPhone, null);
+  assert.deepEqual(result.data.updatedFields, ["contactPhone"]);
+});
+
+test("UPDATE contactPhone tipo inválido → debe ser texto", () => {
+  const result = parseClinicUpdateInput({ contactPhone: 5 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Teléfono de contacto debe ser texto.");
+});
+
+test("UPDATE contactPhone excede 50 → error de longitud", () => {
+  const result = parseClinicUpdateInput({ contactPhone: "9".repeat(51) });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Teléfono de contacto excede 50 caracteres.");
+});
+
+test("UPDATE sin campos → error de body vacío", () => {
+  const result = parseClinicUpdateInput({});
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Debe enviar al menos un dato de clínica para actualizar.");
+});
+
+test("UPDATE con todos los campos undefined → error de body vacío", () => {
+  const result = parseClinicUpdateInput({
+    clinicName: undefined,
+    contactEmail: undefined,
+    contactPhone: undefined,
+  });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Debe enviar al menos un dato de clínica para actualizar.");
+});
+
+test("UPDATE precedencia: clinicName gana sobre email inválido", () => {
+  const result = parseClinicUpdateInput({ clinicName: "", contactEmail: "malo" });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Nombre de clínica es obligatorio.");
+});
+
+test("UPDATE precedencia: contactEmail-tipo gana sobre contactPhone-tipo", () => {
+  const result = parseClinicUpdateInput({ contactEmail: 1, contactPhone: 2 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto debe ser texto.");
+});
+
+test("UPDATE precedencia: validación de tipo/formato gana sobre body-vacío", () => {
+  const result = parseClinicUpdateInput({ contactEmail: "malo" });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Email de contacto inválido.");
+});
+
+/* ==========================================================================
+ * parseClinicDeleteConfirmation
+ * ======================================================================== */
+
+test("DELETE confirmClinicName válido", () => {
+  const result = parseClinicDeleteConfirmation({ confirmClinicName: "Clínica Demo" });
+  assert.ok(result.ok);
+  assert.equal(result.confirmClinicName, "Clínica Demo");
+});
+
+test("DELETE confirmClinicName aplica trim", () => {
+  const result = parseClinicDeleteConfirmation({ confirmClinicName: "  Clínica Demo  " });
+  assert.ok(result.ok);
+  assert.equal(result.confirmClinicName, "Clínica Demo");
+});
+
+test("DELETE confirmClinicName ausente → obligatorio", () => {
+  const result = parseClinicDeleteConfirmation({});
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Confirmación de clínica es obligatorio.");
+});
+
+test("DELETE confirmClinicName no string → obligatorio", () => {
+  const result = parseClinicDeleteConfirmation({ confirmClinicName: 123 });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Confirmación de clínica es obligatorio.");
+});
+
+test("DELETE confirmClinicName vacío → obligatorio", () => {
+  const result = parseClinicDeleteConfirmation({ confirmClinicName: "   " });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Confirmación de clínica es obligatorio.");
+});
+
+test("DELETE confirmClinicName excede 255 → error de longitud", () => {
+  const result = parseClinicDeleteConfirmation({ confirmClinicName: "a".repeat(256) });
+  assert.ok(!result.ok);
+  assert.equal(result.error, "Confirmación de clínica excede 255 caracteres.");
+});
+
+/* ==========================================================================
+ * confirmClinicNameMatches
+ * ======================================================================== */
+
+test("confirmClinicNameMatches: match exacto → true", () => {
+  assert.equal(confirmClinicNameMatches("Clínica Demo", "Clínica Demo"), true);
+});
+
+test("confirmClinicNameMatches: mismatch por casing → false", () => {
+  assert.equal(confirmClinicNameMatches("clínica demo", "Clínica Demo"), false);
+});
+
+test("confirmClinicNameMatches: mismatch por espacio en el nombre real → false", () => {
+  assert.equal(confirmClinicNameMatches("Clínica Demo", "Clínica Demo "), false);
+});
+
+test("confirmClinicNameMatches: es case-sensitive y sin normalización adicional", () => {
+  assert.equal(confirmClinicNameMatches("ABC", "abc"), false);
+  assert.equal(confirmClinicNameMatches("ABC", "ABC"), true);
+});


### PR DESCRIPTION
## Summary

M25 establishes the pure `server/features/clinics/domain` boundary and extracts
the real administrative create, update and delete validation rules from
`server/routes/admin-clinics.fastify.ts`.

The domain defines `ClinicUserRole` autonomously and does not import Fastify,
Drizzle, persistence, configuration, transport or infrastructure.

HTTP contracts, messages, validation precedence, normalization, auditing,
CORS, authentication, trusted-origin enforcement, error mapping, transactions
and SQL behavior remain unchanged.

## Scope

- [x] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [ ] Scripts/tooling
- [ ] Repository configuration
- [ ] Other
- [ ] Mixed-scope exception

Tests and documentation are supporting changes for the single primary backend
runtime scope. M25 does not change frontend source, dependencies, workflows,
migrations, schema or repository configuration.

## Validation

- Clinics directed suite: PASS.
- `pnpm install --frozen-lockfile`: PASS.
- Resolved framework version inherited from main: Next.js 16.2.11.
- `pnpm audit --prod`: PASS.
- `pnpm audit`: PASS.
- `pnpm typecheck`: PASS.
- `pnpm typecheck:test`: PASS.
- `pnpm validate:local`: PASS.
- Complete backend test suite: PASS.
- Backend build: PASS.
- `pnpm security:public-surface`: PASS.
- `git diff --check`: PASS.
- Exact M25 allowlist: 9 files.
- Working tree clean after rebase and validation.
- No persistence, frontend, migration, dependency, CI or lockfile changes in
  the M25 diff.

Security prerequisite #1530 was merged into `main` before this branch was
rebased. M25 now inherits the patched Next.js 16.2.11 lockfile without adding
dependency files to its own pull-request diff.

## Rollback

Revert the M25 commit to restore the original inline validations in the
administrative route. The domain addition is additive and there are no schema,
migration, persistence, dependency or HTTP contract changes, so rollback is
independent and requires no data operation.