### PR TITLE
fix(governance): support trusted Dependabot pull requests

### DIFF
--- a/docs/implementation/dependabot-pr-governance-compatibility.md
+++ b/docs/implementation/dependabot-pr-governance-compatibility.md
@@ -1,0 +1,81 @@
+# Dependabot PR Governance Compatibility
+
+## Objective
+
+Allow trusted Dependabot pull requests to satisfy repository pull-request
+governance without requiring Dependabot-generated bodies to reproduce the
+human pull-request template.
+
+This change does not bypass technical governance validation and does not
+enable automatic merge.
+
+## Problem
+
+Dependabot generates release-note bodies rather than the repository sections
+`Summary`, `Scope`, `Validation` and `Rollback`.
+
+The governance validator therefore rejected otherwise valid dependency
+updates after Backend and Frontend CI had passed.
+
+## Trusted identity contract
+
+Automated metadata and scope inference is allowed only when all identity
+conditions hold:
+
+1. The pull-request author is exactly `dependabot[bot]`.
+2. The head branch begins with `dependabot/`.
+3. The head repository is non-empty.
+4. The head and base repositories are identical.
+
+A human-created branch whose name resembles a Dependabot branch is not
+trusted. A Dependabot-looking branch from a fork is not trusted.
+
+## Changed-file contract
+
+Trusted inference accepts only modified files matching one of these classes:
+
+- any workspace `package.json`;
+- `package-lock.json`;
+- `pnpm-lock.yaml`;
+- `yarn.lock`;
+- `npm-shrinkwrap.json`;
+- YAML workflows directly below `.github/workflows/`.
+
+Added, deleted or renamed files are rejected. Runtime source files,
+documentation, scripts, repository configuration and arbitrary files are
+rejected.
+
+## Preserved governance checks
+
+Trusted inference changes only the source of PR metadata and scope
+declaration. These checks remain mandatory:
+
+- `git diff --check`;
+- sensitive-path policy;
+- added-line secret scanning;
+- Markdown validation;
+- Quality Gate Impact validation;
+- changed-file classification;
+- same-repository comparison range validation.
+
+Human pull requests continue to require the complete body template and exact
+scope checkboxes.
+
+## Validation
+
+Contract tests cover:
+
+- valid Dependabot identity;
+- human author spoofing;
+- non-Dependabot branch spoofing;
+- fork spoofing;
+- workspace manifest plus root lockfile updates;
+- GitHub Actions workflow updates;
+- runtime-source rejection;
+- added, deleted and renamed file rejection.
+
+## Rollback
+
+Revert the DP-2 commit. Human and Dependabot pull requests will again use the
+same manual metadata and scope contract. No runtime, API, database,
+authentication or application behavior is affected.

--- a/scripts/governance/pr-governance-validator.d.mts
+++ b/scripts/governance/pr-governance-validator.d.mts
@@ -11,6 +11,25 @@ export interface ScopeContractResult {
   exceptionChecked: boolean;
 }
 
+export interface GovernanceChangedFileEntry {
+  status: string;
+  path: string;
+  display?: string;
+  oldPath?: string;
+  newPath?: string;
+}
+
+export interface DependabotAutomationContractInput {
+  event: unknown;
+  entries: GovernanceChangedFileEntry[];
+}
+
+export interface DependabotAutomationContractResult {
+  failures: string[];
+  details: string[];
+  primary: string[];
+}
+
 export const CATEGORY_ORDER: string[];
 
 export function classifyPath(inputPath: string): string;
@@ -20,5 +39,11 @@ export function extractSection(body: string, sectionName: string): string;
 export function derivePrimaryCategories(inputCategories: string[]): string[];
 
 export function evaluateScopeContract(input: ScopeContractInput): ScopeContractResult;
+
+export function isTrustedDependabotPullRequest(event: unknown): boolean;
+
+export function evaluateDependabotAutomationContract(
+  input: DependabotAutomationContractInput,
+): DependabotAutomationContractResult;
 
 export function main(): number;

--- a/scripts/governance/pr-governance-validator.mjs
+++ b/scripts/governance/pr-governance-validator.mjs
@@ -29,6 +29,13 @@ export const CATEGORY_ORDER = [
 
 const REQUIRED_SECTIONS = ["Summary", "Scope", "Validation", "Rollback"];
 const SUPPORTING_CATEGORIES = new Set(["documentation", "tests"]);
+const TRUSTED_DEPENDABOT_LOGIN = "dependabot[bot]";
+const TRUSTED_DEPENDABOT_BRANCH_PREFIX = "dependabot/";
+const DEPENDABOT_ALLOWED_PATH_PATTERNS = [
+  /(^|\/)package\.json$/i,
+  /(^|\/)(package-lock\.json|pnpm-lock\.yaml|yarn\.lock|npm-shrinkwrap\.json)$/i,
+  /^\.github\/workflows\/[^/]+\.ya?ml$/i,
+];
 const SCOPE_LABEL_TO_CATEGORY = new Map([
   ["backend runtime", "backend"],
   ["frontend runtime", "frontend"],
@@ -178,6 +185,77 @@ export function derivePrimaryCategories(inputCategories) {
   if (categories.includes("tests")) return ["tests"];
   if (categories.includes("documentation")) return ["documentation"];
   return categories;
+}
+
+export function isTrustedDependabotPullRequest(event) {
+  const pullRequest = event?.pull_request;
+  const authorLogin = pullRequest?.user?.login ?? "";
+  const headRef = pullRequest?.head?.ref ?? "";
+  const headRepository = pullRequest?.head?.repo?.full_name ?? "";
+  const baseRepository = pullRequest?.base?.repo?.full_name ?? "";
+
+  return (
+    authorLogin === TRUSTED_DEPENDABOT_LOGIN &&
+    headRef.startsWith(TRUSTED_DEPENDABOT_BRANCH_PREFIX) &&
+    Boolean(headRepository) &&
+    headRepository === baseRepository
+  );
+}
+
+export function evaluateDependabotAutomationContract({ event, entries }) {
+  const failures = [];
+  const details = [];
+
+  if (!isTrustedDependabotPullRequest(event)) {
+    failures.push(
+      "Automated metadata inference requires a same-repository pull request authored by dependabot[bot] from a dependabot/* branch.",
+    );
+
+    return {
+      failures,
+      details,
+      primary: [],
+    };
+  }
+
+  const unsupportedEntries = entries.filter(
+    (entry) =>
+      entry.status !== "M" ||
+      !DEPENDABOT_ALLOWED_PATH_PATTERNS.some((pattern) =>
+        pattern.test(normalizePath(entry.path)),
+      ),
+  );
+
+  if (unsupportedEntries.length > 0) {
+    failures.push(
+      `Trusted Dependabot metadata inference only permits modified package manifests, lockfiles, or GitHub Actions workflows. Unsupported change(s): ${unsupportedEntries
+        .map((entry) => entry.display ?? entry.path)
+        .join("; ")}.`,
+    );
+  }
+
+  const primary = derivePrimaryCategories(
+    entries.map((entry) => classifyPath(entry.path)),
+  );
+
+  if (primary.length === 0) {
+    failures.push(
+      "Cannot derive a governed scope for the trusted Dependabot pull request.",
+    );
+  }
+
+  details.push(
+    `Trusted Dependabot author: ${TRUSTED_DEPENDABOT_LOGIN}.`,
+    `Trusted branch prefix: ${TRUSTED_DEPENDABOT_BRANCH_PREFIX}.`,
+    `Automatically inferred primary categories: ${primary.join(", ") || "(none)"}.`,
+    "Automated metadata inference does not skip diff, sensitive-path, secret, Markdown, or quality-gate validation.",
+  );
+
+  return {
+    failures,
+    details,
+    primary,
+  };
 }
 
 function parseScopeCheckboxes(scopeText) {
@@ -567,19 +645,68 @@ export function main() {
       }
 
       if (EVENT_NAME === "pull_request") {
-        const body = event.pull_request?.body ?? "";
-        const missing = REQUIRED_SECTIONS.filter((section) => !sectionPresent(body, section));
-        if (!body.trim()) fail("metadata", "PR body is required and cannot be empty.");
-        else if (missing.length > 0) fail("metadata", `Missing required section(s): ${missing.join(", ")}.`);
-        else pass("metadata", "Required PR body sections are present.");
+        if (isTrustedDependabotPullRequest(event)) {
+          pass(
+            "metadata",
+            "Trusted Dependabot pull request detected; generated PR body metadata accepted.",
+          );
 
-        const scope = evaluateScopeContract({
-          body,
-          categories: entries.map((entry) => classifyPath(entry.path)),
-        });
-        scope.details.forEach((message) => detail("scope", message));
-        scope.failures.forEach((message) => fail("scope", message));
-        if (scope.failures.length === 0) pass("scope", "Declared scope matches changed files.");
+          const automation = evaluateDependabotAutomationContract({
+            event,
+            entries,
+          });
+
+          automation.details.forEach((message) =>
+            detail("scope", message),
+          );
+          automation.failures.forEach((message) =>
+            fail("scope", message),
+          );
+
+          if (automation.failures.length === 0) {
+            pass(
+              "scope",
+              "Trusted Dependabot scope was inferred from the validated changed-file manifest.",
+            );
+          }
+        } else {
+          const body = event.pull_request?.body ?? "";
+          const missing = REQUIRED_SECTIONS.filter(
+            (section) => !sectionPresent(body, section),
+          );
+
+          if (!body.trim()) {
+            fail("metadata", "PR body is required and cannot be empty.");
+          } else if (missing.length > 0) {
+            fail(
+              "metadata",
+              `Missing required section(s): ${missing.join(", ")}.`,
+            );
+          } else {
+            pass("metadata", "Required PR body sections are present.");
+          }
+
+          const scope = evaluateScopeContract({
+            body,
+            categories: entries.map((entry) =>
+              classifyPath(entry.path),
+            ),
+          });
+
+          scope.details.forEach((message) =>
+            detail("scope", message),
+          );
+          scope.failures.forEach((message) =>
+            fail("scope", message),
+          );
+
+          if (scope.failures.length === 0) {
+            pass(
+              "scope",
+              "Declared scope matches changed files.",
+            );
+          }
+        }
       } else {
         results.metadata = "N/A";
         if (results.scope !== "FAIL") results.scope = "N/A";

--- a/test/unit/infrastructure/pr-governance-single-scope-contract.test.ts
+++ b/test/unit/infrastructure/pr-governance-single-scope-contract.test.ts
@@ -4,7 +4,9 @@ import assert from "node:assert/strict";
 import {
   classifyPath,
   derivePrimaryCategories,
+  evaluateDependabotAutomationContract,
   evaluateScopeContract,
+  isTrustedDependabotPullRequest,
 } from "../../../scripts/governance/pr-governance-validator.mjs";
 
 function prBody(scopeLines: string[], extraSections = ""): string {
@@ -190,4 +192,256 @@ test("template other-scope guidance comment is not accepted as detail", () => {
   });
 
   assert.ok(result.failures.some((failure) => failure.includes("Other Scope Detail")));
+});
+
+function trustedDependabotEvent(): any {
+  return {
+    pull_request: {
+      user: {
+        login: "dependabot[bot]",
+      },
+      head: {
+        ref: "dependabot/npm_and_yarn/react-dom-19.2.8",
+        repo: {
+          full_name: "LABVETNEB/PORTAL-VETNEB",
+        },
+      },
+      base: {
+        ref: "main",
+        repo: {
+          full_name: "LABVETNEB/PORTAL-VETNEB",
+        },
+      },
+    },
+  };
+}
+
+test("trusted Dependabot pull request identity requires bot author, branch and same repository", () => {
+  const trusted = trustedDependabotEvent();
+
+  assert.equal(
+    isTrustedDependabotPullRequest(trusted),
+    true,
+  );
+
+  const humanSpoof = structuredClone(trusted);
+  humanSpoof.pull_request.user.login = "human-maintainer";
+
+  assert.equal(
+    isTrustedDependabotPullRequest(humanSpoof),
+    false,
+  );
+
+  const branchSpoof = structuredClone(trusted);
+  branchSpoof.pull_request.head.ref = "feature/dependabot-lookalike";
+
+  assert.equal(
+    isTrustedDependabotPullRequest(branchSpoof),
+    false,
+  );
+
+  const forkSpoof = structuredClone(trusted);
+  forkSpoof.pull_request.head.repo.full_name =
+    "untrusted-fork/PORTAL-VETNEB";
+
+  assert.equal(
+    isTrustedDependabotPullRequest(forkSpoof),
+    false,
+  );
+});
+
+test("trusted Dependabot npm update infers frontend and dependency scopes", () => {
+  const result = evaluateDependabotAutomationContract({
+    event: trustedDependabotEvent(),
+    entries: [
+      {
+        status: "M",
+        path: "frontend/package.json",
+        display: "frontend/package.json",
+      },
+      {
+        status: "M",
+        path: "pnpm-lock.yaml",
+        display: "pnpm-lock.yaml",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(
+    result.primary,
+    ["frontend", "dependencies/lockfiles"],
+  );
+});
+
+test("trusted Dependabot GitHub Actions update accepts workflow-only modifications", () => {
+  const event = trustedDependabotEvent();
+  event.pull_request.head.ref =
+    "dependabot/github_actions/actions/checkout-7.0.1";
+
+  const result = evaluateDependabotAutomationContract({
+    event,
+    entries: [
+      {
+        status: "M",
+        path: ".github/workflows/backend-ci.yml",
+        display: ".github/workflows/backend-ci.yml",
+      },
+      {
+        status: "M",
+        path: ".github/workflows/frontend-ci.yml",
+        display: ".github/workflows/frontend-ci.yml",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.primary, ["workflows/CI"]);
+});
+
+test("trusted Dependabot metadata inference rejects runtime source changes", () => {
+  const result = evaluateDependabotAutomationContract({
+    event: trustedDependabotEvent(),
+    entries: [
+      {
+        status: "M",
+        path: "server/index.ts",
+        display: "server/index.ts",
+      },
+    ],
+  });
+
+  assert.ok(
+    result.failures.some((failure) =>
+      failure.includes("Unsupported change"),
+    ),
+  );
+});
+
+test("trusted Dependabot metadata inference rejects additions, deletions and renames", () => {
+  for (const status of ["A", "D", "R100"]) {
+    const result = evaluateDependabotAutomationContract({
+      event: trustedDependabotEvent(),
+      entries: [
+        {
+          status,
+          path: "frontend/package.json",
+          display: `${status} frontend/package.json`,
+        },
+      ],
+    });
+
+    assert.ok(
+      result.failures.some((failure) =>
+        failure.includes("Unsupported change"),
+      ),
+    );
+  }
+});
+
+test("trusted Dependabot identity rejects a pull request without a head repository", () => {
+  const missingHeadRepo = structuredClone(trustedDependabotEvent());
+  delete missingHeadRepo.pull_request.head.repo;
+
+  assert.equal(
+    isTrustedDependabotPullRequest(missingHeadRepo),
+    false,
+  );
+
+  const result = evaluateDependabotAutomationContract({
+    event: missingHeadRepo,
+    entries: [
+      {
+        status: "M",
+        path: "package.json",
+        display: "package.json",
+      },
+    ],
+  });
+
+  assert.ok(
+    result.failures.some((failure) =>
+      failure.includes("same-repository pull request"),
+    ),
+  );
+  assert.deepEqual(result.primary, []);
+});
+
+test("trusted Dependabot root manifest plus root lockfile infers dependency scope", () => {
+  const result = evaluateDependabotAutomationContract({
+    event: trustedDependabotEvent(),
+    entries: [
+      {
+        status: "M",
+        path: "package.json",
+        display: "package.json",
+      },
+      {
+        status: "M",
+        path: "pnpm-lock.yaml",
+        display: "pnpm-lock.yaml",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.primary, ["dependencies/lockfiles"]);
+});
+
+test("trusted Dependabot GitHub Actions update accepts .yaml workflow extension", () => {
+  const event = trustedDependabotEvent();
+  event.pull_request.head.ref =
+    "dependabot/github_actions/actions/setup-node-5.0.0";
+
+  const result = evaluateDependabotAutomationContract({
+    event,
+    entries: [
+      {
+        status: "M",
+        path: ".github/workflows/release.yaml",
+        display: ".github/workflows/release.yaml",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.deepEqual(result.primary, ["workflows/CI"]);
+});
+
+test("trusted Dependabot metadata inference rejects frontend source changes", () => {
+  const result = evaluateDependabotAutomationContract({
+    event: trustedDependabotEvent(),
+    entries: [
+      {
+        status: "M",
+        path: "frontend/src/app/page.tsx",
+        display: "frontend/src/app/page.tsx",
+      },
+    ],
+  });
+
+  assert.ok(
+    result.failures.some((failure) =>
+      failure.includes("Unsupported change"),
+    ),
+  );
+});
+
+test("trusted Dependabot metadata inference rejects documentation changes", () => {
+  const result = evaluateDependabotAutomationContract({
+    event: trustedDependabotEvent(),
+    entries: [
+      {
+        status: "M",
+        path: "docs/implementation/example.md",
+        display: "docs/implementation/example.md",
+      },
+    ],
+  });
+
+  assert.ok(
+    result.failures.some((failure) =>
+      failure.includes("Unsupported change"),
+    ),
+  );
 });


### PR DESCRIPTION
## Summary

Adds a narrowly scoped governance path for authentic same-repository
Dependabot pull requests.

Dependabot-generated bodies may use inferred metadata and scope only after
strict author, branch, repository and changed-file validation. Human pull
requests continue to require the complete governance template.

## Scope

- [ ] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [x] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [x] Scripts/tooling
- [ ] Repository configuration
- [ ] Other
- [x] Mixed-scope exception

## Mixed-Scope Justification

The governance validator runtime `pr-governance-validator.mjs` is classified as
Workflows/CI, while its public TypeScript declaration `pr-governance-validator.d.mts`
is classified as Scripts/tooling. The contract tests and implementation
documentation are supporting changes to those same primary scopes. Splitting the
runtime from its declaration would publish executable behavior without its public
type contract, or a contract without executable enforcement. They share one
rollback boundary and must be released together.

## Validation

- `git diff --check`: PASS.
- `pnpm typecheck:test`: PASS.
- Targeted PR governance contract tests: PASS (25 tests).
- `pnpm validate:local`: PASS.
- Full test suite: PASS with zero failures (1 preexisting Windows symlink skip).
- Backend build: PASS.
- `pnpm security:public-surface`: PASS.
- Exact four-file allowlist verified.
- `.mjs` and `.d.mts` export parity verified.
- Human PR metadata enforcement preserved.
- Dependabot spoofing and fork cases rejected.

## Rollback

Revert this commit. Dependabot pull requests will again require the same manual
body metadata and scope declarations as human pull requests. No runtime,
database, API, authentication, application or dependency behavior is changed.
