### PR TITLE
chore(security): patch postcss and js-yaml advisories

### DIFF
--- a/docs/implementation/security-postcss-js-yaml-advisory-hotfix.md
+++ b/docs/implementation/security-postcss-js-yaml-advisory-hotfix.md
@@ -1,0 +1,110 @@
+# Hotfix de advisories de PostCSS y js-yaml
+
+## Estado base
+
+- Fecha: 2026-07-24.
+- Repositorio: `C:\PORTAL-VETNEB`.
+- Rama: `chore/security-postcss-8-5-17`.
+- Base exacta: `9ef2621875429b788a0260aae65dd7eb3753db23`.
+- El árbol y el índice estaban limpios antes del hotfix.
+- PostCSS resolvía a `8.5.14` en `frontend > next > postcss`.
+- js-yaml resolvía a `5.2.1` como dependencia de desarrollo del workspace raíz.
+
+## Scope incluido
+
+- Override de PostCSS para cubrir el rango vulnerable `<=8.5.17`.
+- Override de js-yaml para cubrir el rango vulnerable `<=5.2.1`.
+- Regeneración controlada de `pnpm-lock.yaml` con PNPM `11.13.0`.
+- Actualización del contrato exacto de overrides de seguridad.
+- Exclusión puntual `minimumReleaseAgeExclude` para `js-yaml@5.2.2`, publicada
+  el 2026-07-23 y requerida por PNPM para aplicar inmediatamente el parche.
+
+## Scope excluido
+
+- Runtime frontend y backend.
+- `frontend/package.json`, Next, Tailwind y eslint-config-next.
+- Workflows, schema, migraciones, auth y configuración productiva.
+- M35 y su documentación de cierre.
+- Cualquier dependencia distinta de PostCSS y js-yaml.
+- Deploy y merge.
+
+## Auditoría previa
+
+- `pnpm audit --prod` detectó PostCSS `<=8.5.17` en
+  `frontend > next > postcss`; la versión corregida mínima informada fue
+  `8.5.18`.
+- El workspace ya declaraba y resolvía PostCSS `8.5.19`, por lo que se eligió
+  esa versión para consolidar dos resoluciones en una.
+- Tras corregir PostCSS, `pnpm audit` detectó js-yaml `>=5.0.0 <=5.2.1`; la
+  versión corregida mínima informada fue `5.2.2`.
+- No se deshabilitó ningún audit ni se redujo su nivel de bloqueo.
+
+## Cambios
+
+- `pnpm-workspace.yaml`:
+  - `"postcss@<=8.5.17": "8.5.19"`.
+  - `"js-yaml@<=5.2.1": "5.2.2"`.
+  - Exclusión de edad limitada exactamente a `js-yaml@5.2.2`.
+- `pnpm-lock.yaml`:
+  - PostCSS `8.5.14` fue reemplazado por `8.5.19`.
+  - js-yaml `5.2.1` fue reemplazado por `5.2.2`.
+  - Se eliminó `nanoid@3.3.16`, nodo usado exclusivamente por el PostCSS
+    retirado.
+  - No cambiaron otras resoluciones ni importers no relacionados.
+- `test/architecture/toolchain-contract.test.ts`:
+  - Actualiza las dos entradas exactas de `SECURITY_OVERRIDE_LINES`.
+
+## Archivos
+
+- `pnpm-workspace.yaml`.
+- `pnpm-lock.yaml`.
+- `test/architecture/toolchain-contract.test.ts`.
+- `docs/implementation/security-postcss-js-yaml-advisory-hotfix.md`.
+
+## Validaciones
+
+- `pnpm install --frozen-lockfile` — `PASSED`.
+- `pnpm why postcss -r` — `PASSED`; una resolución: `8.5.19`.
+- `pnpm list postcss -r` — `PASSED`.
+- `pnpm why js-yaml -r` — `PASSED`; una resolución: `5.2.2`.
+- `pnpm list js-yaml -r` — `PASSED`.
+- `pnpm audit --prod` — `PASSED`; sin vulnerabilidades conocidas.
+- `pnpm audit` — `PASSED`; sin vulnerabilidades conocidas.
+- `pnpm exec tsx --test test/architecture/toolchain-contract.test.ts` —
+  `PASSED`; 8/8.
+- `pnpm typecheck` — `PASSED`.
+- `pnpm typecheck:test` — `PASSED`.
+- `pnpm validate:local` — `PASSED`; 3668 aprobados, 0 fallos, 1 omitido, y
+  build backend correcto.
+- `pnpm --dir frontend lint` — `PASSED`.
+- `pnpm --dir frontend typecheck` — `PASSED`.
+- `pnpm --dir frontend build` — `PASSED`.
+- `pnpm security:public-surface` — `PASSED`.
+- `git diff --check` — `PASSED`.
+
+## Resultado
+
+El workspace queda con una única resolución segura de PostCSS (`8.5.19`) y
+una única resolución segura de js-yaml (`5.2.2`). Ambos audits obligatorios
+terminan con exit code 0. El lockfile queda acotado a las dos remediaciones y
+sus nodos estrictamente derivados, sin cambios runtime.
+
+## Riesgo residual
+
+- `js-yaml@5.2.2` se publicó menos de 24 horas antes de la remediación. La
+  excepción de edad está limitada al paquete y versión exactos; no desactiva
+  la política para ninguna otra dependencia.
+- El hotfix modifica resoluciones transitivas y de tooling. Los contratos,
+  typechecks, tests, audits y builds reducen el riesgo de incompatibilidad,
+  pero los checks remotos siguen siendo el gate definitivo previo al merge.
+
+## Rollback
+
+Revertir el commit del hotfix restaura los overrides y el lockfile anteriores.
+No requiere migración de schema, datos, credenciales ni infraestructura.
+
+## Estado final
+
+Implementación local validada y lista para publicación. El PR debe permanecer
+abierto, no draft y sin merge hasta que todos los checks requeridos estén
+verdes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,9 +13,9 @@ overrides:
   fast-uri@>=4.0.0 <4.1.1: 4.1.1
   find-my-way@<=9.6.0: 9.7.0
   sharp@<0.35.0: 0.35.3
-  postcss@<8.5.10: 8.5.14
+  postcss@<=8.5.17: 8.5.19
   ws@>=8.0.0 <8.20.1: 8.20.1
-  js-yaml: 5.2.1
+  js-yaml@<=5.2.1: 5.2.2
 
 importers:
 
@@ -65,8 +65,8 @@ importers:
         specifier: 0.28.1
         version: 0.28.1
       js-yaml:
-        specifier: 5.2.1
-        version: 5.2.1
+        specifier: 5.2.2
+        version: 5.2.2
       tsx:
         specifier: ^4.23.1
         version: 4.23.1
@@ -2314,8 +2314,8 @@ packages:
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
-  js-yaml@5.2.1:
-    resolution: {integrity: sha512-zfLtNfQqxVqq3uaTqSkh4x4hZw3KHobGUA0fJUj4wawW8bsQLTVqpHdXSIzidh7o+4lEW36tANuAGdaFx6Zgnw==}
+  js-yaml@5.2.2:
+    resolution: {integrity: sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==}
     hasBin: true
 
   jsesc@3.1.0:
@@ -2524,11 +2524,6 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
-  nanoid@3.3.16:
-    resolution: {integrity: sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==}
-    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
-    hasBin: true
-
   napi-postinstall@0.3.4:
     resolution: {integrity: sha512-PHI5f1O0EP5xJ9gQmFGMS6IZcrVvTjpXjz7Na41gTE7eE2hK11lg04CECCYEEjdc17EV4DO+fkGEtt7TpTaTiQ==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
@@ -2713,10 +2708,6 @@ packages:
   possible-typed-array-names@1.1.0:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
-
-  postcss@8.5.14:
-    resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
-    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.19:
     resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
@@ -5302,7 +5293,7 @@ snapshots:
 
   js-tokens@4.0.0: {}
 
-  js-yaml@5.2.1:
+  js-yaml@5.2.2:
     dependencies:
       argparse: 2.0.1
 
@@ -5485,8 +5476,6 @@ snapshots:
 
   nanoid@3.3.12: {}
 
-  nanoid@3.3.16: {}
-
   napi-postinstall@0.3.4: {}
 
   natural-compare@1.4.0: {}
@@ -5497,7 +5486,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.0
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.14
+      postcss: 8.5.19
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
@@ -5684,12 +5673,6 @@ snapshots:
   pngjs@7.0.0: {}
 
   possible-typed-array-names@1.1.0: {}
-
-  postcss@8.5.14:
-    dependencies:
-      nanoid: 3.3.16
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
 
   postcss@8.5.19:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -15,12 +15,15 @@ overrides:
   "fast-uri@>=4.0.0 <4.1.1": "4.1.1"
   "find-my-way@<=9.6.0": "9.7.0"
   "sharp@<0.35.0": "0.35.3"
-  "postcss@<8.5.10": "8.5.14"
+  "postcss@<=8.5.17": "8.5.19"
   "ws@>=8.0.0 <8.20.1": "8.20.1"
-  js-yaml: "5.2.1"
+  "js-yaml@<=5.2.1": "5.2.2"
 
 allowBuilds:
   argon2: false
   esbuild: false
   sharp: false
   unrs-resolver: false
+
+minimumReleaseAgeExclude:
+  - js-yaml@5.2.2

--- a/scripts/governance/workflow-security-validator.mjs
+++ b/scripts/governance/workflow-security-validator.mjs
@@ -495,7 +495,7 @@ export function evaluateWorkflowSecurity({ rootDir = process.cwd(), workflowPath
     validateWorkflowDocument({ document, workflow, report });
   }
 
-  report.details.push(`Parsed ${workflows.length} workflow file(s) with js-yaml 5.2.1.`);
+  report.details.push(`Parsed ${workflows.length} workflow file(s) with js-yaml 5.2.2.`);
   report.details.push(
     `Applied maxDepth=${MAX_YAML_DEPTH}, maxTotalMergeKeys=${MAX_TOTAL_MERGE_KEYS} and maxAliases=0.`,
   );

--- a/test/architecture/toolchain-contract.test.ts
+++ b/test/architecture/toolchain-contract.test.ts
@@ -25,9 +25,9 @@ const SECURITY_OVERRIDE_LINES = [
   '  "fast-uri@>=4.0.0 <4.1.1": "4.1.1"',
   '  "find-my-way@<=9.6.0": "9.7.0"',
   '  "sharp@<0.35.0": "0.35.3"',
-  '  "postcss@<8.5.10": "8.5.14"',
+  '  "postcss@<=8.5.17": "8.5.19"',
   '  "ws@>=8.0.0 <8.20.1": "8.20.1"',
-  '  js-yaml: "5.2.1"',
+  '  "js-yaml@<=5.2.1": "5.2.2"',
 ] as const;
 
 function readTextFile(...segments: string[]): string {


### PR DESCRIPTION
## Summary

- Patches the vulnerable transitive PostCSS resolution used by Next: `8.5.14` ÔåÆ `8.5.19`.
- Patches the vulnerable workspace js-yaml resolution: `5.2.1` ÔåÆ `5.2.2`.
- Regenerates the PNPM lockfile with PNPM `11.13.0`.
- Updates the exact security override architecture contract.
- Adds the security implementation record required by repository policy.
- Does not modify application runtime, workflows, schema or M35.

## Scope

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [x] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [x] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [x] mixed-scope exception

Primary scopes: dependencies and workflows/CI.

## Mixed-Scope Justification

The dependency overrides, lockfile and exact toolchain contract are inseparable from the one-line workflow-security validator banner correction. Landing only the dependency files would leave required governance evidence reporting the vulnerable js-yaml version, while landing only the validator correction would report a version not resolved by the workspace. Tests and documentation support this single atomic security remediation.
## Validation

- `pnpm install --frozen-lockfile` ÔÇö PASSED.
- `pnpm why postcss -r` ÔÇö PASSED; one resolution, `8.5.19`, including `frontend > next > postcss`.
- `pnpm list postcss -r` ÔÇö PASSED.
- `pnpm why js-yaml -r` ÔÇö PASSED; one resolution, `5.2.2`.
- `pnpm list js-yaml -r` ÔÇö PASSED.
- `pnpm audit --prod` ÔÇö PASSED; no known vulnerabilities.
- `pnpm audit` ÔÇö PASSED; no known vulnerabilities.
- `pnpm exec tsx --test test/architecture/toolchain-contract.test.ts` ÔÇö PASSED; 8/8.
- `pnpm typecheck` ÔÇö PASSED.
- `pnpm typecheck:test` ÔÇö PASSED.
- `pnpm validate:local` ÔÇö PASSED; 3668 passed, 0 failed, 1 skipped; backend build passed.
- `pnpm --dir frontend lint` ÔÇö PASSED.
- `pnpm --dir frontend typecheck` ÔÇö PASSED.
- `pnpm --dir frontend build` ÔÇö PASSED.
- `pnpm security:public-surface` ÔÇö PASSED.
- `git diff --check` and `git diff --cached --check` ÔÇö PASSED.

## Lockfile scope

- PostCSS `8.5.14` is removed and consolidated into the existing safe `8.5.19` resolution.
- js-yaml `5.2.1` is replaced by `5.2.2`.
- `nanoid@3.3.16`, used exclusively by the removed PostCSS resolution, is removed.
- No unrelated dependency resolution or importer changes are included.
- PNPM added an exact `minimumReleaseAgeExclude` entry for newly published `js-yaml@5.2.2`; the broader supply-chain policy remains enabled.

## Security

- No PostCSS resolution remains in the vulnerable `<=8.5.17` range.
- No js-yaml `5.2.1` resolution remains.
- Mandatory audits remain enabled and blocking.
- No bypass, ignore, audit-level reduction or workflow change.
- No secrets, schema, auth or runtime source changes.

## Preserved contracts

- All non-PostCSS and non-js-yaml dependency resolutions remain unchanged.
- Next and frontend source remain unchanged.
- Backend runtime remains unchanged.
- M35 remains unchanged.
- Existing security overrides remain exact.

## Rollback

Revert the hotfix commit to restore the previous PostCSS and js-yaml overrides and lockfile. No schema, data, credential or infrastructure migration is required.