### PR TITLE
refactor(study-tracking): close phase architecture

### DIFF
--- a/docs/implementation/m35-study-tracking-phase-closeout.md
+++ b/docs/implementation/m35-study-tracking-phase-closeout.md
@@ -1,0 +1,286 @@
+# M35 — Study Tracking phase closeout
+
+## Identificación
+
+- Milestone: M35, cierre de Fase G — Study Tracking.
+- Rama: `refactor/backend-modularization-m35-study-tracking-phase-closeout`.
+- Base exacta: `9ef2621875429b788a0260aae65dd7eb3753db23`
+  (`refactor(study-tracking): thin admin route (#1567)`).
+- Instrucciones aplicables: `AGENTS.md` raíz; no existen instrucciones
+  anidadas.
+- Naturaleza: tests, guards y documentación, más retiro de dos shims de dominio
+  sin consumidores. Cero cambios de comportamiento en runtime.
+
+M35 cierra M30, M31, M32 y M32b. Los PR históricos son #1564, #1565, #1566 y
+#1567. No inicia M33, M34, M35b ni Reports.
+
+## Censo legacy y decisión
+
+El censo combinó `rg`, `git grep` y AST TypeScript sobre imports estáticos,
+exports, `import()` y `require()`.
+
+| Clase | Resultado |
+| --- | --- |
+| Runtime | Cero consumidores de los shims domain; tres consumidores externos del shim DB |
+| Tests ejecutables | Dominio y application consumen sus barrels canónicos; ningún test necesita los shims domain |
+| Guards source-only | El guard domain se invierte a path ausente; el guard M35 congela el resultado |
+| Documentación canónica | Este documento y los README del feature reflejan el estado final |
+| Menciones históricas | M30–M32b, auditorías y `docs/pr-history` se conservan como historia |
+| Paths inexistentes/comentarios | No cuentan como consumidores runtime |
+
+### Shims de dominio
+
+Antes:
+
+- `server/lib/study-tracking.ts`: reexport de una línea al barrel domain;
+- `server/lib/token-study-tracking.ts`: el mismo reexport;
+- consumidores ejecutables reales: 0.
+
+Después: ambos paths están ausentes y los guards prohíben recrearlos o
+importarlos. Los seis consumidores runtime del dominio ya usan
+`server/features/study-tracking/domain/index.ts`.
+
+### Shim de persistencia
+
+`server/db-study-tracking.ts` se conserva sin cambios como reexport de una
+línea:
+
+```ts
+export * from "./features/study-tracking/infrastructure/index.ts";
+```
+
+Allowlist residual exacta:
+
+| Consumidor | Owner | Milestone de retiro |
+| --- | --- | --- |
+| `server/routes/admin-particular-tokens.fastify.ts` | Particular Access | M33 |
+| `server/routes/particular-tokens.fastify.ts` | Particular Access | M33 |
+| `server/routes/admin-reports.fastify.ts` | Reports | M36 |
+
+No existe un cuarto consumidor. Las tres rutas propias de Study Tracking tienen
+cero imports del shim y cero imports directos de infrastructure.
+
+La afirmación de cierre es: cero imports legacy dentro de las superficies
+propias de Study Tracking y un shim DB residual controlado para consumidores
+externos pendientes. No se afirma cero paths legacy globales.
+
+## Arquitectura final
+
+```text
+server/features/study-tracking/
+  domain/
+    index.ts
+    study-tracking.ts
+    token-study-tracking.ts
+  application/
+    index.ts
+    *-operations.ts
+    *-use-cases.ts
+    ports/*.ts
+  infrastructure/
+    index.ts
+    study-tracking-repository.ts
+  study-tracking-route-composition.ts
+```
+
+- Domain: reglas, schemas, fechas, etapas, serialización y coordinación pura
+  con persistencia inyectada; cero Fastify, DB, Drizzle runtime, email,
+  auditoría, application o infrastructure.
+- Application: puertos type-only, casos de uso y operaciones por realm; cero
+  Fastify, DB, Drizzle, schema o infrastructure concreta. Los side effects
+  atraviesan únicamente los puertos de notificación y auditoría.
+- Infrastructure: repository canónico único con 13 funciones públicas,
+  queries, filtros, orden, paginación y timestamps preservados; cero HTTP,
+  auth, email, auditoría o application. Transacciones: 0.
+- Composition: único seam autorizado desde las rutas hacia el barrel de
+  infrastructure. Exporta cargas clinic, particular y admin; no contiene
+  queries, reglas, Fastify, auth, validación ni estado global mutable.
+
+Inventario exacto del feature: 23 archivos (19 TypeScript y 4 README).
+
+## Rutas, hashes, endpoints y Options
+
+Los SHA-256 iniciales y finales deben coincidir:
+
+| Ruta | SHA-256 |
+| --- | --- |
+| `server/routes/study-tracking.fastify.ts` | `2ce07bd8abb818b39bc2369095f71e19b5b1bd2a1dcba38f7848acaf349507b1` |
+| `server/routes/particular-study-tracking.fastify.ts` | `ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb` |
+| `server/routes/admin-study-tracking.fastify.ts` | `c93824a2a7f2866c658e00304964927cbfc981b5b9c2046860657a6feb89c589` |
+
+### Clínica
+
+Endpoints: `GET /`, `GET /:trackingCaseId`, `POST /`, `GET /notifications`,
+`PATCH /notifications/:notificationId/read`,
+`PATCH /notifications/read-all` y cinco OPTIONS.
+
+Options (22): `deleteActiveSession`, `getActiveSessionByToken`,
+`getClinicUserById`, `updateSessionLastAccess`, `hashSessionToken`,
+`getClinicById`, `getReportById`, `getClinicScopedReportById`,
+`getParticularTokenById`, `updateParticularTokenReport`,
+`createStudyTrackingCase`, `updateStudyTrackingCase`,
+`getClinicScopedStudyTrackingCase`, `listStudyTrackingCases`,
+`createStudyTrackingNotification`, `listStudyTrackingNotifications`,
+`markStudyTrackingNotificationReadScoped`,
+`markAllStudyTrackingNotificationsReadScoped`,
+`sendSpecialStainRequiredEmail`, `writeAuditLog`, `now`, `createDate`.
+
+### Particular
+
+Endpoints: `GET /me`, `GET /notifications`,
+`PATCH /notifications/:notificationId/read`,
+`PATCH /notifications/read-all` y cuatro OPTIONS.
+
+Options (10): `deleteParticularSession`, `getParticularSessionByToken`,
+`getParticularTokenById`, `updateParticularSessionLastAccess`,
+`hashSessionToken`, `getParticularStudyTrackingCase`,
+`listStudyTrackingNotifications`,
+`markStudyTrackingNotificationReadScoped`,
+`markAllStudyTrackingNotificationsReadScoped`, `now`.
+
+### Admin
+
+Endpoints: `GET /`, `GET /:trackingCaseId`, `POST /`,
+`PATCH /:trackingCaseId`, `GET /notifications`,
+`PATCH /notifications/:notificationId/read`,
+`PATCH /notifications/read-all` y cinco OPTIONS.
+
+Options (22): `deleteAdminSession`, `getAdminSessionByToken`,
+`getAdminUserById`, `updateAdminSessionLastAccess`, `hashSessionToken`,
+`getClinicById`, `getReportById`, `getParticularTokenById`,
+`updateParticularTokenReport`, `createStudyTrackingCase`,
+`updateStudyTrackingCase`, `getClinicScopedStudyTrackingCase`,
+`getStudyTrackingCaseById`, `listStudyTrackingCases`,
+`createStudyTrackingNotification`, `listStudyTrackingNotifications`,
+`markStudyTrackingNotificationRead`,
+`markAllStudyTrackingNotificationsRead`,
+`sendSpecialStainRequiredEmail`, `writeAuditLog`, `now`, `createDate`.
+
+## Operations application
+
+- Clínica: list cases, get case, create case, list notifications, mark one,
+  mark all.
+- Particular: `/me`, list notifications, mark one, mark all.
+- Admin: list/get/create/update cases, list notifications, mark one, mark all.
+
+Las diez factories públicas de query, command, side effects y operaciones de
+alto nivel tienen export por barrel, consumidor runtime/application y test
+unitario. Los guards thin fijan las operaciones exactas invocadas por cada
+handler.
+
+## Matriz de autoridad y evidencia cross-tenant
+
+| Realm | Autoridad | Evidencia |
+| --- | --- | --- |
+| Clínica | `clinicId` sólo desde sesión clínica | list/get/notificaciones y acknowledgements reciben `auth.clinicId`; report y token se validan clinic-scoped; input `clinicId=999` no reemplaza al actor |
+| Particular | `particularTokenId` sólo desde sesión particular | `/me` y notificaciones reciben el token autenticado; clínica/report derivan del token persistido; input `particularTokenId=999` no reemplaza al actor |
+| Admin | autoridad global con filtro `clinicId` opcional | queries globales o clinic-scoped, ownership report/token, create/update y PATCH body sobre query |
+| Cross-realm | cookies y autenticadores separados | cada integración rechaza con 401 cookies de los otros dos realms |
+
+`CTIDOR-017` enlaza evidencia ejecutable de clínica, particular y admin,
+incluidos los 404 genéricos de notification ownership y los tests unitarios de
+scope. La evidencia de staging queda
+`pending_runtime_staging_evidence`. No se afirma RLS.
+
+## Side effects y auditoría
+
+Create clínica conserva:
+
+1. referencias y ownership;
+2. cálculo de entrega;
+3. creación;
+4. vínculo token/report;
+5. notificación;
+6. timestamp;
+7. email best-effort;
+8. auditoría del caso;
+9. auditoría de notificación;
+10. respuesta.
+
+Create admin conserva validación de referencias, creación, vínculo,
+notificación opcional, timestamp, email best-effort y las dos auditorías antes
+de responder.
+
+Update admin conserva update simple, stage change, tinción requerida, tinción
+resuelta, combinación stage+tinción, vínculo, fallback de timestamp y múltiples
+auditorías. Los payloads, eventos, `createdVia`, `updatedVia`, `fromStage`,
+`toStage`, metadata, null/undefined y errores por identidad permanecen
+protegidos por unit tests e integración.
+
+Sólo SMTP se aísla como best-effort. No hay retry, compensación, outbox,
+transacción nueva ni cambio de destinatarios. El warning por clínica ausente y
+la metadata segura se preservan. Auditoría mantiene actor por realm, event
+names, clinic/report, metadata y propagación de errores.
+
+## Tests y guards M35
+
+- Nuevo `test/architecture/study-tracking-phase-closeout.test.ts`: inventario
+  exacto; shims domain ausentes; shim DB y allowlist; owners/milestones; hashes
+  de rutas; seam de composición; consumers/tests de application; separación de
+  realms; guards existentes y ausencia de M33.
+- Guard domain: invertido de shim existente a paths ausentes y cero imports
+  globales.
+- Suite completeness: registra el guard M35.
+- Integraciones clínica/particular/admin: agregan selectores hostiles y
+  separación cross-realm.
+- Cross-tenant IDOR: agrega `CTIDOR-017` con paths y nombres de evidencia
+  ejecutable.
+
+Los guards existentes de application, infrastructure, thin clinic/particular y
+thin admin mantienen sus invariantes sin duplicarlos en M35.
+
+## Allowlist y denylist
+
+El cambio se limita a shims domain, README canónicos, documento M35, guard M35,
+guard domain, suite completeness, cross-tenant IDOR y las tres integraciones
+Study Tracking. El README infrastructure cambia porque su inventario de
+consumidores estaba desactualizado.
+
+Permanecen sin cambios: tres rutas propias, domain canónico, application,
+repository/infrastructure TypeScript, composition, shim DB, consumidores
+externos, Reports, Particular Access, Report Access, auth, email, auditoría,
+CORS, permisos, schema, migraciones, frontend, manifests, lockfile, scripts,
+workflows y configuración productiva.
+
+## Riesgos, rollback y readiness
+
+- Riesgo residual: el shim DB sigue siendo dependencia externa hasta M33/M36.
+  Mitigación: contenido exacto y allowlist default-deny.
+- Riesgo residual: aislamiento multi-tenant depende de aplicación, no de RLS.
+  Mitigación: integración por realm, operations unitarias, ownership y
+  `CTIDOR-017`.
+- Rollback: revertir el commit M35 restaura únicamente los dos reexports
+  domain y retira tests/docs M35. No requiere migración, schema, compensación o
+  cambio de datos.
+- Evidencia local: se completa en la sección de validación.
+- Runtime staging: pendiente.
+- DB/schema real: no validada en M35.
+- Producción: no ejecutada.
+
+## Validación
+
+| Gate | Estado | Resultado |
+| --- | --- | --- |
+| Guard M35 | PASSED | 9/9, 0 skip/fail, exit code 0 |
+| Guards domain/application/infrastructure + completeness + IDOR | PASSED | 52/52 final, 0 skip/fail, exit code 0 |
+| Cohorte dirigida | PASSED | 42 archivos, 313/313, 0 skip/fail, exit code 0 |
+| `pnpm typecheck` | PASSED | exit code 0 |
+| `pnpm typecheck:test` | PASSED | exit code 0 |
+| `pnpm validate:local` | PASSED | 3.684 tests: 3.683 pass, 1 skip, 0 fail; exit code 0 |
+| Build | PASSED | esbuild, incluido en `validate:local`, exit code 0 |
+| `pnpm security:public-surface` | PASSED | cero findings públicos; dos markers server-only esperados; exit code 0 |
+| `git diff --check` | PASSED | exit code 0 |
+
+La primera corrida de la etapa dirigida terminó FAILED sólo porque el contrato
+completeness exige que su propio source sea ASCII-only y un marcador nuevo
+contenía una letra acentuada. El marcador se normalizó a ASCII; la repetición
+exacta quedó 52/52 PASSED. No hubo fallo runtime ni cambio productivo.
+
+Audits de dependencias, schema/migraciones y frontend E2E no se seleccionan
+porque el diff no modifica esos dominios.
+
+## Estado final
+
+Fase G queda cerrada por evidencia local ejecutable. El cierre remoto se
+completa con el PR M35 y sus checks. El siguiente milestone es M33, no iniciado.
+M35 no afirma merge.

--- a/server/features/study-tracking/README.md
+++ b/server/features/study-tracking/README.md
@@ -1,9 +1,8 @@
 # Study Tracking
 
-Contexto backend abierto en M30 y expandido en M31/M32/M32b como parte de la
-Fase G.
+Bounded context backend cerrado en M35 después de M30, M31, M32 y M32b.
 
-## Estado en M32b
+## Arquitectura final
 
 - `domain/` contiene las reglas existentes de seguimiento de estudios y la
   coordinación pura, con persistencia inyectada, para asegurar el caso asociado
@@ -20,12 +19,18 @@ Fase G.
 - Las rutas clínica, particular y admin ya no importan el shim de persistencia.
   Una composición feature-level mínima selecciona las operaciones canónicas
   sin agregar queries ni lógica.
-- Los otros cuatro consumidores runtime continúan usando el shim.
 - `server/lib/study-tracking.ts` y
-  `server/lib/token-study-tracking.ts` permanecen como shims temporales de una
-  línea. Expiran en M35, después del censo final de Fase G.
-- `server/db-study-tracking.ts` permanece como shim temporal para consumidores
-  que se migrarán con las rutas de sus contextos.
+  `server/lib/token-study-tracking.ts` fueron retirados en M35: el censo
+  textual y AST confirmó cero consumidores ejecutables.
+- `server/db-study-tracking.ts` permanece como shim externo controlado de una
+  línea. Las tres rutas propias no lo consumen y su allowlist residual exacta
+  es:
+
+| Consumidor | Owner | Retiro |
+| --- | --- | --- |
+| `server/routes/admin-particular-tokens.fastify.ts` | Particular Access | M33 |
+| `server/routes/particular-tokens.fastify.ts` | Particular Access | M33 |
+| `server/routes/admin-reports.fastify.ts` | Reports | M36 |
 
 M32 adelgazó únicamente `study-tracking.fastify.ts` y
 `particular-study-tracking.fastify.ts`. M32b adelgaza exclusivamente
@@ -35,5 +40,6 @@ casos, notificaciones, email y auditoría a
 filtro clinic-scoped opcional, CORS, payloads, SQL, schema y migraciones no
 cambian.
 
-M31 está cerrado y M32 quedó cerrado en el PR #1566. M32b está implementado.
-M33 y milestones posteriores no fueron iniciados.
+M30, M31, M32, M32b y M35 están cerrados. Fase G queda cerrada con evidencia
+local ejecutable, runtime de las tres rutas intacto y readiness de staging
+pendiente. No se afirma RLS. El próximo milestone es M33 y no fue iniciado.

--- a/server/features/study-tracking/infrastructure/README.md
+++ b/server/features/study-tracking/infrastructure/README.md
@@ -6,8 +6,11 @@ Repositorio canónico de persistencia movido en M31:
 - `index.ts`: único barrel público de infraestructura.
 
 El move conserva queries, filtros, orden, paginación, timestamps y resultados.
-`server/db-study-tracking.ts` permanece como shim temporal para consumidores que
-se migrarán junto con sus rutas en M32, M32b, M33, M34 y M36.
+`server/db-study-tracking.ts` permanece como shim externo controlado para
+`admin-particular-tokens.fastify.ts` y `particular-tokens.fastify.ts`
+(Particular Access, M33), y `admin-reports.fastify.ts` (Reports, M36). Las tres
+rutas propias de Study Tracking consumen infrastructure únicamente mediante la
+composición feature-level.
 
 Esta capa sólo puede depender de Drizzle, `server/db.ts`,
 `drizzle/schema.ts` y `server/lib/list-pagination.ts`. No contiene Fastify,

--- a/server/lib/study-tracking.ts
+++ b/server/lib/study-tracking.ts
@@ -1,1 +1,0 @@
-export * from "../features/study-tracking/domain/index.ts";

--- a/server/lib/token-study-tracking.ts
+++ b/server/lib/token-study-tracking.ts
@@ -1,1 +1,0 @@
-export * from "../features/study-tracking/domain/index.ts";

--- a/test/architecture/security/security-cross-tenant-idor-contract.test.ts
+++ b/test/architecture/security/security-cross-tenant-idor-contract.test.ts
@@ -382,6 +382,32 @@ const CROSS_TENANT_IDOR_CONTRACTS: readonly CrossTenantIdorContract[] = [
     ],
     productionReadinessStatus: "pending_runtime_staging_evidence",
   },
+  {
+    id: "CTIDOR-017",
+    actor: "clinic_or_particular_session",
+    resource: "study_tracking_cases_and_notifications",
+    operation:
+      "clinic and particular actors must derive scope from their authenticated realm and must not read or acknowledge foreign tracking resources",
+    requiredOwnerKey: "auth.clinicId_or_particularTokenId",
+    expectedFailure: {
+      status: 404,
+      noDisclosure: true,
+      reason: "hidden_cross_tenant_study_tracking_resource",
+    },
+    protectedSurface: "server/routes/study-tracking.fastify.ts",
+    runtimeEvidence: [
+      "staging clinic and particular probes with foreign tracking and notification identifiers",
+      "verify foreign selectors never replace the authenticated clinic or particular token",
+    ],
+    requiredTestEvidence: [
+      "test/integration/adapters/controllers/study-tracking.fastify.test.ts",
+      "test/integration/adapters/controllers/particular-study-tracking.fastify.test.ts",
+      "test/integration/adapters/controllers/admin-study-tracking.fastify.test.ts",
+      "test/unit/application/study-tracking/clinic-study-tracking-operations.test.ts",
+      "test/unit/application/study-tracking/particular-study-tracking-operations.test.ts",
+    ],
+    productionReadinessStatus: "pending_runtime_staging_evidence",
+  },
 ] as const;
 
 function readSource(relativePath: string): string {
@@ -402,7 +428,7 @@ test("cross-tenant IDOR contract matrix has unique IDs", () => {
   const ids = CROSS_TENANT_IDOR_CONTRACTS.map((contract) => contract.id);
 
   assert.deepEqual(ids, uniqueValues(ids));
-  assert.equal(ids.length >= 16, true);
+  assert.equal(ids.length >= 17, true);
 
   for (const id of ids) {
     assert.match(id, /^CTIDOR-\d{3}$/);
@@ -567,6 +593,62 @@ test("Clinics contract links executable GET PATCH POST and DELETE tenant evidenc
   assert.equal(
     commandService.includes(
       "commands a\u00edslan persistencia publicaci\u00f3n b\u00fasqueda firma y storage de selectores extranjeros",
+    ),
+    true,
+  );
+});
+
+test("Study Tracking contract links executable tenant and cross-realm evidence", () => {
+  const contract = CROSS_TENANT_IDOR_CONTRACTS.find(
+    (candidate) => candidate.id === "CTIDOR-017",
+  );
+
+  assert.ok(contract);
+  assert.deepEqual(contract.requiredTestEvidence, [
+    "test/integration/adapters/controllers/study-tracking.fastify.test.ts",
+    "test/integration/adapters/controllers/particular-study-tracking.fastify.test.ts",
+    "test/integration/adapters/controllers/admin-study-tracking.fastify.test.ts",
+    "test/unit/application/study-tracking/clinic-study-tracking-operations.test.ts",
+    "test/unit/application/study-tracking/particular-study-tracking-operations.test.ts",
+  ]);
+
+  const clinicIntegration = readSource(contract.requiredTestEvidence[0]);
+  const particularIntegration = readSource(contract.requiredTestEvidence[1]);
+  const adminIntegration = readSource(contract.requiredTestEvidence[2]);
+  const clinicOperations = readSource(contract.requiredTestEvidence[3]);
+  const particularOperations = readSource(contract.requiredTestEvidence[4]);
+
+  for (const marker of [
+    "responde 404 gen\u00e9rico en PATCH /notifications/:notificationId/read cross-clinic",
+    "ignora clinicId de input y usa la cl\u00ednica autenticada",
+    "no acepta sesiones admin o particular como cl\u00ednica",
+  ]) {
+    assert.equal(clinicIntegration.includes(marker), true, marker);
+  }
+
+  for (const marker of [
+    "responde 404 gen\u00e9rico en PATCH /notifications/:notificationId/read cross-token",
+    "ignora selectores de input y usa el token autenticado",
+    "no acepta sesiones admin o cl\u00ednica como particular",
+  ]) {
+    assert.equal(particularIntegration.includes(marker), true, marker);
+  }
+
+  assert.equal(
+    adminIntegration.includes(
+      "no acepta sesiones cl\u00ednica o particular como admin",
+    ),
+    true,
+  );
+  assert.equal(
+    clinicOperations.includes(
+      "clinic operations aplican scope y preservan identidad en lecturas y acuses",
+    ),
+    true,
+  );
+  assert.equal(
+    particularOperations.includes(
+      "particular operations derivan todo el scope del token autenticado",
     ),
     true,
   );

--- a/test/architecture/study-tracking-domain-boundary-guard.test.ts
+++ b/test/architecture/study-tracking-domain-boundary-guard.test.ts
@@ -161,30 +161,23 @@ test("los seis consumidores runtime usan únicamente el barrel canónico", () =>
   assert.deepEqual(violations, []);
 });
 
-test("los shims legacy son reexports mínimos de una línea al barrel", () => {
+test("M35 retira los shims legacy de dominio sin consumidores", () => {
   for (const file of legacyShimFiles) {
-    assert.equal(existsSync(join(repoRoot, file)), true, `${file} debe existir`);
-    assert.equal(
-      readText(file).trim(),
-      'export * from "../features/study-tracking/domain/index.ts";',
-      `${file} sólo puede reexportar el barrel canónico`,
-    );
+    assert.equal(existsSync(join(repoRoot, file)), false, `${file} debe estar ausente`);
   }
 });
 
-test("ningún consumidor runtime usa los shims legacy", () => {
+test("ningún consumidor global usa los shims legacy retirados", () => {
   const violations: string[] = [];
 
-  for (const file of walkTsFiles("server")) {
-    if (legacyShimFiles.includes(file as (typeof legacyShimFiles)[number])) {
-      continue;
-    }
+  for (const root of ["server", "test"] as const) {
+    for (const file of walkTsFiles(root)) {
+      for (const { specifier } of listImportReferences(readText(file))) {
+        const target = resolveSpecifier(file, specifier);
 
-    for (const { specifier } of listImportReferences(readText(file))) {
-      const target = resolveSpecifier(file, specifier);
-
-      if (legacyShimFiles.includes(target as (typeof legacyShimFiles)[number])) {
-        violations.push(`${file}: import legacy "${specifier}" -> ${target}`);
+        if (legacyShimFiles.includes(target as (typeof legacyShimFiles)[number])) {
+          violations.push(`${file}: import legacy "${specifier}" -> ${target}`);
+        }
       }
     }
   }

--- a/test/architecture/study-tracking-phase-closeout.test.ts
+++ b/test/architecture/study-tracking-phase-closeout.test.ts
@@ -1,0 +1,357 @@
+import assert from "node:assert/strict";
+import { createHash } from "node:crypto";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const repoRoot = process.cwd();
+const featureDir = "server/features/study-tracking";
+const applicationIndex = `${featureDir}/application/index.ts`;
+const infrastructureIndex = `${featureDir}/infrastructure/index.ts`;
+const compositionFile = `${featureDir}/study-tracking-route-composition.ts`;
+const dbShim = "server/db-study-tracking.ts";
+const domainShims = [
+  "server/lib/study-tracking.ts",
+  "server/lib/token-study-tracking.ts",
+] as const;
+const routes = {
+  clinic: "server/routes/study-tracking.fastify.ts",
+  particular: "server/routes/particular-study-tracking.fastify.ts",
+  admin: "server/routes/admin-study-tracking.fastify.ts",
+} as const;
+
+const routeHashes = new Map<string, string>([
+  [routes.clinic, "2ce07bd8abb818b39bc2369095f71e19b5b1bd2a1dcba38f7848acaf349507b1"],
+  [routes.particular, "ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb"],
+  [routes.admin, "c93824a2a7f2866c658e00304964927cbfc981b5b9c2046860657a6feb89c589"],
+]);
+
+const expectedFeatureFiles = [
+  `${featureDir}/README.md`,
+  `${featureDir}/application/README.md`,
+  `${featureDir}/application/admin-study-tracking-operations.ts`,
+  `${featureDir}/application/clinic-study-tracking-operations.ts`,
+  `${featureDir}/application/index.ts`,
+  `${featureDir}/application/particular-study-tracking-operations.ts`,
+  `${featureDir}/application/ports/admin-study-tracking-reference-repository.ts`,
+  `${featureDir}/application/ports/clinic-study-tracking-reference-repository.ts`,
+  `${featureDir}/application/ports/study-tracking-audit-port.ts`,
+  `${featureDir}/application/ports/study-tracking-command-repository.ts`,
+  `${featureDir}/application/ports/study-tracking-notification-port.ts`,
+  `${featureDir}/application/ports/study-tracking-query-repository.ts`,
+  `${featureDir}/application/study-tracking-command-use-cases.ts`,
+  `${featureDir}/application/study-tracking-query-use-cases.ts`,
+  `${featureDir}/application/study-tracking-side-effect-use-cases.ts`,
+  `${featureDir}/domain/README.md`,
+  `${featureDir}/domain/index.ts`,
+  `${featureDir}/domain/study-tracking.ts`,
+  `${featureDir}/domain/token-study-tracking.ts`,
+  `${featureDir}/infrastructure/README.md`,
+  `${featureDir}/infrastructure/index.ts`,
+  `${featureDir}/infrastructure/study-tracking-repository.ts`,
+  compositionFile,
+].sort();
+
+const residualDbConsumers = new Map<string, { owner: string; milestone: string }>([
+  [
+    "server/routes/admin-particular-tokens.fastify.ts",
+    { owner: "Particular Access", milestone: "M33" },
+  ],
+  [
+    "server/routes/particular-tokens.fastify.ts",
+    { owner: "Particular Access", milestone: "M33" },
+  ],
+  [
+    "server/routes/admin-reports.fastify.ts",
+    { owner: "Reports", milestone: "M36" },
+  ],
+]);
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8").replace(/\r\n/g, "\n");
+}
+
+function walkFiles(relativeDir: string): string[] {
+  const absoluteDir = resolve(repoRoot, relativeDir);
+
+  if (!existsSync(absoluteDir)) {
+    return [];
+  }
+
+  return readdirSync(absoluteDir, { withFileTypes: true }).flatMap((entry) => {
+    const relativePath = `${relativeDir}/${entry.name}`;
+    return entry.isDirectory() ? walkFiles(relativePath) : [relativePath];
+  });
+}
+
+function parse(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readSource(relativePath),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function normalizePath(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+function resolveSpecifier(file: string, specifier: string): string {
+  if (!specifier.startsWith(".")) {
+    return specifier;
+  }
+
+  const target = normalizePath(
+    relative(repoRoot, resolve(repoRoot, dirname(file), specifier)),
+  );
+
+  if (target.endsWith(".ts")) {
+    return target;
+  }
+
+  if (existsSync(resolve(repoRoot, `${target}.ts`))) {
+    return `${target}.ts`;
+  }
+
+  return existsSync(resolve(repoRoot, `${target}/index.ts`))
+    ? `${target}/index.ts`
+    : target;
+}
+
+function importTargets(relativePath: string): string[] {
+  const targets: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      targets.push(resolveSpecifier(relativePath, node.moduleSpecifier.text));
+    } else if (
+      ts.isCallExpression(node) &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      (
+        node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === "require")
+      )
+    ) {
+      targets.push(resolveSpecifier(relativePath, node.arguments[0].text));
+    }
+
+    node.forEachChild(visit);
+  }
+
+  visit(parse(relativePath));
+  return targets;
+}
+
+function digest(relativePath: string): string {
+  return createHash("sha256")
+    .update(readFileSync(resolve(repoRoot, relativePath)))
+    .digest("hex");
+}
+
+test("M35 congela el inventario exacto de Study Tracking y no inicia M33", () => {
+  assert.deepEqual(walkFiles(featureDir).sort(), expectedFeatureFiles);
+  assert.equal(existsSync(resolve(repoRoot, "server/features/particular-access")), false);
+  assert.equal(existsSync(resolve(repoRoot, "server/features/report-access")), false);
+});
+
+test("M35 retira ambos shims domain y prohíbe imports globales a sus paths", () => {
+  for (const shim of domainShims) {
+    assert.equal(existsSync(resolve(repoRoot, shim)), false, shim);
+  }
+
+  const violations: string[] = [];
+
+  for (const root of ["server", "test"] as const) {
+    for (const file of walkFiles(root).filter((path) => path.endsWith(".ts"))) {
+      for (const target of importTargets(file)) {
+        if (domainShims.includes(target as (typeof domainShims)[number])) {
+          violations.push(`${file} -> ${target}`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("M35 conserva el shim DB de una linea con allowlist externa exacta", () => {
+  assert.equal(
+    readSource(dbShim).trim(),
+    'export * from "./features/study-tracking/infrastructure/index.ts";',
+  );
+
+  const actualConsumers = walkFiles("server")
+    .filter((file) => file.endsWith(".ts") && file !== dbShim)
+    .filter((file) => importTargets(file).includes(dbShim))
+    .sort();
+
+  assert.deepEqual(actualConsumers, [...residualDbConsumers.keys()].sort());
+});
+
+test("cada consumidor residual del shim DB tiene owner y milestone documentados", () => {
+  const readme = readSource(`${featureDir}/README.md`);
+  const closeout = readSource("docs/implementation/m35-study-tracking-phase-closeout.md");
+
+  for (const [consumer, ownership] of residualDbConsumers) {
+    for (const source of [readme, closeout]) {
+      assert.ok(source.includes(consumer), consumer);
+      assert.ok(source.includes(ownership.owner), ownership.owner);
+      assert.ok(source.includes(ownership.milestone), ownership.milestone);
+    }
+  }
+});
+
+test("las tres rutas permanecen exactas y sólo atraviesan application y composition", () => {
+  for (const [route, expectedHash] of routeHashes) {
+    assert.equal(digest(route), expectedHash, route);
+
+    const targets = importTargets(route);
+    assert.ok(targets.includes(applicationIndex), route);
+    assert.ok(targets.includes(compositionFile), route);
+    assert.equal(targets.includes(dbShim), false, route);
+    assert.equal(
+      targets.some((target) => target.startsWith(`${featureDir}/infrastructure/`)),
+      false,
+      route,
+    );
+  }
+});
+
+test("composition sigue siendo el único seam route a infrastructure", () => {
+  assert.deepEqual([...new Set(importTargets(compositionFile))], [infrastructureIndex]);
+
+  const source = readSource(compositionFile);
+  assert.deepEqual(
+    Array.from(
+      source.matchAll(/export async function (load[A-Za-z]+StudyTrackingPersistence)\(/g),
+      (match) => match[1],
+    ),
+    [
+      "loadClinicStudyTrackingPersistence",
+      "loadParticularStudyTrackingPersistence",
+      "loadAdminStudyTrackingPersistence",
+    ],
+  );
+  assert.equal(/\b(?:select|insert|update|delete)\s*\(/.test(source), false);
+  assert.equal(source.includes("drizzle-orm"), false);
+  assert.equal(source.includes("Fastify"), false);
+});
+
+test("todas las factories application públicas conservan consumidor y test", () => {
+  const contracts = [
+    {
+      factory: "createClinicStudyTrackingQueryUseCases",
+      source: `${featureDir}/application/study-tracking-query-use-cases.ts`,
+      consumer: `${featureDir}/application/clinic-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-query-use-cases.test.ts",
+    },
+    {
+      factory: "createAdminStudyTrackingQueryUseCases",
+      source: `${featureDir}/application/study-tracking-query-use-cases.ts`,
+      consumer: `${featureDir}/application/admin-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-query-use-cases.test.ts",
+    },
+    {
+      factory: "createParticularStudyTrackingQueryUseCases",
+      source: `${featureDir}/application/study-tracking-query-use-cases.ts`,
+      consumer: `${featureDir}/application/particular-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-query-use-cases.test.ts",
+    },
+    {
+      factory: "createClinicStudyTrackingCommandUseCases",
+      source: `${featureDir}/application/study-tracking-command-use-cases.ts`,
+      consumer: `${featureDir}/application/clinic-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-command-use-cases.test.ts",
+    },
+    {
+      factory: "createAdminStudyTrackingCommandUseCases",
+      source: `${featureDir}/application/study-tracking-command-use-cases.ts`,
+      consumer: `${featureDir}/application/admin-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-command-use-cases.test.ts",
+    },
+    {
+      factory: "createParticularStudyTrackingCommandUseCases",
+      source: `${featureDir}/application/study-tracking-command-use-cases.ts`,
+      consumer: `${featureDir}/application/particular-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-command-use-cases.test.ts",
+    },
+    {
+      factory: "createStudyTrackingSideEffectUseCases",
+      source: `${featureDir}/application/study-tracking-side-effect-use-cases.ts`,
+      consumer: `${featureDir}/application/clinic-study-tracking-operations.ts`,
+      test: "test/unit/application/study-tracking/study-tracking-side-effect-use-cases.test.ts",
+    },
+    {
+      factory: "createClinicStudyTrackingOperations",
+      source: `${featureDir}/application/clinic-study-tracking-operations.ts`,
+      consumer: routes.clinic,
+      test: "test/unit/application/study-tracking/clinic-study-tracking-operations.test.ts",
+    },
+    {
+      factory: "createParticularStudyTrackingOperations",
+      source: `${featureDir}/application/particular-study-tracking-operations.ts`,
+      consumer: routes.particular,
+      test: "test/unit/application/study-tracking/particular-study-tracking-operations.test.ts",
+    },
+    {
+      factory: "createAdminStudyTrackingOperations",
+      source: `${featureDir}/application/admin-study-tracking-operations.ts`,
+      consumer: routes.admin,
+      test: "test/unit/application/study-tracking/admin-study-tracking-operations.test.ts",
+    },
+  ] as const;
+
+  for (const contract of contracts) {
+    assert.ok(readSource(contract.source).includes(contract.factory), contract.factory);
+    assert.ok(readSource(applicationIndex).includes(contract.factory), contract.factory);
+    assert.ok(readSource(contract.consumer).includes(contract.factory), contract.factory);
+    assert.ok(readSource(contract.test).includes(contract.factory), contract.factory);
+  }
+});
+
+test("los tres realms quedan separados con evidencia runtime", () => {
+  assert.ok(readSource(routes.clinic).includes("cookies[ENV.cookieName]"));
+  assert.ok(readSource(routes.particular).includes("cookies[ENV.particularCookieName]"));
+  assert.ok(readSource(routes.admin).includes("authenticateFastifyAdmin"));
+
+  const evidence = new Map<string, string>([
+    [
+      "test/integration/adapters/controllers/study-tracking.fastify.test.ts",
+      "no acepta sesiones admin o particular como clínica",
+    ],
+    [
+      "test/integration/adapters/controllers/particular-study-tracking.fastify.test.ts",
+      "no acepta sesiones admin o clínica como particular",
+    ],
+    [
+      "test/integration/adapters/controllers/admin-study-tracking.fastify.test.ts",
+      "no acepta sesiones clínica o particular como admin",
+    ],
+  ]);
+
+  for (const [file, marker] of evidence) {
+    assert.ok(readSource(file).includes(marker), `${file}: ${marker}`);
+  }
+});
+
+test("los guards de capa y rutas permanecen ejecutables en el cierre", () => {
+  for (const file of [
+    "test/architecture/study-tracking-domain-boundary-guard.test.ts",
+    "test/architecture/study-tracking-application-boundary-guard.test.ts",
+    "test/architecture/study-tracking-infrastructure-boundary-guard.test.ts",
+    "test/architecture/study-tracking-clinic-particular-thin-routes.test.ts",
+    "test/architecture/study-tracking-admin-thin-route.test.ts",
+    "test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts",
+  ]) {
+    assert.equal(existsSync(resolve(repoRoot, file)), true, file);
+    assert.ok(readSource(file).includes("node:test"), file);
+  }
+});

--- a/test/integration/adapters/controllers/admin-study-tracking.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-study-tracking.fastify.test.ts
@@ -205,6 +205,24 @@ test("adminStudyTrackingNativeRoutes preserva OPTIONS y CORS en toda la superfic
   }
 });
 
+test("adminStudyTrackingNativeRoutes no acepta sesiones clínica o particular como admin", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/study-tracking",
+      headers: {
+        cookie: `${ENV.cookieName}=clinic-session; ${ENV.particularCookieName}=particular-session`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});
+
 test("adminStudyTrackingNativeRoutes conserva auth ausente inválida y expirada con clear-cookie", async () => {
   const missingApp = await createTestApp();
   const invalidApp = await createTestApp({

--- a/test/integration/adapters/controllers/particular-study-tracking.fastify.test.ts
+++ b/test/integration/adapters/controllers/particular-study-tracking.fastify.test.ts
@@ -145,6 +145,49 @@ test("particularStudyTrackingNativeRoutes expone GET /me con seguimiento del tok
   }
 });
 
+test("particularStudyTrackingNativeRoutes ignora selectores de input y usa el token autenticado", async () => {
+  const calls: number[] = [];
+  const app = await createTestApp({
+    getParticularStudyTrackingCase: async (particularTokenId: number) => {
+      calls.push(particularTokenId);
+      return createTrackingCaseFixture();
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/study-tracking/me?particularTokenId=999&clinicId=999",
+      headers: {
+        cookie: `${ENV.particularCookieName}=particular-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(calls, [7]);
+  } finally {
+    await app.close();
+  }
+});
+
+test("particularStudyTrackingNativeRoutes no acepta sesiones admin o clínica como particular", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular/study-tracking/me",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session; ${ENV.cookieName}=clinic-session`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});
+
 test("particularStudyTrackingNativeRoutes no permite modificar labReceivedAt", async () => {
   const app = await createTestApp();
 

--- a/test/integration/adapters/controllers/study-tracking.fastify.test.ts
+++ b/test/integration/adapters/controllers/study-tracking.fastify.test.ts
@@ -554,3 +554,48 @@ test("studyTrackingNativeRoutes expone GET /:trackingCaseId con detalle", async 
     await app.close();
   }
 });
+
+test("studyTrackingNativeRoutes ignora clinicId de input y usa la clínica autenticada", async () => {
+  const calls: Array<Record<string, unknown>> = [];
+  const app = await createTestApp({
+    listStudyTrackingCases: async (params: Record<string, unknown>) => {
+      calls.push(params);
+      return [createTrackingCaseFixture()];
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/study-tracking?clinicId=999&limit=5&offset=2",
+      headers: {
+        cookie: `${ENV.cookieName}=session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0]?.clinicId, 3);
+    assert.equal(JSON.stringify(calls).includes("999"), false);
+  } finally {
+    await app.close();
+  }
+});
+
+test("studyTrackingNativeRoutes no acepta sesiones admin o particular como clínica", async () => {
+  const app = await createTestApp();
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/study-tracking",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session; ${ENV.particularCookieName}=particular-session`,
+      },
+    });
+
+    assert.equal(response.statusCode, 401);
+  } finally {
+    await app.close();
+  }
+});

--- a/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
+++ b/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
@@ -141,6 +141,14 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
           "M32 clinic y particular permanecen byte-identical durante M32b",
         ],
       },
+      {
+        path: "test/architecture/study-tracking-phase-closeout.test.ts",
+        markers: [
+          "M35 congela el inventario exacto de Study Tracking",
+          "M35 conserva el shim DB de una linea con allowlist externa exacta",
+          "los tres realms quedan separados con evidencia runtime",
+        ],
+      },
     ],
     runtimeAnchors: [
       {
@@ -512,6 +520,7 @@ test("study tracking suite registers canonical guardrail files", () => {
     "study-tracking-application-boundary-guard.test.ts",
     "study-tracking-infrastructure-boundary-guard.test.ts",
     "study-tracking-clinic-particular-thin-routes.test.ts",
+    "study-tracking-phase-closeout.test.ts",
     "study-tracking.fastify.test.ts",
     "admin-study-tracking.fastify.test.ts",
     "particular-study-tracking.fastify.test.ts",


### PR DESCRIPTION
## Summary
- Change type: backend structural phase closeout.
- Context / issue: M35 closes Phase G — Study Tracking after M30/M31/M32/M32b.
- What changed: removed two domain re-export shims with zero executable consumers; added the M35 closeout guard; strengthened executable clinic/particular/admin tenant and cross-realm evidence; updated canonical docs.
- Keeps the DB shim only for three external pending consumers and does not start M33.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Tests and documentation are supporting evidence for the single backend structural closeout scope.

## Validation
- [x] M35 guard: 9/9 pass, 0 skip/fail, exit 0.
- [x] Layer/completeness/IDOR stage: 52/52 final, 0 skip/fail, exit 0.
- [x] Directed cohort: 42 files, 313/313 pass, 0 skip/fail, exit 0.
- [x] `pnpm typecheck`: exit 0.
- [x] `pnpm typecheck:test`: exit 0.
- [x] `pnpm validate:local`: 3,684 tests; 3,683 pass, 1 pre-existing skip, 0 fail; exit 0.
- [x] `pnpm build`: esbuild passed inside `validate:local`, exit 0.
- [x] `pnpm security:public-surface`: no public findings; two expected server-only markers; exit 0.
- [x] `git diff --check` and cached diff check: exit 0.
- [x] Route SHA-256 values preserved: clinic `2ce07bd8...507b1`, particular `ed7d3f4a...591fb`, admin `c93824a2...c589`.
- [x] Domain legacy imports after: 0. Domain shims after: 0.
- [x] DB shim consumers: exactly 3; allowlist guarded.
- [ ] Relevant remote CI checks passed (pending at PR creation).

The first directed-stage run failed only on the suite-completeness ASCII-only self-contract; the new accented marker was normalized to ASCII and the exact rerun passed 52/52. No runtime failure occurred.

## Security
- Clinic authority remains `clinicId` from the authenticated clinic session only.
- Particular authority remains `particularTokenId` from the authenticated particular session only.
- Admin remains globally authoritative with optional clinic-scoped filtering.
- Cross-realm integration tests reject cookies from the other two realms with 401.
- Report/token ownership, trusted-origin, auth, audit ordering and best-effort email remain intact.
- No RLS claim; no schema, migration, dependency, secret, auth, cookie or CORS change.

## Architecture
- Final layers: domain → application ports/use cases/realm operations; infrastructure implements persistence; feature composition is the only route-to-infrastructure seam.
- Domain barrels are canonical; `server/lib/study-tracking.ts` and `server/lib/token-study-tracking.ts` are removed.
- `server/db-study-tracking.ts` remains an unchanged one-line shim with exact allowlist:
  - `server/routes/admin-particular-tokens.fastify.ts` — Particular Access, M33.
  - `server/routes/particular-tokens.fastify.ts` — Particular Access, M33.
  - `server/routes/admin-reports.fastify.ts` — Reports, M36.
- The three owned routes import application barrels plus feature composition, never the DB shim or infrastructure directly.
- No orphan public application factory; M33 remains absent.

## Preserved Contracts
- All endpoints and OPTIONS registries.
- Status codes, payloads, messages and serializers.
- Auth realms, cookie selection, scopes and trusted-origin.
- Exact Options sets: clinic 22, particular 10, admin 22.
- Pagination, null/undefined and error identity.
- Clinic/admin create side-effect order and admin update combinations.
- PATCH admin: body `clinicId` over query and target resolution/404 before Zod/400.
- Audit actors/events/metadata and email best-effort policy.

## Rollback
- Trigger: unexpected regression attributable to M35 closeout evidence or removed compatibility paths.
- Steps: revert commit `da784bc50cef9fa59b5eef140a1686e71f096557`.
- Data impact: none; restores only the two one-line shims and removes M35 tests/docs. No migration, schema rollback or compensation.