### PR TITLE
chore(ci): bump actions/checkout to 7.0.1

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -51,7 +51,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup pnpm
         uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9

--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/qga-governance.yml
+++ b/.github/workflows/qga-governance.yml
@@ -23,12 +23,12 @@ jobs:
 
     steps:
       - name: Checkout trusted base branch
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           persist-credentials: false
 
       - name: Checkout candidate head as inert data
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: qga-candidate-head

--- a/.github/workflows/visual-regression-manual.yml
+++ b/.github/workflows/visual-regression-manual.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
 
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7

--- a/test/architecture/toolchain-contract.test.ts
+++ b/test/architecture/toolchain-contract.test.ts
@@ -125,7 +125,7 @@ test("Backend CI uses the pinned pnpm and Node toolchain", () => {
     workflow,
     "concurrency:\n  group: backend-ci-${{ github.workflow }}-${{ github.ref }}\n  cancel-in-progress: true",
   );
-  assertContains(workflow, "uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7");
+  assertContains(workflow, "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7");
   assertContains(workflow, "uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9");
   assertContains(workflow, "uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7");
   assertNotContains(workflow, "uses: actions/checkout@v7");

--- a/test/unit/infrastructure/frontend-ci-workflow.test.ts
+++ b/test/unit/infrastructure/frontend-ci-workflow.test.ts
@@ -103,7 +103,7 @@ test("Frontend CI define toolchain y cache de pnpm esperados", () => {
   const source = readWorkflow();
 
   assertContains(source, "timeout-minutes: 20");
-  assertContains(source, "uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7");
+  assertContains(source, "uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7");
   assertContains(source, "uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271 # v6.0.9");
   assertContains(source, "uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7");
   assertContains(source, "uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7");

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -27,7 +27,7 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
   [
     ".github/workflows/backend-ci.yml",
     [
-      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271",
       "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
     ],
@@ -35,7 +35,7 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
   [
     ".github/workflows/frontend-ci.yml",
     [
-      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271",
       "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
       "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
@@ -44,15 +44,15 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
   [
     ".github/workflows/pr-governance.yml",
     [
-      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
     ],
   ],
   [
     ".github/workflows/qga-governance.yml",
     [
-      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
-      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       "pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271",
       "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
       "actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1",
@@ -61,7 +61,7 @@ const pinnedActionReferences = new Map<string, readonly string[]>([
   [
     ".github/workflows/visual-regression-manual.yml",
     [
-      "actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0",
+      "actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1",
       "actions/setup-node@820762786026740c76f36085b0efc47a31fe5020",
       "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
       "actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a",
@@ -79,11 +79,11 @@ const mutableActionReferences = [
 
 const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
-  [".github/workflows/backend-ci.yml", "f40ad6d2859e9ba594c83126f9ba1e87e0a1f031193396bb98feea2f0e40f882"],
-  [".github/workflows/frontend-ci.yml", "ab34aea3f70558eec441d8969187587a406e0f4c0fab04d3a5d6e583cd554607"],
-  [".github/workflows/pr-governance.yml", "11a3f1b9a0afa6e935709deac50d38bccea2ca074599b6f272e05ca380ddff80"],
-  [".github/workflows/qga-governance.yml", "89abf7907ed702b5f7de82f3b0f0cc174e8cdf2e990f9dd0f61cea49a65de2ee"],
-  [".github/workflows/visual-regression-manual.yml", "3344160f3c37da9067ba744ca317a27168799839157c95301e8ac3905754faf0"],
+  [".github/workflows/backend-ci.yml", "aa70fb1e91bc4527819f778b65e19f24e4a2a9a4311033f968323014d3e5e629"],
+  [".github/workflows/frontend-ci.yml", "58258646ff64fcf4a71433f879a41bac59cbcdef306d5bab92417f3f08699476"],
+  [".github/workflows/pr-governance.yml", "4e0bf177a8581c9dd655f1ca6aa1510a823cdd976c885c4ba50b41129e4157d7"],
+  [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],
+  [".github/workflows/visual-regression-manual.yml", "86784fe26f1f15e2ae6fb60ee8c26ef050f311bcebab72a2e1732739e035fee9"],
 ]);
 
 function readWorkflow(workflowPath: string): string {


### PR DESCRIPTION
## Summary

Bumps `actions/checkout` from v7.0.0 (`9c091bb`) to v7.0.1
(`3d3c42e5aac5ba805825da76410c181273ba90b1`) across all five canonical
workflows, and updates the coupled workflow-security contract tests that pin
the reviewed checkout SHA and the canonical workflow digests.

This supersedes Dependabot PR #1531. The action bump and its pinned-SHA /
digest contract tests are coupled and cannot land separately: Dependabot may
only modify workflow files, so the required test updates must accompany the
bump in a single change.

## Scope

- [ ] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [x] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [ ] Repository configuration
- [ ] Other

## Validation

- `actions/checkout` `v7.0.1` verified to resolve to `3d3c42e5aac5ba805825da76410c181273ba90b1`.
- `git diff --check`: PASS.
- `pnpm validate:local`: PASS (typecheck, typecheck:test, full suite, build).
- Full test suite: 3484 pass, 0 fail, 1 preexisting Windows symlink skip.
- Backend build: PASS.
- Only the pinned checkout SHA changes in each workflow; no permission,
  concurrency or step changes.
- Canonical workflow digests recomputed only for the five checkout-using
  workflows; `app-version-force-update.yml` digest unchanged.

## Rollback

Revert this commit to restore `actions/checkout` v7.0.0 and the previous
reviewed SHA / digest contract values. No runtime, database, API,
authentication or application behavior is affected.
