### PR TITLE
chore(deps): bump argon2 to 0.45.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.110.8",
-    "argon2": "^0.44.0",
+    "argon2": "^0.45.1",
     "dotenv": "^17.4.2",
     "drizzle-orm": "^0.45.2",
     "fastify": "^5.10.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,8 +24,8 @@ importers:
         specifier: ^2.110.8
         version: 2.110.8
       argon2:
-        specifier: ^0.44.0
-        version: 0.44.0
+        specifier: ^0.45.1
+        version: 0.45.1
       dotenv:
         specifier: ^17.4.2
         version: 17.4.2
@@ -1484,8 +1484,8 @@ packages:
   append-field@1.0.0:
     resolution: {integrity: sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw==}
 
-  argon2@0.44.0:
-    resolution: {integrity: sha512-zHPGN3S55sihSQo0dBbK0A5qpi2R31z7HZDZnry3ifOyj8bZZnpZND2gpmhnRGO1V/d555RwBqIK5W4Mrmv3ig==}
+  argon2@0.45.1:
+    resolution: {integrity: sha512-skm+/WCjkGqCQxF7FG1LuZXM5yvbFjgbfiCGsud2oLgaDhh6b6dbH0b1EkghbM+xx4Bj8Ape+KKgixoIlWZicQ==}
     engines: {node: '>=16.17.0'}
 
   argparse@2.0.1:
@@ -2557,8 +2557,8 @@ packages:
       sass:
         optional: true
 
-  node-addon-api@8.7.0:
-    resolution: {integrity: sha512-9MdFxmkKaOYVTV+XVRG8ArDwwQ77XIgIPyKASB1k3JPq3M8fGQQQE3YpMOrKm6g//Ktx8ivZr8xo1Qmtqub+GA==}
+  node-addon-api@8.9.0:
+    resolution: {integrity: sha512-ekZMeaaIzSQTSpr7X2X3iJM7lTzgnx8ahAG9pJfT/7+14mlEM8ZYQ9cgCDvSSRbReFK0oHli3WrZdCiRsgAT9Q==}
     engines: {node: ^18 || ^20 || >= 21}
 
   node-exports-info@1.6.0:
@@ -4342,11 +4342,11 @@ snapshots:
 
   append-field@1.0.0: {}
 
-  argon2@0.44.0:
+  argon2@0.45.1:
     dependencies:
       '@phc/format': 1.0.0
       cross-env: 10.1.0
-      node-addon-api: 8.7.0
+      node-addon-api: 8.9.0
       node-gyp-build: 4.8.4
 
   argparse@2.0.1: {}
@@ -5516,7 +5516,7 @@ snapshots:
       - '@types/node'
       - babel-plugin-macros
 
-  node-addon-api@8.7.0: {}
+  node-addon-api@8.9.0: {}
 
   node-exports-info@1.6.0:
     dependencies:

--- a/server/lib/auth-security.ts
+++ b/server/lib/auth-security.ts
@@ -6,7 +6,7 @@ const PASSWORD_HASH_OPTIONS = {
   memoryCost: 19456,
   timeCost: 2,
   parallelism: 1,
-};
+} as const;
 
 export function hashLegacyPassword(password: string): string {
   return crypto.createHash("sha256").update(password).digest("hex");


### PR DESCRIPTION
## Summary

Updates Argon2 from 0.44.0 to 0.45.1 and applies the minimal type-safe
compatibility adjustment required by the tightened `HashOptions.type`
declaration.

`PASSWORD_HASH_OPTIONS` now uses `as const`, preserving the literal
`argon2.argon2id` type without `any`, casts or behavioral changes.

## Scope

- [x] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [x] Dependencies
- [ ] Scripts/tooling
- [ ] Repository configuration
- [ ] Other
- [x] Mixed-scope exception

## Mixed-Scope Justification

Argon2 0.45.1 tightens the public `HashOptions.type` contract. The dependency
update cannot typecheck without updating its existing backend call-site.

The dependency bump, root lockfile and one-line literal-type preservation in
`auth-security.ts` form one indivisible compatibility boundary. Splitting them
would leave either an unbuildable dependency update or an unnecessary runtime
change without the dependency that requires it.

## Validation

- `pnpm install --frozen-lockfile`: PASS.
- Native Argon2 module load: PASS.
- Argon2id hash generation: PASS.
- Correct-password verification: PASS.
- Incorrect-password rejection: PASS.
- `pnpm validate:local`: PASS.
- Typecheck: PASS with no `any` degradation.
- Test typecheck: PASS.
- Full test suite: PASS with zero failures.
- Backend build: PASS.
- `pnpm security:public-surface`: PASS.
- Exact three-file allowlist verified.
- `git diff --check`: PASS.

## Rollback

Revert this commit to restore Argon2 0.44.0, the previous lockfile and the
previous inferred object type.

Rollback does not require database changes or hash migration. Existing Argon2
hash strings remain compatible with the updated verifier.