### PR TITLE
fix(deps): patch brace-expansion audit advisory

### DIFF
--- a/docs/implementation/brace-expansion-security-advisory-hotfix.md
+++ b/docs/implementation/brace-expansion-security-advisory-hotfix.md
@@ -1,0 +1,111 @@
+# Brace Expansion Security Advisory Hotfix
+
+## Estado base
+
+- Repositorio: `LABVETNEB/PORTAL-VETNEB`.
+- Base del cambio: `c27e9d7cad98d4cf9a203e97c0ba083b7c3ab731`.
+- Rama: `fix/security-brace-expansion-5-0-8`.
+- Pull request: `#1571`.
+- Gestor: PNPM `11.13.0`.
+- Estado productivo inicial: `pnpm audit --prod` sin vulnerabilidades conocidas.
+- Estado completo inicial: `pnpm audit` fallaba por una vulnerabilidad alta en una dependencia transitiva del tooling frontend.
+
+## Alcance incluido
+
+- Consolidación de los overrides de `brace-expansion` para cubrir todas las versiones vulnerables.
+- Regeneración mecánica de `pnpm-lock.yaml`.
+- Actualización del contrato ejecutable de seguridad del toolchain.
+- Documentación de la auditoría, validaciones, riesgo residual y rollback.
+
+## Alcance excluido
+
+- Código de aplicación backend.
+- Código de aplicación frontend.
+- Schema, migraciones y acceso a datos.
+- Auth, cookies, CORS, CSP, rate limits y configuración productiva.
+- Actualizaciones generales de dependencias.
+- Playwright y cambios visuales.
+
+## Auditoría previa
+
+La auditoría productiva finalizaba correctamente:
+
+```text
+pnpm audit --prod = PASSED, exit 0
+```
+
+La auditoría completa reproducía el advisory:
+
+```text
+pnpm audit = FAILED, exit 1
+Advisory = GHSA-mh99-v99m-4gvg
+Package = brace-expansion
+Vulnerable versions = <=5.0.7
+Patched versions = >=5.0.8
+Severity = high
+```
+
+El primer intento de corrección actualizó la resolución `5.0.7`, pero conservó `brace-expansion@1.1.16` en ramas transitivas del tooling ESLint del frontend. Por ese motivo el audit completo continuaba fallando.
+
+## Causa raíz
+
+Los overrides históricos cubrían rangos fragmentados y permitían que una rama transitiva permaneciera en `brace-expansion@1.1.16`, versión incluida en el rango vulnerable del advisory. La resolución parcheada para el rango moderno no cubría esa rama antigua.
+
+## Cambios implementados
+
+- Los overrides fragmentados se reemplazaron por un único contrato:
+
+```yaml
+"brace-expansion@<=5.0.7": "5.0.8"
+```
+
+- `pnpm-lock.yaml` fue regenerado con PNPM `11.13.0`.
+- Se eliminaron las resoluciones vulnerables de `brace-expansion` y transitivas ya innecesarias.
+- `test/architecture/toolchain-contract.test.ts` fue actualizado para fijar el override nuevo como contrato ejecutable.
+- No se modificó código de aplicación.
+
+## Archivos
+
+- `pnpm-workspace.yaml`
+- `pnpm-lock.yaml`
+- `test/architecture/toolchain-contract.test.ts`
+- `docs/implementation/brace-expansion-security-advisory-hotfix.md`
+
+## Validaciones
+
+| Validación | Estado | Evidencia |
+|---|---|---|
+| Toolchain contract | PASSED | 8/8 |
+| `pnpm audit --prod` | PASSED | exit 0; sin vulnerabilidades conocidas |
+| `pnpm audit` | PASSED | exit 0; sin vulnerabilidades conocidas |
+| `pnpm validate:local` | PASSED | 3704 tests; 3703 pass; 1 skip; 0 fail; build incluido |
+| Frontend lint | PASSED | exit 0 |
+| Frontend typecheck | PASSED | exit 0 |
+| Frontend build | PASSED | exit 0 |
+| `pnpm security:public-surface` | PASSED | sin exposición pública detectada |
+| `git diff --check` | PASSED | sin findings |
+| Playwright | NOT_RUN | excluido del alcance de este hotfix no visual |
+| Migraciones adicionales | NOT_RUN | no hubo cambios de schema ni migraciones |
+
+## Resultado
+
+La resolución transitiva queda consolidada en `brace-expansion@5.0.8`. Ambos audits finalizan con exit code 0 y el contrato del toolchain protege el override requerido.
+
+## Riesgo residual
+
+- El cambio afecta únicamente una resolución transitiva del tooling.
+- No cambia el runtime productivo ni fuentes backend/frontend.
+- La compatibilidad del tooling queda cubierta por lint, typecheck, build y la suite local completa.
+- Permanece el riesgo general de advisories futuros en dependencias transitivas; se controla mediante los audits obligatorios de CI.
+
+## Rollback
+
+Revertir conjuntamente el override, el lockfile, el contrato ejecutable y este documento. No debe revertirse sólo una parte porque se rompería la correspondencia entre configuración, resolución y guard de arquitectura.
+
+## Estado final
+
+- Corrección de seguridad: `PASSED`.
+- `pnpm audit --prod`: `PASSED`.
+- `pnpm audit`: `PASSED`.
+- Código de aplicación modificado: no.
+- Riesgo residual: limitado al mantenimiento futuro del grafo transitivo.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,9 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<1.1.16: 1.1.16
-  brace-expansion@>=2.0.0 <2.1.2: 2.1.2
-  brace-expansion@>=3.0.0 <5.0.7: 5.0.7
+  brace-expansion@<=5.0.7: 5.0.8
   esbuild: 0.28.1
   fast-uri@<3.1.4: 3.1.4
   fast-uri@>=4.0.0 <4.1.1: 4.1.1
@@ -1562,9 +1560,6 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1574,12 +1569,9 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@1.1.16:
-    resolution: {integrity: sha512-IDw48K2/2kRkg9LdJxurvq3lV3aBgq0REY89duEqFRthjlPdXHKMj7EnQOXVckxzgisinf3nHfrcE2FufFLXMw==}
-
-  brace-expansion@5.0.7:
-    resolution: {integrity: sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==}
-    engines: {node: 18 || 20 || >=22}
+  brace-expansion@5.0.8:
+    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+    engines: {node: 20 || >=22}
 
   braces@3.0.3:
     resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
@@ -1621,9 +1613,6 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -4438,18 +4427,11 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.11.0: {}
 
-  brace-expansion@1.1.16:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
-
-  brace-expansion@5.0.7:
+  brace-expansion@5.0.8:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4497,8 +4479,6 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
-
-  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -5439,11 +5419,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.7
+      brace-expansion: 5.0.8
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.16
+      brace-expansion: 5.0.8
 
   minimist@1.2.8: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,9 +7,7 @@ autoInstallPeers: true
 preferWorkspacePackages: true
 
 overrides:
-  "brace-expansion@<1.1.16": "1.1.16"
-  "brace-expansion@>=2.0.0 <2.1.2": "2.1.2"
-  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7"
+  "brace-expansion@<=5.0.7": "5.0.8"
   esbuild: "0.28.1"
   "fast-uri@<3.1.4": "3.1.4"
   "fast-uri@>=4.0.0 <4.1.1": "4.1.1"

--- a/test/architecture/toolchain-contract.test.ts
+++ b/test/architecture/toolchain-contract.test.ts
@@ -17,9 +17,7 @@ const PNPM_WORKFLOW_FILES = [
 ] as const;
 
 const SECURITY_OVERRIDE_LINES = [
-  '  "brace-expansion@<1.1.16": "1.1.16"',
-  '  "brace-expansion@>=2.0.0 <2.1.2": "2.1.2"',
-  '  "brace-expansion@>=3.0.0 <5.0.7": "5.0.7"',
+  '  "brace-expansion@<=5.0.7": "5.0.8"',
   '  esbuild: "0.28.1"',
   '  "fast-uri@<3.1.4": "3.1.4"',
   '  "fast-uri@>=4.0.0 <4.1.1": "4.1.1"',


### PR DESCRIPTION
## Summary

- replaces the fragmented `brace-expansion` overrides with `brace-expansion@<=5.0.7 → 5.0.8`
- regenerates the pnpm lockfile with PNPM 11.13.0
- realigns the executable toolchain security contract
- documents the security advisory hotfix and validation evidence
- changes no application source code

## Scope

- [x] Dependencies

R2 dependency and lockfile correction limited to:

- `pnpm-workspace.yaml`
- `pnpm-lock.yaml`
- `test/architecture/toolchain-contract.test.ts`
- `docs/implementation/brace-expansion-security-advisory-hotfix.md`

## Validation

- toolchain contract: PASSED
- `pnpm audit --prod`: PASSED
- `pnpm audit`: PASSED
- `pnpm validate:local`: PASSED
- frontend lint: PASSED
- frontend typecheck: PASSED
- frontend build: PASSED
- `pnpm security:public-surface`: PASSED
- `git diff --check`: PASSED

## Rollback

Revert the dependency-security change to restore the previous overrides, lockfile resolutions, executable contract, and documentation together.