### PR TITLE
refactor(clinics): thin admin routes

### DIFF
--- a/docs/implementation/m27-clinics-thin-admin.md
+++ b/docs/implementation/m27-clinics-thin-admin.md
@@ -1,0 +1,120 @@
+# M27 — Clinics thin admin
+
+## Baseline
+
+- Rama: refactor/backend-modularization-m27-clinics-thin-admin.
+- Base: eb46092922de66989ed8e98c16b1379d5c32989c.
+- Repository canónico:
+  server/features/clinics/infrastructure/admin-clinics-repository.ts.
+- Blob inicial del repository: 7d9437d49e461536a742a95f9fa13794814dafd0.
+- Transacciones iniciales: 2.
+- El árbol y el índice estaban limpios.
+
+## Arquitectura
+
+Antes:
+
+~~~text
+Fastify route
+  -> server/db-admin-clinics.ts (shim)
+       -> Clinics infrastructure
+~~~
+
+Después:
+
+~~~text
+Fastify route
+  -> servicio directo Clinics
+       -> carga lazy de Clinics infrastructure
+~~~
+
+No se crea una capa application ni puertos, adapters, clases, factories o
+repositorios genéricos. El SQL y las dos transacciones permanecen en el
+repository canónico sin modificaciones.
+
+## Servicios directos
+
+- admin-clinics-query-service.ts delega listado y obtención por id sin
+  transformar params ni resultados.
+- admin-clinics-command-service.ts coordina hash inyectado, create, update,
+  confirmación exacta y delete, credenciales y clasificación/sanitización de
+  errores PostgreSQL.
+- Ambos cargan infrastructure/index.ts de forma lazy cuando no reciben el
+  seam correspondiente.
+- Ningún servicio depende de Fastify, auditoría, CORS o auth.
+
+## Responsabilidades preservadas en rutas
+
+Las rutas conservan registro Fastify, métodos y paths, parsing, validación
+HTTP, CORS, trusted-origin, autenticación administrativa, respuestas, status
+codes, mensajes exactos, auditoría posterior al éxito, logging con contexto
+de request, mapeo final de errores a HTTP y seams de inyección.
+
+admin-users-roles.fastify.ts sólo delega a Clinics el comando de actualización
+de credenciales. El resto de Users/Roles no se refactoriza.
+
+## Retiro del shim
+
+server/db-admin-clinics.ts se elimina después de reapuntar imports runtime y
+type-only activos. Las menciones históricas en documentación previa no forman
+parte de la resolución runtime.
+
+## Allowlist real
+
+- docs/implementation/m27-clinics-thin-admin.md.
+- server/db-admin-clinics.ts (eliminado).
+- server/features/clinics/README.md.
+- server/features/clinics/admin-clinics-command-service.ts.
+- server/features/clinics/admin-clinics-query-service.ts.
+- server/features/clinics/infrastructure/README.md.
+- server/routes/admin-clinics.fastify.ts.
+- server/routes/admin-users-roles.fastify.ts.
+- test/architecture/clinics-infrastructure-boundary-guard.test.ts.
+- test/integration/adapters/controllers/admin-clinics.fastify.test.ts.
+- test/integration/adapters/controllers/admin-users-roles.fastify.test.ts.
+- test/unit/clinics/admin-clinics-command-service.test.ts.
+- test/unit/clinics/admin-clinics-query-service.test.ts.
+- test/unit/infrastructure/global-performance-resilience-contract.test.ts.
+
+## Denylist respetada
+
+No se modifican repository ni barrel de infrastructure, domain, Users/Roles
+DB, fastify-app, db.ts, schema, Drizzle, migraciones, frontend, manifiestos,
+lockfiles, dependencias, scripts, CI, perfil público, auth global, sesiones,
+cookies o permisos.
+
+## Tests y contratos
+
+La validación M27 incluye typecheck runtime/test, tests unitarios de ambos
+servicios, guards Clinics, contratos admin source-only e integraciones Fastify.
+Después ejecuta validate:local, security:public-surface y git diff --check.
+
+El contrato global de performance/resiliencia sólo actualiza su comentario
+source-only para reflejar que el shim ya no existe; continúa midiendo el
+repository canónico sin debilitar expectativas.
+
+El guard de infrastructure verifica ausencia del shim y application,
+presencia y pureza de servicios, consumo lazy del barrel canónico, rutas sin
+imports directos de infrastructure y delegación exclusiva del comando de
+credenciales desde Users/Roles.
+
+## Resultado de validación
+
+- pnpm typecheck: PASSED.
+- pnpm typecheck:test: PASSED.
+- Tests dirigidos M27: PASSED (167/167).
+- pnpm validate:local: PASSED (typecheck, typecheck:test, 3513 tests con
+  3512 pass, 1 skip y 0 fail, y build).
+- pnpm security:public-surface: PASSED.
+- git diff --check: PASSED.
+
+## Rollback
+
+Revertir el cambio restaura el shim y la coordinación inline en las rutas.
+No requiere migración de datos, rollback de schema ni cambios de
+infraestructura.
+
+## Fuera de alcance
+
+M28 (perfil público) y M29 (cierre y verificación cross-tenant) permanecen
+fuera de M27.

--- a/server/db-admin-clinics.ts
+++ b/server/db-admin-clinics.ts
@@ -1,1 +1,0 @@
-export * from "./features/clinics/infrastructure/index.ts";

--- a/server/features/clinics/README.md
+++ b/server/features/clinics/README.md
@@ -1,17 +1,18 @@
 
 # Clinics · bounded context
 
-Contexto Clinics del backend. Abierto en M25 y con persistencia canónica
-materializada en M26.
+Contexto Clinics del backend. Abierto en M25, con persistencia canónica
+materializada en M26 y administración adelgazada en M27.
 
-## Estado por capas (M26)
+## Estado por capas (M27)
 
 | Capa | Estado | Contenido |
 |---|---|---|
 | domain/ | con código | Validación y normalización puras. |
 | infrastructure/ | con código | Repository Drizzle, SQL legacy, serialización y dos transacciones. |
-| application/ | ausente | Diferido; no se anticipa capa. |
-| routes/ | ausente | Las rutas permanecen en server/routes hasta M27. |
+| servicios directos | con código | Query y command services mínimos, sin capa application. |
+| application/ | ausente | No se necesita para el corte actual. |
+| routes/ | externas al contexto | Conservan exclusivamente responsabilidades HTTP y operativas. |
 
 ## Topología actual
 
@@ -20,27 +21,27 @@ admin-clinics.fastify.ts
 admin-users-roles.fastify.ts
   ├─ HTTP / CORS / auth / auditoría / error mapping
   ├─ features/clinics/domain
-  └─ db-admin-clinics.ts
-       └─ shim
-            └─ features/clinics/infrastructure/index.ts
-                 └─ admin-clinics-repository.ts
-                      ├─ Drizzle / SQL / serialización
-                      └─ 2 transacciones exactas
+  └─ features/clinics/admin-clinics-{query,command}-service.ts
+       └─ carga lazy de features/clinics/infrastructure/index.ts
+            └─ admin-clinics-repository.ts
+                 ├─ Drizzle / SQL / serialización
+                 └─ 2 transacciones exactas
 ~~~
 
-Las rutas conservan temporalmente el path legacy. La implementación real
-existe en una única copia canónica dentro de infrastructure.
+Los servicios coordinan consultas y comandos administrativos sin Fastify,
+auth, CORS ni auditoría. Las rutas preservan los seams de inyección usados por
+tests y la implementación persiste en una única copia canónica.
 
 ## Programa
 
 - M25: dominio y validaciones — cerrado.
-- M26: repository y persistencia — este milestone.
-- M27: adelgazar rutas admin y retirar el shim.
+- M26: repository y persistencia — cerrado.
+- M27: adelgazar rutas admin y retirar el shim — cerrado.
 - M28: adelgazar perfil público.
 - M29: cierre y verificación cross-tenant.
 
 ## Fuera de alcance
 
-M26 no modifica endpoints, payloads, status codes, CORS, auth, auditoría,
+M27 no modifica endpoints, payloads, status codes, CORS, auth, auditoría,
 permisos, perfil público, schema, migraciones, dependencias, lockfiles,
 frontend, scripts ni CI.

--- a/server/features/clinics/admin-clinics-command-service.ts
+++ b/server/features/clinics/admin-clinics-command-service.ts
@@ -1,0 +1,272 @@
+import { confirmClinicNameMatches } from "./domain/index.ts";
+import type {
+  AdminClinicCreateInput,
+  AdminClinicCreateResult,
+  AdminClinicDeleteInput,
+  AdminClinicSummary,
+  AdminClinicUpdateInput,
+  AdminClinicUserCredentialsUpdateInput,
+  AdminClinicUserCredentialsUpdateResult,
+} from "./infrastructure/index.ts";
+
+export type {
+  AdminClinicCreateInput,
+  AdminClinicCreateResult,
+  AdminClinicDeleteInput,
+  AdminClinicSummary,
+  AdminClinicUpdateInput,
+  AdminClinicUserCredentialsUpdateInput,
+  AdminClinicUserCredentialsUpdateResult,
+} from "./infrastructure/index.ts";
+
+export type AdminClinicCreateCommandInput = Omit<
+  AdminClinicCreateInput,
+  "passwordHash"
+> & {
+  password: string;
+};
+
+export type AdminClinicUserCredentialsCommandInput = Omit<
+  AdminClinicUserCredentialsUpdateInput,
+  "passwordHash"
+> & {
+  password?: string;
+};
+
+export type AdminClinicsCommandServiceOverrides = {
+  createAdminClinicWithUser?: (
+    input: AdminClinicCreateInput,
+  ) => Promise<AdminClinicCreateResult>;
+  updateAdminClinic?: (
+    input: AdminClinicUpdateInput,
+  ) => Promise<AdminClinicSummary | null>;
+  getAdminClinicById?: (
+    clinicId: number,
+  ) => Promise<AdminClinicSummary | null>;
+  deleteAdminClinic?: (
+    input: AdminClinicDeleteInput,
+  ) => Promise<AdminClinicSummary | null>;
+  updateAdminClinicUserCredentials?: (
+    input: AdminClinicUserCredentialsUpdateInput,
+  ) => Promise<AdminClinicUserCredentialsUpdateResult>;
+};
+
+export type HashPassword = (
+  password: string,
+) => Promise<string>;
+
+type AdminClinicsCommandServiceDeps = Required<
+  AdminClinicsCommandServiceOverrides
+>;
+
+let defaultDepsPromise:
+  | Promise<AdminClinicsCommandServiceDeps>
+  | undefined;
+
+async function loadDefaultDeps(): Promise<AdminClinicsCommandServiceDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = import("./infrastructure/index.ts").then(
+      (repository) => ({
+        createAdminClinicWithUser:
+          repository.createAdminClinicWithUser,
+        updateAdminClinic: repository.updateAdminClinic,
+        getAdminClinicById: repository.getAdminClinicById,
+        deleteAdminClinic: repository.deleteAdminClinic,
+        updateAdminClinicUserCredentials:
+          repository.updateAdminClinicUserCredentials,
+      }),
+    );
+  }
+
+  return defaultDepsPromise;
+}
+
+async function resolveDep<
+  Key extends keyof AdminClinicsCommandServiceDeps,
+>(
+  key: Key,
+  overrides: AdminClinicsCommandServiceOverrides,
+): Promise<AdminClinicsCommandServiceDeps[Key]> {
+  const override = overrides[key];
+
+  if (override) {
+    return override as AdminClinicsCommandServiceDeps[Key];
+  }
+
+  return (await loadDefaultDeps())[key];
+}
+
+export async function createAdminClinicCommand(
+  input: AdminClinicCreateCommandInput,
+  deps: AdminClinicsCommandServiceOverrides & {
+    hashPassword: HashPassword;
+  },
+) {
+  const createAdminClinicWithUser = await resolveDep(
+    "createAdminClinicWithUser",
+    deps,
+  );
+  const passwordHash = await deps.hashPassword(input.password);
+  const { password: _password, ...clinicInput } = input;
+
+  return createAdminClinicWithUser({
+    ...clinicInput,
+    passwordHash,
+  });
+}
+
+export async function updateAdminClinicCommand(
+  input: AdminClinicUpdateInput,
+  overrides: AdminClinicsCommandServiceOverrides = {},
+) {
+  const updateAdminClinic = await resolveDep(
+    "updateAdminClinic",
+    overrides,
+  );
+
+  return updateAdminClinic(input);
+}
+
+export type DeleteAdminClinicCommandResult =
+  | {
+      ok: true;
+      clinic: AdminClinicSummary;
+    }
+  | {
+      ok: false;
+      reason: "not_found" | "confirmation_mismatch";
+    };
+
+export async function deleteAdminClinicCommand(
+  input: {
+    clinicId: number;
+    confirmClinicName: string;
+  },
+  overrides: AdminClinicsCommandServiceOverrides = {},
+): Promise<DeleteAdminClinicCommandResult> {
+  const getAdminClinicById = await resolveDep(
+    "getAdminClinicById",
+    overrides,
+  );
+  const clinic = await getAdminClinicById(input.clinicId);
+
+  if (!clinic) {
+    return {
+      ok: false,
+      reason: "not_found",
+    };
+  }
+
+  if (
+    !confirmClinicNameMatches(
+      input.confirmClinicName,
+      clinic.clinicName,
+    )
+  ) {
+    return {
+      ok: false,
+      reason: "confirmation_mismatch",
+    };
+  }
+
+  const deleteAdminClinic = await resolveDep(
+    "deleteAdminClinic",
+    overrides,
+  );
+  const deletedClinic = await deleteAdminClinic({
+    clinicId: input.clinicId,
+  });
+
+  return deletedClinic
+    ? {
+        ok: true,
+        clinic: deletedClinic,
+      }
+    : {
+        ok: false,
+        reason: "not_found",
+      };
+}
+
+export async function updateAdminClinicUserCredentialsCommand(
+  input: AdminClinicUserCredentialsCommandInput,
+  deps: AdminClinicsCommandServiceOverrides & {
+    hashPassword: HashPassword;
+  },
+) {
+  const updateAdminClinicUserCredentials = await resolveDep(
+    "updateAdminClinicUserCredentials",
+    deps,
+  );
+  const passwordHash =
+    input.password === undefined
+      ? undefined
+      : await deps.hashPassword(input.password);
+  const { password: _password, ...credentialsInput } = input;
+
+  return updateAdminClinicUserCredentials({
+    ...credentialsInput,
+    passwordHash,
+  });
+}
+
+export type AdminClinicsPostgresErrorKind =
+  | "username_conflict"
+  | "schema_mismatch"
+  | "active_dependency"
+  | "unknown";
+
+export type SanitizedPostgresErrorMetadata = {
+  errorName: string;
+  errorCode: string;
+  constraintName: string | null;
+  tableName: string | null;
+  columnName: string | null;
+};
+
+export function classifyAdminClinicsPostgresError(
+  error: unknown,
+): {
+  kind: AdminClinicsPostgresErrorKind;
+  metadata: SanitizedPostgresErrorMetadata;
+} {
+  const record =
+    typeof error === "object" && error !== null
+      ? (error as Record<string, unknown>)
+      : {};
+  const errorCode =
+    typeof record.code === "string" ? record.code : "unknown";
+  const metadata = {
+    errorName:
+      typeof record.name === "string"
+        ? record.name
+        : "UnknownError",
+    errorCode,
+    constraintName:
+      typeof record.constraint_name === "string"
+        ? record.constraint_name
+        : null,
+    tableName:
+      typeof record.table_name === "string"
+        ? record.table_name
+        : null,
+    columnName:
+      typeof record.column_name === "string"
+        ? record.column_name
+        : null,
+  };
+
+  const kindByCode: Record<
+    string,
+    AdminClinicsPostgresErrorKind
+  > = {
+    "23505": "username_conflict",
+    "23502": "schema_mismatch",
+    "23503": "active_dependency",
+  };
+
+  return {
+    kind: kindByCode[errorCode] ?? "unknown",
+    metadata,
+  };
+}

--- a/server/features/clinics/admin-clinics-query-service.ts
+++ b/server/features/clinics/admin-clinics-query-service.ts
@@ -1,0 +1,82 @@
+import type {
+  AdminClinicsSnapshot,
+  AdminClinicSummary,
+} from "./infrastructure/index.ts";
+
+export type {
+  AdminClinicsSnapshot,
+  AdminClinicSummary,
+} from "./infrastructure/index.ts";
+
+export type AdminClinicsListParams = {
+  limit?: number;
+  offset?: number;
+  search?: string;
+};
+
+export type AdminClinicsQueryServiceOverrides = {
+  listAdminClinics?: (
+    params: AdminClinicsListParams,
+  ) => Promise<AdminClinicsSnapshot>;
+  getAdminClinicById?: (
+    clinicId: number,
+  ) => Promise<AdminClinicSummary | null>;
+};
+
+type AdminClinicsQueryServiceDeps = Required<
+  AdminClinicsQueryServiceOverrides
+>;
+
+let defaultDepsPromise:
+  | Promise<AdminClinicsQueryServiceDeps>
+  | undefined;
+
+async function loadDefaultDeps(): Promise<AdminClinicsQueryServiceDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = import("./infrastructure/index.ts").then(
+      (repository) => ({
+        listAdminClinics: repository.listAdminClinics,
+        getAdminClinicById: repository.getAdminClinicById,
+      }),
+    );
+  }
+
+  return defaultDepsPromise;
+}
+
+async function resolveListAdminClinics(
+  overrides: AdminClinicsQueryServiceOverrides,
+) {
+  return (
+    overrides.listAdminClinics ??
+    (await loadDefaultDeps()).listAdminClinics
+  );
+}
+
+async function resolveGetAdminClinicById(
+  overrides: AdminClinicsQueryServiceOverrides,
+) {
+  return (
+    overrides.getAdminClinicById ??
+    (await loadDefaultDeps()).getAdminClinicById
+  );
+}
+
+export async function listAdminClinicsQuery(
+  params: AdminClinicsListParams,
+  overrides: AdminClinicsQueryServiceOverrides = {},
+) {
+  const listAdminClinics = await resolveListAdminClinics(overrides);
+
+  return listAdminClinics(params);
+}
+
+export async function getAdminClinicQuery(
+  clinicId: number,
+  overrides: AdminClinicsQueryServiceOverrides = {},
+) {
+  const getAdminClinicById =
+    await resolveGetAdminClinicById(overrides);
+
+  return getAdminClinicById(clinicId);
+}

--- a/server/features/clinics/infrastructure/README.md
+++ b/server/features/clinics/infrastructure/README.md
@@ -29,5 +29,5 @@ Supabase, middlewares ni una capa application.
 - Cascada transaccional de eliminación en el mismo orden.
 - Superficie pública histórica.
 
-server/db-admin-clinics.ts permanece como shim temporal de un único re-export.
-Las rutas serán reapuntadas y el shim será retirado en M27.
+M27 retiró server/db-admin-clinics.ts. Los servicios directos del contexto
+cargan este barrel de forma lazy; las rutas no importan infrastructure.

--- a/server/routes/admin-clinics.fastify.ts
+++ b/server/routes/admin-clinics.fastify.ts
@@ -19,16 +19,26 @@ import {
 import type {
   AdminClinicCreateInput,
   AdminClinicCreateResult,
-  AdminClinicsSnapshot,
   AdminClinicSummary,
   AdminClinicDeleteInput,
   AdminClinicUpdateInput,
-} from "../db-admin-clinics.ts";
+} from "../features/clinics/admin-clinics-command-service.ts";
+import {
+  classifyAdminClinicsPostgresError,
+  createAdminClinicCommand,
+  deleteAdminClinicCommand,
+  updateAdminClinicCommand,
+} from "../features/clinics/admin-clinics-command-service.ts";
+import type {
+  AdminClinicsSnapshot,
+} from "../features/clinics/admin-clinics-query-service.ts";
+import {
+  listAdminClinicsQuery,
+} from "../features/clinics/admin-clinics-query-service.ts";
 import {
   parseClinicCreateInput,
   parseClinicUpdateInput,
   parseClinicDeleteConfirmation,
-  confirmClinicNameMatches,
 } from "../features/clinics/domain/index.ts";
 
 type AdminSessionRecord = {
@@ -104,7 +114,7 @@ export type AdminClinicsNativeRoutesOptions = {
   now?: () => number;
 };
 
-type NativeAdminClinicsDeps = Required<
+type NativeAdminClinicsCoreDeps = Required<
   Pick<
     AdminClinicsNativeRoutesOptions,
     | "deleteAdminSession"
@@ -112,24 +122,30 @@ type NativeAdminClinicsDeps = Required<
     | "updateAdminSessionLastAccess"
     | "hashSessionToken"
     | "hashPassword"
+    | "writeAuditLog"
+  >
+>;
+
+type NativeAdminClinicsDeps = NativeAdminClinicsCoreDeps &
+  Pick<
+    AdminClinicsNativeRoutesOptions,
     | "listAdminClinics"
     | "createAdminClinicWithUser"
     | "getAdminClinicById"
     | "updateAdminClinic"
     | "deleteAdminClinic"
-    | "writeAuditLog"
-  >
->;
+  >;
 
-let defaultDepsPromise: Promise<NativeAdminClinicsDeps> | undefined;
+let defaultDepsPromise:
+  | Promise<NativeAdminClinicsCoreDeps>
+  | undefined;
 
-async function loadDefaultDeps(): Promise<NativeAdminClinicsDeps> {
+async function loadDefaultDeps(): Promise<NativeAdminClinicsCoreDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const audit = await import("../lib/audit.ts");
-      const adminClinics = await import("../db-admin-clinics.ts");
 
       return {
         deleteAdminSession: db.deleteAdminSession,
@@ -137,11 +153,6 @@ async function loadDefaultDeps(): Promise<NativeAdminClinicsDeps> {
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         hashPassword: authSecurity.hashPassword,
-        listAdminClinics: adminClinics.listAdminClinics,
-        createAdminClinicWithUser: adminClinics.createAdminClinicWithUser,
-        getAdminClinicById: adminClinics.getAdminClinicById,
-        updateAdminClinic: adminClinics.updateAdminClinic,
-        deleteAdminClinic: adminClinics.deleteAdminClinic,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
           input: AuditWriteInput,
@@ -219,53 +230,6 @@ function createAuditRequestLike(
   };
 }
 
-function isUniqueViolation(error: unknown) {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === "23505"
-  );
-}
-
-function hasPostgresErrorCode(error: unknown, code: string) {
-  return (
-    typeof error === "object" &&
-    error !== null &&
-    "code" in error &&
-    error.code === code
-  );
-}
-
-function getSanitizedDbErrorDetails(error: unknown) {
-  if (typeof error !== "object" || error === null) {
-    return {
-      errorName: "UnknownError",
-      errorCode: "unknown",
-      constraintName: null,
-      tableName: null,
-      columnName: null,
-    };
-  }
-
-  const err = error as {
-    name?: unknown;
-    code?: unknown;
-    constraint_name?: unknown;
-    table_name?: unknown;
-    column_name?: unknown;
-  };
-
-  return {
-    errorName: typeof err.name === "string" ? err.name : "UnknownError",
-    errorCode: typeof err.code === "string" ? err.code : "unknown",
-    constraintName:
-      typeof err.constraint_name === "string" ? err.constraint_name : null,
-    tableName: typeof err.table_name === "string" ? err.table_name : null,
-    columnName: typeof err.column_name === "string" ? err.column_name : null,
-  };
-}
-
 function getErrorName(error: unknown) {
   if (error instanceof Error) {
     return error.name || "Error";
@@ -306,11 +270,6 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       !!options.updateAdminSessionLastAccess &&
       !!options.hashSessionToken &&
       !!options.hashPassword &&
-      !!options.listAdminClinics &&
-      !!options.createAdminClinicWithUser &&
-      !!options.getAdminClinicById &&
-      !!options.updateAdminClinic &&
-      !!options.deleteAdminClinic &&
       !!options.writeAuditLog;
     const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
 
@@ -326,17 +285,11 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       hashSessionToken:
         options.hashSessionToken ?? defaultDeps!.hashSessionToken,
       hashPassword: options.hashPassword ?? defaultDeps!.hashPassword,
-      listAdminClinics:
-        options.listAdminClinics ?? defaultDeps!.listAdminClinics,
-      createAdminClinicWithUser:
-        options.createAdminClinicWithUser ??
-        defaultDeps!.createAdminClinicWithUser,
-      getAdminClinicById:
-        options.getAdminClinicById ?? defaultDeps!.getAdminClinicById,
-      updateAdminClinic:
-        options.updateAdminClinic ?? defaultDeps!.updateAdminClinic,
-      deleteAdminClinic:
-        options.deleteAdminClinic ?? defaultDeps!.deleteAdminClinic,
+      listAdminClinics: options.listAdminClinics,
+      createAdminClinicWithUser: options.createAdminClinicWithUser,
+      getAdminClinicById: options.getAdminClinicById,
+      updateAdminClinic: options.updateAdminClinic,
+      deleteAdminClinic: options.deleteAdminClinic,
       writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
     };
   }
@@ -405,7 +358,18 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
 
       return reply
         .code(200)
-        .send(await deps.listAdminClinics({ limit, offset, ...(search ? { search } : {}) }));
+        .send(
+          await listAdminClinicsQuery(
+            {
+              limit,
+              offset,
+              ...(search ? { search } : {}),
+            },
+            {
+              listAdminClinics: deps.listAdminClinics,
+            },
+          ),
+        );
     },
   );
 
@@ -436,16 +400,22 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       }
 
       try {
-        const passwordHash = await deps.hashPassword(parsed.data.password);
-        const result = await deps.createAdminClinicWithUser({
-          clinicName: parsed.data.clinicName,
-          contactEmail: parsed.data.contactEmail,
-          contactPhone: parsed.data.contactPhone,
-          username: parsed.data.username,
-          passwordHash,
-          role: parsed.data.role,
-          now: new Date(now()),
-        });
+        const result = await createAdminClinicCommand(
+          {
+            clinicName: parsed.data.clinicName,
+            contactEmail: parsed.data.contactEmail,
+            contactPhone: parsed.data.contactPhone,
+            username: parsed.data.username,
+            password: parsed.data.password,
+            role: parsed.data.role,
+            now: new Date(now()),
+          },
+          {
+            hashPassword: deps.hashPassword,
+            createAdminClinicWithUser:
+              deps.createAdminClinicWithUser,
+          },
+        );
 
         if (!result.ok && result.reason === "username_conflict") {
           return reply.code(409).send({
@@ -491,18 +461,21 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
           },
         });
       } catch (error) {
-        if (isUniqueViolation(error)) {
+        const classified =
+          classifyAdminClinicsPostgresError(error);
+
+        if (classified.kind === "username_conflict") {
           return reply.code(409).send({
             success: false,
             error: "El usuario de acceso ya existe.",
           });
         }
 
-        if (hasPostgresErrorCode(error, "23502")) {
+        if (classified.kind === "schema_mismatch") {
           console.error("[ADMIN_CLINICS_CREATE_SCHEMA_MISMATCH]", {
             requestPath: request.url,
             adminUserId: admin.id,
-            ...getSanitizedDbErrorDetails(error),
+            ...classified.metadata,
           });
 
           return reply.code(500).send({
@@ -553,13 +526,18 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const clinic = await deps.updateAdminClinic({
-      clinicId,
-      clinicName: parsed.data.clinicName,
-      contactEmail: parsed.data.contactEmail,
-      contactPhone: parsed.data.contactPhone,
-      now: new Date(now()),
-    });
+    const clinic = await updateAdminClinicCommand(
+      {
+        clinicId,
+        clinicName: parsed.data.clinicName,
+        contactEmail: parsed.data.contactEmail,
+        contactPhone: parsed.data.contactPhone,
+        now: new Date(now()),
+      },
+      {
+        updateAdminClinic: deps.updateAdminClinic,
+      },
+    );
 
     if (!clinic) {
       return reply.code(404).send({
@@ -625,34 +603,29 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const clinic = await deps.getAdminClinicById(clinicId);
-
-    if (!clinic) {
-      return reply.code(404).send({
-        success: false,
-        error: "Clínica no encontrada.",
-      });
-    }
-
-    if (!confirmClinicNameMatches(parsedDelete.confirmClinicName, clinic.clinicName)) {
-      return reply.code(400).send({
-        success: false,
-        error:
-          "La confirmación no coincide con el nombre exacto de la clínica.",
-      });
-    }
-
-    let deletedClinic: AdminClinicSummary | null;
+    let deletionResult;
 
     try {
-      deletedClinic = await deps.deleteAdminClinic({ clinicId });
+      deletionResult = await deleteAdminClinicCommand(
+        {
+          clinicId,
+          confirmClinicName: parsedDelete.confirmClinicName,
+        },
+        {
+          getAdminClinicById: deps.getAdminClinicById,
+          deleteAdminClinic: deps.deleteAdminClinic,
+        },
+      );
     } catch (error) {
-      if (hasPostgresErrorCode(error, "23503")) {
+      const classified =
+        classifyAdminClinicsPostgresError(error);
+
+      if (classified.kind === "active_dependency") {
         console.error("[ADMIN_CLINICS_DELETE_DEPENDENCY_BLOCK]", {
           requestPath: request.url,
           clinicId,
           adminUserId: admin.id,
-          ...getSanitizedDbErrorDetails(error),
+          ...classified.metadata,
         });
 
         return reply.code(409).send({
@@ -665,12 +638,22 @@ export const adminClinicsNativeRoutes: FastifyPluginAsync<
       throw error;
     }
 
-    if (!deletedClinic) {
-      return reply.code(404).send({
+    if (!deletionResult.ok) {
+      if (deletionResult.reason === "not_found") {
+        return reply.code(404).send({
+          success: false,
+          error: "Clínica no encontrada.",
+        });
+      }
+
+      return reply.code(400).send({
         success: false,
-        error: "Clínica no encontrada.",
+        error:
+          "La confirmación no coincide con el nombre exacto de la clínica.",
       });
     }
+
+    const deletedClinic = deletionResult.clinic;
 
     await safeWriteAuditLog(deps, request, admin, {
       event: AUDIT_EVENTS.CLINIC_DELETED,

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -24,7 +24,10 @@ import type {
 import type {
   AdminClinicUserCredentialsUpdateInput,
   AdminClinicUserCredentialsUpdateResult,
-} from "../db-admin-clinics.ts";
+} from "../features/clinics/admin-clinics-command-service.ts";
+import {
+  updateAdminClinicUserCredentialsCommand,
+} from "../features/clinics/admin-clinics-command-service.ts";
 
 type AdminClinicUserRole = Exclude<AdminRoleUserRole, "admin">;
 
@@ -96,7 +99,7 @@ export type AdminUsersRolesNativeRoutesOptions = {
   now?: () => number;
 };
 
-type NativeAdminUsersRolesDeps = Required<
+type NativeAdminUsersRolesCoreDeps = Required<
   Pick<
     AdminUsersRolesNativeRoutesOptions,
     | "deleteAdminSession"
@@ -105,22 +108,29 @@ type NativeAdminUsersRolesDeps = Required<
     | "hashSessionToken"
     | "getAdminUsersRolesSnapshot"
     | "changeClinicUserRole"
-    | "updateAdminClinicUserCredentials"
     | "hashPassword"
     | "writeAuditLog"
   >
 >;
 
-let defaultDepsPromise: Promise<NativeAdminUsersRolesDeps> | undefined;
+type NativeAdminUsersRolesDeps =
+  NativeAdminUsersRolesCoreDeps &
+    Pick<
+      AdminUsersRolesNativeRoutesOptions,
+      "updateAdminClinicUserCredentials"
+    >;
 
-async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
+let defaultDepsPromise:
+  | Promise<NativeAdminUsersRolesCoreDeps>
+  | undefined;
+
+async function loadDefaultDeps(): Promise<NativeAdminUsersRolesCoreDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const audit = await import("../lib/audit.ts");
       const usersRoles = await import("../db-admin-users-roles.ts");
-      const adminClinics = await import("../db-admin-clinics.ts");
 
       return {
         deleteAdminSession: db.deleteAdminSession,
@@ -129,8 +139,6 @@ async function loadDefaultDeps(): Promise<NativeAdminUsersRolesDeps> {
         hashSessionToken: authSecurity.hashSessionToken,
         getAdminUsersRolesSnapshot: usersRoles.getAdminUsersRolesSnapshot,
         changeClinicUserRole: usersRoles.changeClinicUserRole,
-        updateAdminClinicUserCredentials:
-          adminClinics.updateAdminClinicUserCredentials,
         hashPassword: authSecurity.hashPassword,
         writeAuditLog: audit.writeAuditLog as (
           req: unknown,
@@ -376,7 +384,6 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       !!options.hashSessionToken &&
       !!options.getAdminUsersRolesSnapshot &&
       !!options.changeClinicUserRole &&
-      !!options.updateAdminClinicUserCredentials &&
       !!options.hashPassword &&
       !!options.writeAuditLog;
 
@@ -399,8 +406,7 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       changeClinicUserRole:
         options.changeClinicUserRole ?? defaultDeps!.changeClinicUserRole,
       updateAdminClinicUserCredentials:
-        options.updateAdminClinicUserCredentials ??
-        defaultDeps!.updateAdminClinicUserCredentials,
+        options.updateAdminClinicUserCredentials,
       hashPassword: options.hashPassword ?? defaultDeps!.hashPassword,
       writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
     };
@@ -588,15 +594,20 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const passwordHash = parsed.data.password
-      ? await deps.hashPassword(parsed.data.password)
-      : undefined;
-    const result = await deps.updateAdminClinicUserCredentials({
-      clinicUserId,
-      username: parsed.data.username,
-      passwordHash,
-      now: new Date(now()),
-    });
+    const result =
+      await updateAdminClinicUserCredentialsCommand(
+        {
+          clinicUserId,
+          username: parsed.data.username,
+          password: parsed.data.password,
+          now: new Date(now()),
+        },
+        {
+          hashPassword: deps.hashPassword,
+          updateAdminClinicUserCredentials:
+            deps.updateAdminClinicUserCredentials,
+        },
+      );
 
     if (!result.ok && result.reason === "not_found") {
       return reply.code(404).send({

--- a/test/architecture/clinics-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/clinics-infrastructure-boundary-guard.test.ts
@@ -14,6 +14,10 @@ const repositoryFile =
 const barrelFile = infrastructureDir + "/index.ts";
 const legacyShimFile =
   ["server", "db-admin-clinics.ts"].join("/");
+const queryServiceFile =
+  featureDir + "/admin-clinics-query-service.ts";
+const commandServiceFile =
+  featureDir + "/admin-clinics-command-service.ts";
 const applicationDir = featureDir + "/application";
 
 const routeConsumers = [
@@ -172,7 +176,7 @@ test(
 );
 
 test(
-  "El barrel y el shim son re-exports mínimos",
+  "El barrel permanece canónico y el shim fue retirado",
   () => {
     const barrelLines = stripComments(
       readText(barrelFile),
@@ -185,24 +189,10 @@ test(
       'export * from "./admin-clinics-repository.ts";',
     ]);
 
-    const shimLines = stripComments(
-      readText(legacyShimFile),
-    )
-      .split("\n")
-      .map((line) => line.trim())
-      .filter(Boolean);
-
-    assert.deepEqual(shimLines, [
-      'export * from "./features/clinics/infrastructure/index.ts";',
-    ]);
-
-    const targets = listImportSpecifiers(
-      readText(legacyShimFile),
-    ).map((specifier) =>
-      resolveSpecifier(legacyShimFile, specifier),
+    assert.equal(
+      existsSync(join(repoRoot, legacyShimFile)),
+      false,
     );
-
-    assert.deepEqual(targets, [barrelFile]);
   },
 );
 
@@ -413,9 +403,62 @@ test(
   },
 );
 
+test("Los servicios directos Clinics existen sin application", () => {
+  assert.equal(existsSync(join(repoRoot, queryServiceFile)), true);
+  assert.equal(existsSync(join(repoRoot, commandServiceFile)), true);
+  assert.equal(existsSync(join(repoRoot, applicationDir)), false);
+});
+
 test(
-  "Las rutas siguen consumiendo el shim durante M26",
+  "Los servicios consumen infrastructure canónica sin transporte, auditoría, CORS ni auth",
   () => {
+    for (const serviceFile of [
+      queryServiceFile,
+      commandServiceFile,
+    ]) {
+      const source = readText(serviceFile);
+      const targets = listImportSpecifiers(source).map(
+        (specifier) =>
+          resolveSpecifier(serviceFile, specifier),
+      );
+
+      assert.ok(targets.includes(barrelFile), serviceFile);
+      assert.equal(targets.includes(legacyShimFile), false);
+      assert.equal(targets.includes(repositoryFile), false);
+
+      for (const forbidden of [
+        "Fastify",
+        "AUDIT_EVENTS",
+        "writeAuditLog",
+        "getAllowedOrigins",
+        "enforceTrustedOrigin",
+        "authenticateFastifyAdmin",
+        "auth-security",
+      ]) {
+        assert.equal(
+          source.includes(forbidden),
+          false,
+          `${serviceFile}: ${forbidden}`,
+        );
+      }
+    }
+  },
+);
+
+test(
+  "Las rutas consumen servicios, nunca infrastructure ni el shim",
+  () => {
+    const expectedServices = new Map([
+      [
+        "server/routes/admin-clinics.fastify.ts",
+        [queryServiceFile, commandServiceFile],
+      ],
+      [
+        "server/routes/admin-users-roles.fastify.ts",
+        [commandServiceFile],
+      ],
+    ]);
+
     for (const routeFile of routeConsumers) {
       const targets = listImportSpecifiers(
         readText(routeFile),
@@ -423,13 +466,58 @@ test(
         resolveSpecifier(routeFile, specifier),
       );
 
-      assert.ok(
-        targets.includes(legacyShimFile),
+      for (const serviceFile of expectedServices.get(routeFile) ?? []) {
+        assert.ok(
+          targets.includes(serviceFile),
+          `${routeFile}: ${serviceFile}`,
+        );
+      }
+
+      assert.equal(targets.includes(legacyShimFile), false);
+      assert.equal(targets.includes(repositoryFile), false);
+      assert.equal(targets.includes(barrelFile), false);
+    }
+  },
+);
+
+test(
+  "Las rutas no vuelven a llamar inline los métodos DB Clinics",
+  () => {
+    const directCallPattern =
+      /\bdeps\.(?:listAdminClinics|createAdminClinicWithUser|getAdminClinicById|updateAdminClinic|deleteAdminClinic|updateAdminClinicUserCredentials)\s*\(/g;
+
+    for (const routeFile of routeConsumers) {
+      assert.deepEqual(
+        readText(routeFile).match(directCallPattern) ?? [],
+        [],
+        routeFile,
       );
-      assert.equal(
-        targets.includes(repositoryFile),
-        false,
-      );
+    }
+  },
+);
+
+test(
+  "admin-users-roles delega sólo el comando Clinics de credenciales",
+  () => {
+    const source = readText(
+      "server/routes/admin-users-roles.fastify.ts",
+    );
+
+    assert.equal(
+      source.match(
+        /\bupdateAdminClinicUserCredentialsCommand\s*\(/g,
+      )?.length ?? 0,
+      1,
+    );
+
+    for (const unrelatedCommand of [
+      "createAdminClinicCommand",
+      "updateAdminClinicCommand",
+      "deleteAdminClinicCommand",
+      "listAdminClinicsQuery",
+      "getAdminClinicQuery",
+    ]) {
+      assert.equal(source.includes(unrelatedCommand), false);
     }
   },
 );
@@ -454,7 +542,7 @@ test(
 );
 
 test(
-  "M26 no anticipa application",
+  "M27 no crea application",
   () => {
     assert.equal(
       existsSync(join(repoRoot, applicationDir)),

--- a/test/integration/adapters/controllers/admin-clinics.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-clinics.fastify.test.ts
@@ -19,10 +19,10 @@ type AdminClinicsNativeRoutesOptions = import(
   "../../../../server/routes/admin-clinics.fastify.ts"
 ).AdminClinicsNativeRoutesOptions;
 type AdminClinicCreateResult = import(
-  "../../../../server/db-admin-clinics.ts"
+  "../../../../server/features/clinics/admin-clinics-command-service.ts"
 ).AdminClinicCreateResult;
 type AdminClinicSummary = import(
-  "../../../../server/db-admin-clinics.ts"
+  "../../../../server/features/clinics/admin-clinics-query-service.ts"
 ).AdminClinicSummary;
 
 const demoClinic: AdminClinicSummary = {

--- a/test/integration/adapters/controllers/admin-users-roles.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-users-roles.fastify.test.ts
@@ -32,7 +32,7 @@ type AdminClinicUserRoleChangeResult = import(
   "../../../../server/db-admin-users-roles.ts"
 ).AdminClinicUserRoleChangeResult;
 type AdminClinicUserCredentialsUpdateResult = import(
-  "../../../../server/db-admin-clinics.ts"
+  "../../../../server/features/clinics/admin-clinics-command-service.ts"
 ).AdminClinicUserCredentialsUpdateResult;
 const STAGING_ORIGIN = "https://portal-vetneb-frontend-staging.onrender.com";
 

--- a/test/unit/clinics/admin-clinics-command-service.test.ts
+++ b/test/unit/clinics/admin-clinics-command-service.test.ts
@@ -1,0 +1,287 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  classifyAdminClinicsPostgresError,
+  createAdminClinicCommand,
+  deleteAdminClinicCommand,
+  updateAdminClinicCommand,
+  updateAdminClinicUserCredentialsCommand,
+  type AdminClinicCreateInput,
+  type AdminClinicCreateResult,
+  type AdminClinicSummary,
+  type AdminClinicUserCredentialsUpdateInput,
+  type AdminClinicUserCredentialsUpdateResult,
+} from "../../../server/features/clinics/admin-clinics-command-service.ts";
+
+const clinic: AdminClinicSummary = {
+  clinicId: 17,
+  clinicName: "Clínica Norte",
+  contactEmail: "norte@example.test",
+  contactPhone: null,
+  createdAt: "2026-07-23T00:00:00.000Z",
+  updatedAt: "2026-07-23T00:00:00.000Z",
+};
+
+const clinicUser = {
+  userType: "clinic" as const,
+  userId: 29,
+  username: "clinic-norte",
+  role: "clinic_owner" as const,
+  clinicId: 17,
+  clinicName: "Clínica Norte",
+  createdAt: "2026-07-23T00:00:00.000Z",
+  updatedAt: "2026-07-23T00:00:00.000Z",
+};
+
+test("createAdminClinicCommand hashea una vez y persiste passwordHash", async () => {
+  const calls: string[] = [];
+  let persistedInput: AdminClinicCreateInput | undefined;
+  const expectedResult: AdminClinicCreateResult = {
+    ok: true,
+    clinic,
+    user: clinicUser,
+  };
+
+  const result = await createAdminClinicCommand(
+    {
+      clinicName: clinic.clinicName,
+      contactEmail: "norte@example.test",
+      contactPhone: null,
+      username: "clinic-norte",
+      password: "password-for-test",
+      role: "clinic_owner",
+      now: new Date("2026-07-23T00:00:00.000Z"),
+    },
+    {
+      hashPassword: async (password) => {
+        calls.push(`hash:${password}`);
+        return "hashed-for-test";
+      },
+      createAdminClinicWithUser: async (input) => {
+        calls.push("persist");
+        persistedInput = input;
+        return expectedResult;
+      },
+    },
+  );
+
+  assert.deepEqual(calls, [
+    "hash:password-for-test",
+    "persist",
+  ]);
+  assert.equal(persistedInput?.passwordHash, "hashed-for-test");
+  assert.equal("password" in (persistedInput ?? {}), false);
+  assert.strictEqual(result, expectedResult);
+});
+
+test("updateAdminClinicCommand delega sin mutar el input", async () => {
+  const input = {
+    clinicId: 17,
+    clinicName: "Clínica Norte Actualizada",
+    now: new Date("2026-07-23T12:00:00.000Z"),
+  };
+  let receivedInput: unknown;
+
+  const result = await updateAdminClinicCommand(input, {
+    updateAdminClinic: async (received) => {
+      receivedInput = received;
+      return clinic;
+    },
+  });
+
+  assert.strictEqual(receivedInput, input);
+  assert.strictEqual(result, clinic);
+});
+
+test("deleteAdminClinicCommand no elimina cuando la clínica no existe", async () => {
+  let deleteCalls = 0;
+
+  const result = await deleteAdminClinicCommand(
+    {
+      clinicId: 404,
+      confirmClinicName: clinic.clinicName,
+    },
+    {
+      getAdminClinicById: async () => null,
+      deleteAdminClinic: async () => {
+        deleteCalls += 1;
+        return clinic;
+      },
+    },
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    reason: "not_found",
+  });
+  assert.equal(deleteCalls, 0);
+});
+
+test("deleteAdminClinicCommand exige confirmación exacta antes de eliminar", async () => {
+  let deleteCalls = 0;
+
+  const result = await deleteAdminClinicCommand(
+    {
+      clinicId: 17,
+      confirmClinicName: "clinica norte",
+    },
+    {
+      getAdminClinicById: async () => clinic,
+      deleteAdminClinic: async () => {
+        deleteCalls += 1;
+        return clinic;
+      },
+    },
+  );
+
+  assert.deepEqual(result, {
+    ok: false,
+    reason: "confirmation_mismatch",
+  });
+  assert.equal(deleteCalls, 0);
+});
+
+test("deleteAdminClinicCommand respeta el orden get y delete", async () => {
+  const calls: string[] = [];
+
+  const result = await deleteAdminClinicCommand(
+    {
+      clinicId: 17,
+      confirmClinicName: clinic.clinicName,
+    },
+    {
+      getAdminClinicById: async () => {
+        calls.push("get");
+        return clinic;
+      },
+      deleteAdminClinic: async () => {
+        calls.push("delete");
+        return clinic;
+      },
+    },
+  );
+
+  assert.deepEqual(calls, ["get", "delete"]);
+  assert.deepEqual(result, {
+    ok: true,
+    clinic,
+  });
+});
+
+test("updateAdminClinicUserCredentialsCommand hashea cuando recibe password", async () => {
+  let hashCalls = 0;
+  let persistedInput:
+    | AdminClinicUserCredentialsUpdateInput
+    | undefined;
+  const expectedResult: AdminClinicUserCredentialsUpdateResult = {
+    ok: true,
+    user: clinicUser,
+    previousUsername: "clinic-norte",
+    usernameChanged: false,
+    credentialUpdated: true,
+  };
+
+  const result =
+    await updateAdminClinicUserCredentialsCommand(
+      {
+        clinicUserId: 29,
+        username: "clinic-norte",
+        password: "new-password-for-test",
+      },
+      {
+        hashPassword: async () => {
+          hashCalls += 1;
+          return "new-hash-for-test";
+        },
+        updateAdminClinicUserCredentials: async (input) => {
+          persistedInput = input;
+          return expectedResult;
+        },
+      },
+    );
+
+  assert.equal(hashCalls, 1);
+  assert.equal(
+    persistedInput?.passwordHash,
+    "new-hash-for-test",
+  );
+  assert.strictEqual(result, expectedResult);
+});
+
+test("updateAdminClinicUserCredentialsCommand no hashea sin password", async () => {
+  let hashCalls = 0;
+  let persistedInput:
+    | AdminClinicUserCredentialsUpdateInput
+    | undefined;
+
+  await updateAdminClinicUserCredentialsCommand(
+    {
+      clinicUserId: 29,
+      username: "clinic-norte-next",
+    },
+    {
+      hashPassword: async () => {
+        hashCalls += 1;
+        return "unused";
+      },
+      updateAdminClinicUserCredentials: async (input) => {
+        persistedInput = input;
+        return {
+          ok: false,
+          reason: "not_found",
+        };
+      },
+    },
+  );
+
+  assert.equal(hashCalls, 0);
+  assert.equal(persistedInput?.passwordHash, undefined);
+  assert.equal("password" in (persistedInput ?? {}), false);
+});
+
+test("classifyAdminClinicsPostgresError clasifica 23505", () => {
+  assert.equal(
+    classifyAdminClinicsPostgresError({
+      code: "23505",
+    }).kind,
+    "username_conflict",
+  );
+});
+
+test("classifyAdminClinicsPostgresError clasifica 23502 y 23503", () => {
+  assert.equal(
+    classifyAdminClinicsPostgresError({
+      code: "23502",
+    }).kind,
+    "schema_mismatch",
+  );
+  assert.equal(
+    classifyAdminClinicsPostgresError({
+      code: "23503",
+    }).kind,
+    "active_dependency",
+  );
+});
+
+test("classifyAdminClinicsPostgresError sanitiza metadata técnica", () => {
+  const classified = classifyAdminClinicsPostgresError({
+    name: "DatabaseError",
+    code: "23503",
+    constraint_name: "reports_clinic_id_fkey",
+    table_name: "reports",
+    column_name: "clinic_id",
+    detail: "sensitive detail",
+    message: "sensitive message",
+  });
+  const serialized = JSON.stringify(classified.metadata);
+
+  assert.deepEqual(classified.metadata, {
+    errorName: "DatabaseError",
+    errorCode: "23503",
+    constraintName: "reports_clinic_id_fkey",
+    tableName: "reports",
+    columnName: "clinic_id",
+  });
+  assert.doesNotMatch(serialized, /detail|message|sensitive/);
+});

--- a/test/unit/clinics/admin-clinics-query-service.test.ts
+++ b/test/unit/clinics/admin-clinics-query-service.test.ts
@@ -1,0 +1,66 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getAdminClinicQuery,
+  listAdminClinicsQuery,
+  type AdminClinicSummary,
+  type AdminClinicsSnapshot,
+} from "../../../server/features/clinics/admin-clinics-query-service.ts";
+
+const clinic: AdminClinicSummary = {
+  clinicId: 17,
+  clinicName: "Clínica Norte",
+  contactEmail: "norte@example.test",
+  contactPhone: null,
+  createdAt: "2026-07-23T00:00:00.000Z",
+  updatedAt: "2026-07-23T00:00:00.000Z",
+};
+
+test("listAdminClinicsQuery delega los params exactos y retorna el snapshot exacto", async () => {
+  const params = {
+    limit: 25,
+    offset: 50,
+    search: "norte",
+  };
+  const snapshot: AdminClinicsSnapshot = {
+    success: true,
+    clinics: [{ ...clinic, users: [] }],
+    total: 1,
+    limit: 25,
+    offset: 50,
+  };
+  let receivedParams: unknown;
+
+  const result = await listAdminClinicsQuery(params, {
+    listAdminClinics: async (input) => {
+      receivedParams = input;
+      return snapshot;
+    },
+  });
+
+  assert.strictEqual(receivedParams, params);
+  assert.strictEqual(result, snapshot);
+});
+
+test("getAdminClinicQuery retorna la clínica encontrada sin transformarla", async () => {
+  let receivedClinicId: number | undefined;
+
+  const result = await getAdminClinicQuery(17, {
+    getAdminClinicById: async (clinicId) => {
+      receivedClinicId = clinicId;
+      return clinic;
+    },
+  });
+
+  assert.equal(receivedClinicId, 17);
+  assert.strictEqual(result, clinic);
+});
+
+test("getAdminClinicQuery preserva not-found", async () => {
+  const result = await getAdminClinicQuery(404, {
+    getAdminClinicById: async () => null,
+  });
+
+  assert.equal(result, null);
+});

--- a/test/unit/infrastructure/global-performance-resilience-contract.test.ts
+++ b/test/unit/infrastructure/global-performance-resilience-contract.test.ts
@@ -18,9 +18,8 @@ type HeavySurface = {
 
 const HEAVY_SURFACES: readonly HeavySurface[] = [
   {
-    // M26: Clinics canonical persistence lives in the context
-    // infrastructure layer; server/db-admin-clinics.ts is a compatibility
-    // shim. This contract measures the real implementation.
+    // M27: Clinics canonical persistence remains in the context
+    // infrastructure layer after the compatibility shim was retired.
     file: "server/features/clinics/infrastructure/admin-clinics-repository.ts",
     markers: ["normalizeListPagination", ".limit(limit)", ".offset(offset)"],
   },


### PR DESCRIPTION
## Summary

Introduces direct Clinics query and command services so the administrative
Fastify routes delegate business orchestration to the Clinics context while
retaining HTTP, authentication, CORS, audit and response mapping.

The temporary `server/db-admin-clinics.ts` compatibility shim is removed after
all operational and test consumers are repointed.

The canonical Clinics repository remains byte-identical and retains its two
transaction boundaries.

## Scope

- [x] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [ ] Scripts/tooling
- [ ] Repository configuration
- [ ] Other
- [ ] Mixed-scope exception

## Validation

- Exact fourteen-path allowlist: PASS.
- Runtime typecheck: PASS.
- Test typecheck: PASS.
- Directed M27 cohort: 167 PASS, 0 FAIL.
- Full suite: 3512 PASS, 0 FAIL, 1 preexisting SKIP.
- Backend build: PASS.
- `pnpm validate:local`: PASS.
- `pnpm security:public-surface`: PASS.
- `git diff --check`: PASS.
- Canonical repository hash unchanged: PASS.
- Repository transaction boundaries: exactly 2.
- Legacy shim imports in `server` and `test`: 0.
- Direct route imports from Clinics infrastructure: 0.
- Open pull requests before publication: 0.

## Quality Gate Impact

- Adds unit coverage for the direct Clinics query and command services.
- Updates the Clinics architecture guard for service delegation and shim
  retirement.
- Preserves existing integration coverage for both administrative routes.
- Repoints source-only contracts without removing or weakening expectations.
- Does not skip, remove or weaken any quality gate.

## Rollback

Revert this PR to restore the temporary compatibility shim and return query and
command orchestration to the administrative routes.

Rollback requires no schema migration, data migration, dependency change,
credential rotation or HTTP contract change.