### PR TITLE
fix(security): redact sensitive error response paths

### DIFF
--- a/docs/implementation/public-report-access-error-path-redaction-hotfix.md
+++ b/docs/implementation/public-report-access-error-path-redaction-hotfix.md
@@ -1,0 +1,108 @@
+# Public Report Access error path redaction hotfix
+
+## Baseline
+
+- Repositorio: `LABVETNEB/PORTAL-VETNEB`.
+- Rama: `fix/security-public-report-access-error-path-redaction`.
+- HEAD base: `7297be2b031e18b77164bf0ea610654cd9ba4ea6`.
+- Naturaleza: hotfix R2 de seguridad autorizado por Nico.
+
+## Objetivo
+
+Evitar que una credencial incluida en el path de Public Report Access aparezca
+en `response.path` cuando el handler global transforma un fallo interno en una
+respuesta HTTP.
+
+## Alcance incluido
+
+- `server/fastify-app.ts`.
+- Evidencia ejecutable conjunta en
+  `test/security/token-access-enumeration-disclosure-regression.test.ts`.
+- Este documento.
+
+## Alcance excluido
+
+No se modifican autenticación, cookies, sesiones, CORS, rate limits, schema,
+migraciones, dependencias, frontend, CI ni runtime ajeno al handler global de
+errores. M36 y Reports Phase I no se inician.
+
+## Estado previo y hallazgo
+
+`public-report-access.fastify.ts` ya sanitizaba el path en logs mediante
+`sanitizeUrlForLogs`. Sin embargo, `getFastifyErrorResponsePath` construía el
+campo `path` desde `request.url` sin esa sanitización.
+
+Una excepción de repository o storage en
+`GET /api/public/report-access/:token` producía:
+
+- status `500`;
+- mensaje público genérico;
+- `path` con el token raw.
+
+El token no aparecía en el mensaje genérico, pero su presencia en `path`
+seguía siendo exposición de una credencial.
+
+## Cambio
+
+`getFastifyErrorResponsePath` aplica el sanitizador canónico antes de extraer
+el pathname. Para Public Report Access, el contrato resultante es:
+
+```text
+/api/public/report-access/[REDACTED]
+```
+
+El cambio no altera status codes, bodies funcionales, autenticación, orden de
+side effects ni políticas de rate limit.
+
+## Evidencia
+
+La matriz ejecutable cubre:
+
+- Particular Access missing y foreign clinic indistinguibles;
+- selectores hostiles subordinados al `clinicId` autenticado;
+- redacción de token raw/hash y errores internos;
+- Report Access público malformed, missing, revoked, expired y cross-clinic
+  con `404` genérico;
+- unavailable con `409`;
+- acceso exitoso;
+- fallos de repository y storage con `500`, mensaje genérico y path redactado;
+- rate limit antes de parse/hash/lookup;
+- conteo y orden de record-access, signed URLs y audit.
+
+## Seguridad y riesgo residual
+
+El hotfix reutiliza una función existente y no introduce una segunda regla de
+redacción. El riesgo residual es que futuras credenciales incorporadas a otros
+paths deban registrarse también en el sanitizador canónico. No se afirma
+evidencia de staging, producción, DB real ni RLS.
+
+## Rollback
+
+Revertir únicamente la importación de `sanitizeUrlForLogs` y su aplicación en
+`getFastifyErrorResponsePath`. Ese rollback reabriría la exposición y no debe
+realizarse sin una alternativa equivalente.
+
+## Validaciones
+
+- `pnpm exec node --experimental-strip-types --test
+  test/security/token-access-enumeration-disclosure-regression.test.ts`:
+  `PASSED` (4/4).
+- `pnpm exec node --experimental-strip-types --test
+  test/integration/adapters/controllers/public-report-access.fastify.test.ts`:
+  `PASSED` (7/7).
+- `pnpm exec node --experimental-strip-types --test
+  test/integration/app/fastify-app.test.ts`: `PASSED` (26/26).
+- `pnpm validate:local`: corridas preliminares `FAILED` por tipado incompleto
+  del fixture nuevo y luego por un test de workflow transitorio. Corregido el
+  fixture, el test de workflow pasó dirigido 7/7 y la corrida final quedó
+  `PASSED` con typecheck, typecheck:test, 3725 tests aprobados, un skip previsto
+  y build.
+- `pnpm security:public-surface`: `PASSED`.
+- `pnpm audit --prod` y `pnpm audit`: `NOT_RUN`; no se modificaron
+  dependencias ni lockfiles.
+- Playwright, migraciones y frontend build: `NOT_RUN`; fuera del alcance.
+
+## Estado final
+
+Hotfix local implementado y validado sobre el baseline indicado. M35b se
+preserva como evidencia y no inicia M36 ni Reports Phase I.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -4,6 +4,7 @@ import Fastify, {
   type FastifyRequest,
 } from "fastify";
 import { ENV } from "./lib/env.ts";
+import { sanitizeUrlForLogs } from "./middlewares/request-logger.ts";
 import {
   adminAuditNativeRoutes,
   type AdminAuditNativeRoutesOptions,
@@ -256,7 +257,7 @@ function getPayloadText(payload: unknown): string | null {
 }
 
 function getFastifyErrorResponsePath(request: FastifyRequest) {
-  const url = request.url ?? "";
+  const url = sanitizeUrlForLogs(request.url ?? "");
 
   try {
     return new URL(url, "http://portal-vetneb.local").pathname;

--- a/test/security/token-access-enumeration-disclosure-regression.test.ts
+++ b/test/security/token-access-enumeration-disclosure-regression.test.ts
@@ -1,0 +1,601 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type { Report, ReportAccessToken } from "../../drizzle/schema.ts";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { ENV } = await import("../../server/lib/env.ts");
+const { createFastifyApp } = await import("../../server/fastify-app.ts");
+const { buildFastifyDispatchRouteStubs } =
+  await import("../helpers/fastify-app-route-stubs.ts");
+
+const now = Date.UTC(2026, 6, 25, 12);
+const clinicId = 3;
+const clinicUserId = 9;
+const rawTokenSentinel = "a".repeat(64);
+const tokenHashSentinel = "token_hash_sentinel_m35b";
+const internalFailureSentinel =
+  "SELECT token_hash FROM protected_table; internal_stack_sentinel_m35b";
+
+type JsonObject = Record<string, unknown>;
+
+function report(overrides: Partial<Report> = {}): Report {
+  return {
+    id: 55,
+    clinicId,
+    uploadDate: new Date("2026-07-24T09:00:00.000Z"),
+    studyType: "Histopatologia",
+    patientName: "Paciente de prueba",
+    fileName: "report-55.pdf",
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-07-24T09:30:00.000Z"),
+    createdAt: new Date("2026-07-24T09:00:00.000Z"),
+    updatedAt: new Date("2026-07-24T09:30:00.000Z"),
+    storagePath: "reports/report-55.pdf",
+    previewUrl: null,
+    downloadUrl: null,
+    statusChangedByClinicUserId: null,
+    statusChangedByAdminUserId: null,
+    workflowStage: "sample_received",
+    specialStainRequested: false,
+    specialStainAt: null,
+    workflowUpdatedAt: null,
+    ...overrides,
+  };
+}
+
+function reportAccessToken(
+  overrides: Partial<ReportAccessToken> = {},
+): ReportAccessToken {
+  return {
+    id: 91,
+    clinicId,
+    reportId: 55,
+    tokenHash: tokenHashSentinel,
+    tokenLast4: "rrrr",
+    accessCount: 2,
+    lastAccessAt: null,
+    expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+    revokedAt: null,
+    createdAt: new Date("2026-07-24T09:00:00.000Z"),
+    updatedAt: new Date("2026-07-24T09:30:00.000Z"),
+    createdByClinicUserId: clinicUserId,
+    createdByAdminUserId: null,
+    revokedByClinicUserId: null,
+    revokedByAdminUserId: null,
+    ...overrides,
+  };
+}
+
+function particularToken(overrides: JsonObject = {}) {
+  return {
+    id: 71,
+    clinicId,
+    reportId: 55,
+    tokenHash: tokenHashSentinel,
+    tokenLast4: "rrrr",
+    tutorLastName: "Tutor",
+    petName: "Paciente",
+    petAge: "5",
+    petBreed: "Mestiza",
+    petSex: "Hembra",
+    petSpecies: "Canina",
+    sampleLocation: "Piel",
+    sampleEvolution: "Dos semanas",
+    detailsLesion: null,
+    extractionDate: new Date("2026-07-22T00:00:00.000Z"),
+    shippingDate: new Date("2026-07-23T00:00:00.000Z"),
+    isActive: true,
+    lastLoginAt: null,
+    createdAt: new Date("2026-07-22T12:00:00.000Z"),
+    updatedAt: new Date("2026-07-23T12:00:00.000Z"),
+    createdByAdminId: null,
+    createdByClinicUserId: clinicUserId,
+    ...overrides,
+  };
+}
+
+function clinicAuthStubs() {
+  return {
+    getActiveSessionByToken: async () => ({
+      clinicUserId,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date(now - 60_000),
+    }),
+    getClinicUserById: async () => ({
+      id: clinicUserId,
+      clinicId,
+      username: "clinic-owner-m35b",
+      authProId: null,
+      role: "clinic_owner",
+    }),
+    updateSessionLastAccess: async () => {},
+  };
+}
+
+function normalizeBody(body: string): unknown {
+  const parsed = JSON.parse(body) as JsonObject;
+  delete parsed.requestId;
+  return parsed;
+}
+
+function relevantHeaders(headers: Record<string, unknown>) {
+  return {
+    contentType: headers["content-type"],
+    noStore: headers["cache-control"],
+    rateLimitPolicy: headers["ratelimit-policy"],
+    rateLimitLimit: headers["ratelimit-limit"],
+    rateLimitRemaining: headers["ratelimit-remaining"],
+    rateLimitReset: headers["ratelimit-reset"],
+  };
+}
+
+function assertNoSensitiveDisclosure(value: unknown) {
+  const serialized = JSON.stringify(value);
+  for (const forbidden of [
+    rawTokenSentinel,
+    tokenHashSentinel,
+    "tokenHash",
+    "tokenRaw",
+    "session",
+    "SELECT token_hash",
+    "internal_stack_sentinel_m35b",
+  ]) {
+    assert.equal(
+      serialized.includes(forbidden),
+      false,
+      `response must redact ${forbidden}`,
+    );
+  }
+}
+
+async function withMutedExpectedError<T>(operation: () => Promise<T>) {
+  const originalError = console.error;
+  console.error = () => {};
+  try {
+    return await operation();
+  } finally {
+    console.error = originalError;
+  }
+}
+
+test("Particular Access unifica missing y foreign, ignora selectores hostiles y redacta secretos", async () => {
+  const hiddenResponses: Array<{
+    status: number;
+    body: unknown;
+    headers: ReturnType<typeof relevantHeaders>;
+    calls: string[];
+  }> = [];
+
+  for (const scenario of ["missing", "foreign-clinic"] as const) {
+    const calls: string[] = [];
+    const stubs = buildFastifyDispatchRouteStubs();
+    const app = await createFastifyApp({
+      ...stubs,
+      particularTokensRoutes: {
+        ...stubs.particularTokensRoutes,
+        ...clinicAuthStubs(),
+        getClinicScopedParticularToken: async (
+          tokenId: number,
+          authenticatedClinicId: number,
+        ) => {
+          calls.push(
+            `lookup:${scenario}:${tokenId}:${authenticatedClinicId}`,
+          );
+          return null;
+        },
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/particular-tokens/71",
+        headers: {
+          cookie: `${ENV.cookieName}=clinic-session-m35b`,
+        },
+      });
+      const body = normalizeBody(response.body);
+      hiddenResponses.push({
+        status: response.statusCode,
+        body,
+        headers: relevantHeaders(response.headers),
+        calls,
+      });
+      assertNoSensitiveDisclosure(body);
+      assert.deepEqual(calls, [`lookup:${scenario}:71:${clinicId}`]);
+    } finally {
+      await app.close();
+    }
+  }
+
+  assert.equal(hiddenResponses[0].status, 404);
+  assert.equal(hiddenResponses[1].status, 404);
+  assert.deepEqual(hiddenResponses[0].body, hiddenResponses[1].body);
+  assert.deepEqual(hiddenResponses[0].headers, hiddenResponses[1].headers);
+
+  const listCalls: JsonObject[] = [];
+  const stubs = buildFastifyDispatchRouteStubs();
+  const app = await createFastifyApp({
+    ...stubs,
+    particularTokensRoutes: {
+      ...stubs.particularTokensRoutes,
+      ...clinicAuthStubs(),
+      listParticularTokens: async (params: JsonObject) => {
+        listCalls.push(params);
+        return [particularToken({ isActive: false })];
+      },
+    },
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/particular-tokens?clinicId=999&tokenId=999&reportId=999",
+      headers: {
+        cookie: `${ENV.cookieName}=clinic-session-m35b`,
+      },
+    });
+    const body = normalizeBody(response.body);
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(listCalls, [{ clinicId, limit: 50, offset: 0 }]);
+    assertNoSensitiveDisclosure(body);
+  } finally {
+    await app.close();
+  }
+});
+
+test("Particular Access unifica report foreign y missing y redacta fallos repository", async () => {
+  const outcomes: Array<{ status: number; body: unknown; updateCalls: number }> =
+    [];
+
+  for (const scenario of ["missing", "foreign-clinic"] as const) {
+    let updateCalls = 0;
+    const stubs = buildFastifyDispatchRouteStubs();
+    const app = await createFastifyApp({
+      ...stubs,
+      particularTokensRoutes: {
+        ...stubs.particularTokensRoutes,
+        ...clinicAuthStubs(),
+        getClinicScopedParticularToken: async () =>
+          particularToken({ reportId: null }),
+        getClinicScopedReportById: async () => null,
+        updateParticularTokenReport: async () => {
+          updateCalls += 1;
+          return particularToken();
+        },
+      },
+    });
+
+    try {
+      const response = await app.inject({
+        method: "PATCH",
+        url: "/api/particular-tokens/71/report",
+        headers: {
+          cookie: `${ENV.cookieName}=clinic-session-m35b`,
+          origin: ENV.corsOrigins[0] ?? "http://localhost:3000",
+        },
+        payload: {
+          reportId: 999,
+          clinicId: scenario === "foreign-clinic" ? 999 : clinicId,
+        },
+      });
+      const body = normalizeBody(response.body);
+      outcomes.push({ status: response.statusCode, body, updateCalls });
+      assertNoSensitiveDisclosure(body);
+    } finally {
+      await app.close();
+    }
+  }
+
+  assert.deepEqual(outcomes[0], outcomes[1]);
+  assert.deepEqual(outcomes[0], {
+    status: 404,
+    body: { success: false, error: "Informe no encontrado" },
+    updateCalls: 0,
+  });
+
+  const stubs = buildFastifyDispatchRouteStubs();
+  const app = await createFastifyApp({
+    ...stubs,
+    particularTokensRoutes: {
+      ...stubs.particularTokensRoutes,
+      ...clinicAuthStubs(),
+      getClinicScopedParticularToken: async () => {
+        throw new Error(internalFailureSentinel);
+      },
+    },
+  });
+
+  try {
+    const response = await withMutedExpectedError(() =>
+      app.inject({
+        method: "GET",
+        url: "/api/particular-tokens/71",
+        headers: {
+          cookie: `${ENV.cookieName}=clinic-session-m35b`,
+        },
+      }),
+    );
+    const body = normalizeBody(response.body);
+    assert.equal(response.statusCode, 500);
+    assert.equal((body as JsonObject).error, "Error interno del servidor");
+    assertNoSensitiveDisclosure(body);
+  } finally {
+    await app.close();
+  }
+});
+
+test("Report Access publico ejecuta la matriz M35b sin enumeracion ni disclosure", async () => {
+  type Scenario = {
+    name:
+      | "malformed"
+      | "missing"
+      | "revoked"
+      | "expired"
+      | "cross-clinic"
+      | "unavailable"
+      | "success"
+      | "repository-failure"
+      | "storage-failure";
+    rawToken: string;
+    record?: ReturnType<typeof reportAccessToken> extends infer TToken
+      ? { token: TToken; report: ReturnType<typeof report> } | null
+      : never;
+    expectedStatus: number;
+    expectedCalls: readonly string[];
+  };
+
+  const scenarios: readonly Scenario[] = [
+    {
+      name: "malformed",
+      rawToken: "malformed",
+      expectedStatus: 404,
+      expectedCalls: [],
+    },
+    {
+      name: "missing",
+      rawToken: rawTokenSentinel,
+      record: null,
+      expectedStatus: 404,
+      expectedCalls: ["hash", "lookup"],
+    },
+    {
+      name: "revoked",
+      rawToken: rawTokenSentinel,
+      record: {
+        token: reportAccessToken({ revokedAt: new Date(now - 1) }),
+        report: report(),
+      },
+      expectedStatus: 404,
+      expectedCalls: ["hash", "lookup"],
+    },
+    {
+      name: "expired",
+      rawToken: rawTokenSentinel,
+      record: {
+        token: reportAccessToken({ expiresAt: new Date(now) }),
+        report: report(),
+      },
+      expectedStatus: 404,
+      expectedCalls: ["hash", "lookup"],
+    },
+    {
+      name: "cross-clinic",
+      rawToken: rawTokenSentinel,
+      record: {
+        token: reportAccessToken(),
+        report: report({ clinicId: 999 }),
+      },
+      expectedStatus: 404,
+      expectedCalls: ["hash", "lookup"],
+    },
+    {
+      name: "unavailable",
+      rawToken: rawTokenSentinel,
+      record: {
+        token: reportAccessToken(),
+        report: report({ currentStatus: "processing" }),
+      },
+      expectedStatus: 409,
+      expectedCalls: ["hash", "lookup"],
+    },
+    {
+      name: "success",
+      rawToken: rawTokenSentinel,
+      record: { token: reportAccessToken(), report: report() },
+      expectedStatus: 200,
+      expectedCalls: [
+        "hash",
+        "lookup",
+        "record-access",
+        "signed-preview",
+        "signed-download",
+        "audit",
+      ],
+    },
+    {
+      name: "repository-failure",
+      rawToken: rawTokenSentinel,
+      expectedStatus: 500,
+      expectedCalls: ["hash", "lookup"],
+    },
+    {
+      name: "storage-failure",
+      rawToken: rawTokenSentinel,
+      record: { token: reportAccessToken(), report: report() },
+      expectedStatus: 500,
+      expectedCalls: [
+        "hash",
+        "lookup",
+        "record-access",
+        "signed-preview",
+        "signed-download",
+      ],
+    },
+  ];
+
+  const generic404: Array<{
+    body: unknown;
+    headers: ReturnType<typeof relevantHeaders>;
+  }> = [];
+
+  for (const scenario of scenarios) {
+    const calls: string[] = [];
+    const stubs = buildFastifyDispatchRouteStubs();
+    const app = await createFastifyApp({
+      ...stubs,
+      publicReportAccessRoutes: {
+        ...stubs.publicReportAccessRoutes,
+        now: () => now,
+        hashSessionToken: () => {
+          calls.push("hash");
+          return tokenHashSentinel;
+        },
+        getReportAccessTokenWithReportByTokenHash: async () => {
+          calls.push("lookup");
+          if (scenario.name === "repository-failure") {
+            throw new Error(internalFailureSentinel);
+          }
+          return scenario.record ?? null;
+        },
+        recordReportAccessTokenAccess: async () => {
+          calls.push("record-access");
+          return reportAccessToken({
+            accessCount: 3,
+            lastAccessAt: new Date(now),
+          }) as never;
+        },
+        createSignedReportUrl: async () => {
+          calls.push("signed-preview");
+          if (scenario.name === "storage-failure") {
+            throw new Error(internalFailureSentinel);
+          }
+          return "https://signed.example/preview";
+        },
+        createSignedReportDownloadUrl: async () => {
+          calls.push("signed-download");
+          return "https://signed.example/download";
+        },
+        writeAuditLog: async (_request: unknown, input: JsonObject) => {
+          calls.push("audit");
+          assert.equal(input.clinicId, clinicId);
+          assert.equal(input.reportId, 55);
+          assert.equal(input.targetReportAccessTokenId, 91);
+          assert.equal(
+            JSON.stringify(input).includes(tokenHashSentinel),
+            false,
+          );
+          assert.equal(
+            JSON.stringify(input).includes(rawTokenSentinel),
+            false,
+          );
+        },
+      },
+    });
+
+    try {
+      const operation = () =>
+        app.inject({
+          method: "GET",
+          url: `/api/public/report-access/${scenario.rawToken}`,
+        });
+      const response =
+        scenario.expectedStatus === 500
+          ? await withMutedExpectedError(operation)
+          : await operation();
+      const body = normalizeBody(response.body);
+
+      assert.equal(response.statusCode, scenario.expectedStatus, scenario.name);
+      assert.deepEqual(calls, scenario.expectedCalls, scenario.name);
+      assertNoSensitiveDisclosure(body);
+
+      if (scenario.expectedStatus === 404) {
+        generic404.push({
+          body,
+          headers: relevantHeaders(response.headers),
+        });
+      }
+      if (scenario.name === "unavailable") {
+        assert.deepEqual(body, {
+          success: false,
+          error:
+            "El informe todavia no esta disponible para acceso publico"
+              .replace("todavia", "todavía")
+              .replace("esta", "está")
+              .replace("publico", "público"),
+          currentStatus: "processing",
+        });
+      }
+      if (scenario.expectedStatus === 500) {
+        assert.equal(
+          (body as JsonObject).error,
+          "Error interno del servidor",
+        );
+        assert.equal(
+          (body as JsonObject).path,
+          "/api/public/report-access/[REDACTED]",
+        );
+        assert.equal(calls.includes("audit"), false);
+      }
+    } finally {
+      await app.close();
+    }
+  }
+
+  assert.equal(generic404.length, 5);
+  for (const outcome of generic404.slice(1)) {
+    assert.deepEqual(outcome, generic404[0]);
+  }
+});
+
+test("Report Access publico aplica rate limit antes de parse, hash y repository", async () => {
+  const calls: string[] = [];
+  const stubs = buildFastifyDispatchRouteStubs();
+  const app = await createFastifyApp({
+    ...stubs,
+    publicReportAccessRoutes: {
+      ...stubs.publicReportAccessRoutes,
+      now: () => now,
+      publicReportAccessRateLimitMaxAttempts: 1,
+      publicReportAccessRateLimitWindowMs: 60_000,
+      hashSessionToken: () => {
+        calls.push("hash");
+        return tokenHashSentinel;
+      },
+      getReportAccessTokenWithReportByTokenHash: async () => {
+        calls.push("lookup");
+        return null;
+      },
+    },
+  });
+
+  try {
+    const first = await app.inject({
+      method: "GET",
+      url: `/api/public/report-access/${rawTokenSentinel}`,
+      remoteAddress: "203.0.113.35",
+    });
+    const callsAfterFirst = [...calls];
+    const second = await app.inject({
+      method: "GET",
+      url: `/api/public/report-access/${rawTokenSentinel}`,
+      remoteAddress: "203.0.113.35",
+    });
+
+    assert.equal(first.statusCode, 404);
+    assert.equal(second.statusCode, 429);
+    assert.deepEqual(callsAfterFirst, ["hash", "lookup"]);
+    assert.deepEqual(calls, callsAfterFirst);
+    assertNoSensitiveDisclosure(normalizeBody(second.body));
+  } finally {
+    await app.close();
+  }
+});


### PR DESCRIPTION
## Summary

- redacts sensitive token route segments before exposing `response.path` from the global Fastify error handler
- reuses the canonical URL sanitizer without changing the error envelope, status code, request ID, logging, or normal non-sensitive paths
- adds an executable regression matrix covering public Report Access repository and storage failures
- documents the R2 security hotfix and its validation evidence
- preserves M35b without starting M36 or Reports Phase I

## Scope

- [x] Backend Runtime

Security correction limited to:

- `server/fastify-app.ts`
- `test/security/token-access-enumeration-disclosure-regression.test.ts`
- `docs/implementation/public-report-access-error-path-redaction-hotfix.md`

Tests and documentation support the single backend runtime scope.

Excluded:

- authentication
- cookies and sessions
- CORS and trusted-origin
- rate limits
- feature repositories and routes
- schema and migrations
- dependencies and lockfiles
- frontend
- CI and workflows
- M36 and Reports Phase I

## Validation

- token-access enumeration/disclosure regression: PASSED, 4/4
- Public Report Access integration: PASSED, 7/7
- Fastify app integration: PASSED, 26/26
- `pnpm validate:local`: PASSED, 3725 pass, 1 skip, 0 fail, build included
- `pnpm security:public-surface`: PASSED
- `git diff --check`: PASSED
- dependency audits: NOT_RUN, dependency graph unchanged
- Playwright: NOT_RUN, frontend unchanged
- migrations: NOT_RUN, schema unchanged

The first complete validation attempts exposed fixture typing issues and one transient out-of-scope workflow-test failure. The fixtures were aligned with the current schema, the isolated workflow test passed, and the final complete validation passed without runtime changes beyond the authorized redaction.

## Rollback

Revert the hotfix commit to restore the previous global error-path behavior and remove its regression evidence and implementation record. No schema, migration, dependency, credential, storage, or data rollback is required.