### PR TITLE
chore(dependabot): remove duplicate frontend ecosystem

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,14 +8,6 @@ updates:
     labels:
       - dependencies
 
-  - package-ecosystem: npm
-    directory: /frontend
-    schedule:
-      interval: weekly
-    open-pull-requests-limit: 10
-    labels:
-      - dependencies
-
   - package-ecosystem: github-actions
     directory: /
     schedule:


### PR DESCRIPTION
## Summary

Removes the duplicated Dependabot npm ecosystem configured for `/frontend`.

The repository uses a PNPM workspace with a single root `pnpm-lock.yaml`. The
root npm ecosystem already discovers dependencies declared by
`frontend/package.json` and updates the manifest and lockfile atomically.

Removing the nested ecosystem prevents manifest-only pull requests that cannot
pass `pnpm install --frozen-lockfile` and eliminates duplicate dependency PRs.

## Scope

- [ ] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [ ] Scripts/tooling
- [x] Repository configuration
- [ ] Other
- [ ] Mixed-scope exception

## Validation

- Exact allowlist: `.github/dependabot.yml`.
- Exactly one npm ecosystem remains, rooted at `/`.
- Exactly one GitHub Actions ecosystem remains, rooted at `/`.
- The `/frontend` npm ecosystem is absent.
- Existing labels and open-pull-request limits remain unchanged.
- `git diff --check`: PASS.
- `pnpm validate:local`: PASS.
- Backend suite: 3475 tests, 3474 passed, 0 failed, 1 skipped.
- Backend build: PASS.
- `pnpm security:public-surface`: PASS.
- Working tree clean after commit.

## Rollback

Revert this commit to restore the separate `/frontend` Dependabot ecosystem.
Rollback affects only dependency-update generation and does not change runtime,
database, API, authentication, frontend behavior, workflows or lockfile data.