### PR TITLE
test(security): close token access phase

### DIFF
--- a/docs/implementation/m35b-token-access-enumeration-disclosure-closeout.md
+++ b/docs/implementation/m35b-token-access-enumeration-disclosure-closeout.md
@@ -1,0 +1,122 @@
+# M35b — Token Access enumeration/disclosure closeout
+
+## Identificación
+
+- Milestone: M35b.
+- Repositorio: `LABVETNEB/PORTAL-VETNEB`.
+- Rama:
+  `test/backend-modularization-m35b-token-access-enumeration-disclosure-closeout`.
+- Baseline exacto: `f30bef676bb93d4e2d6e766386139ad053624a30`.
+- M33: cerrado por PR #1570.
+- M34: cerrado por PR #1572.
+- Hotfix R2 de redacción global: PR #1573.
+
+## Scope
+
+Incluye la regresión ejecutable conjunta de Particular Access y Report Access,
+el guard arquitectónico M35b, la ampliación conjunta de la matriz cross-tenant
+IDOR, el registro de owners en suite completeness y este closeout.
+
+Excluye runtime, frontend, schema/migraciones, dependencias, CI, auth, cookies,
+sesiones, CORS, cambios de rate limits, M36 y Reports Phase I. No se modifican
+implementaciones ni reglas internas ya cerradas por M33 y M34.
+
+## Matriz Particular Access
+
+| Contrato | Evidencia ejecutable |
+| --- | --- |
+| Token missing vs foreign | mismo `404`, body y headers |
+| Selector hostil | query `clinicId`, `tokenId` y `reportId` no reemplaza la clínica autenticada |
+| Report missing vs foreign | mismo resultado y cero writes |
+| Repository failure | `500` genérico sin error interno |
+| Token raw/hash | ausentes de respuestas y auditoría |
+| Clinic authority | `clinicId` deriva de la sesión autenticada |
+| Side effects | ownership inválido corta antes de persistir |
+
+## Matriz Report Access
+
+| Contrato | Evidencia ejecutable |
+| --- | --- |
+| malformed, missing, revoked, expired y cross-clinic | `404` indistinguible |
+| unavailable | `409` legítimamente distinguible |
+| success | `200` y orden completo observado |
+| repository failure | `500` genérico, sin audit |
+| storage failure | `500` genérico, sin audit |
+| rate limit | `429` antes de parse, hash y repository |
+| side effects | record access antes de signed URLs; audit al final |
+| path redaction | `response.path` es `/api/public/report-access/[REDACTED]` |
+
+## Contratos cerrados
+
+- Las respuestas de recursos missing, foreign, inválidos por lifecycle o
+  cross-realm son indistinguibles cuando el contrato exige ocultamiento.
+- `409` para informe no disponible y `429` para rate limit permanecen estados
+  legítimamente distinguibles.
+- No se exponen token raw/hash, detalles de repository/storage, SQL ni stack.
+- El scope de clínica autenticada prevalece sobre selectores hostiles.
+- Particular Access y Report Access permanecen separados por realm.
+- La auditoría conserva atribución segura por actor, clínica, informe y token
+  id, sin credenciales.
+- Revocación y expiración se evalúan antes de exponer el informe.
+- El rate limit público corta antes de parse, hash, repository y side effects.
+
+## Hotfix R2
+
+M35b detectó el P1 de disclosure del token raw mediante `response.path`. El PR
+#1573 corrigió el path global antes de este closeout y dejó el contrato
+ejecutable en
+`test/security/token-access-enumeration-disclosure-regression.test.ts`. El
+hallazgo inicial está corregido y no constituye un fallo residual.
+
+## Guards
+
+- A — registry/path/closeout, misma cobertura:
+  `test/architecture/security/security-boundary-suite-completeness.test.ts` y
+  `test/architecture/token-access-m35b-closeout.test.ts`.
+- B — matriz conjunta con evidencia ejecutable:
+  `test/architecture/security/security-cross-tenant-idor-contract.test.ts`.
+- C — debilitamiento: 0.
+
+Los demás guards globales de lifecycle, rate limits, ownership, disclosure,
+log redaction y write attribution ya anclaban las superficies canónicas y no
+se modificaron sólo para mencionar M35b.
+
+## Validación
+
+| Gate | Estado | Resultado |
+| --- | --- | --- |
+| Cohorte M35b | PASSED | exit 0, 10/10 |
+| Cinco integraciones token access | PASSED | exit 0, 49/49 |
+| Suite completeness | PASSED | exit 0, 6/6 |
+| Cross-tenant IDOR final | PASSED | exit 0, 9/9 |
+| `pnpm typecheck:test` | PASSED | exit 0 |
+| `pnpm validate:local` | PASSED | exit 0; typechecks, 3.732 pass, 1 skip, 0 fail y build |
+| `pnpm security:public-surface` | PASSED | exit 0, sin findings públicos |
+| `pnpm audit --prod` | PASSED | exit 0, sin vulnerabilidades conocidas |
+| `pnpm audit` | PASSED | exit 0, sin vulnerabilidades conocidas |
+| `git diff --check` | PASSED | exit 0 |
+
+La primera cohorte M35b quedó `FAILED` 9/10 porque el guard nuevo no reconocía
+la allowlist M33 expresada como array seguido de `.sort()`; el parser
+source-aware se corrigió y la repetición exacta quedó `PASSED` 10/10. La
+primera cohorte de guards quedó `FAILED` 14/15 por una colisión de substring
+con el autocontrol de secretos del propio CTIDOR; se corrigió sólo esa frase y
+CTIDOR quedó `PASSED` 9/9. No hubo fallos runtime.
+
+## Riesgo residual
+
+- No existe ni se afirma RLS.
+- Staging, DB real y producción: NOT_RUN.
+- Playwright: NOT_RUN, fuera del scope.
+- M36 permanece pendiente.
+
+## Rollback
+
+Revertir únicamente los tests, guards y documentación M35b. No hay runtime,
+schema, migración ni datos que compensar.
+
+## Estado final
+
+- Fase H: cerrada.
+- M36: no iniciado.
+- Reports Phase I: no iniciada.

--- a/test/architecture/security/security-boundary-suite-completeness.test.ts
+++ b/test/architecture/security/security-boundary-suite-completeness.test.ts
@@ -666,6 +666,14 @@ test("security boundary suite keeps required downstream runtime tests explicit",
       marker: "audit exports rechazan cookies de dominios cruzados antes de listar",
     },
     {
+      path: "test/security/token-access-enumeration-disclosure-regression.test.ts",
+      marker: "Report Access publico ejecuta la matriz M35b sin enumeracion ni disclosure",
+    },
+    {
+      path: "test/architecture/token-access-m35b-closeout.test.ts",
+      marker: "M35b ancla la matriz ejecutable conjunta por tests y escenarios concretos",
+    },
+    {
       path: "test/architecture/security/security-production-invariants.test.ts",
       marker: "errores internos se loguean, pero la respuesta 500 no expone detalles",
     },

--- a/test/architecture/security/security-cross-tenant-idor-contract.test.ts
+++ b/test/architecture/security/security-cross-tenant-idor-contract.test.ts
@@ -408,6 +408,28 @@ const CROSS_TENANT_IDOR_CONTRACTS: readonly CrossTenantIdorContract[] = [
     ],
     productionReadinessStatus: "pending_runtime_staging_evidence",
   },
+  {
+    id: "CTIDOR-018",
+    actor: "clinic_session_and_public_report_token",
+    resource: "particular_and_public_report_token_access",
+    operation:
+      "Particular and Report Access must hide missing foreign and cross-realm resources while ignoring hostile tenant selectors",
+    requiredOwnerKey: "auth.clinicId_and_token_hash",
+    expectedFailure: {
+      status: 404,
+      noDisclosure: true,
+      reason: "hidden_missing_foreign_or_cross_realm_token_resource",
+    },
+    protectedSurface: "server/routes/public-report-access.fastify.ts",
+    runtimeEvidence: [
+      "staging probes across clinic and public access domains remain pending",
+      "verify hostile selectors cannot replace authenticated clinic ownership",
+    ],
+    requiredTestEvidence: [
+      "test/security/token-access-enumeration-disclosure-regression.test.ts",
+    ],
+    productionReadinessStatus: "pending_runtime_staging_evidence",
+  },
 ] as const;
 
 function readSource(relativePath: string): string {
@@ -428,7 +450,7 @@ test("cross-tenant IDOR contract matrix has unique IDs", () => {
   const ids = CROSS_TENANT_IDOR_CONTRACTS.map((contract) => contract.id);
 
   assert.deepEqual(ids, uniqueValues(ids));
-  assert.equal(ids.length >= 17, true);
+  assert.equal(ids.length >= 18, true);
 
   for (const id of ids) {
     assert.match(id, /^CTIDOR-\d{3}$/);
@@ -652,6 +674,30 @@ test("Study Tracking contract links executable tenant and cross-realm evidence",
     ),
     true,
   );
+});
+
+test("Token Access contract links joint non-enumeration and hostile-selector evidence", () => {
+  const contract = CROSS_TENANT_IDOR_CONTRACTS.find(
+    (candidate) => candidate.id === "CTIDOR-018",
+  );
+
+  assert.ok(contract);
+  assert.deepEqual(contract.requiredTestEvidence, [
+    "test/security/token-access-enumeration-disclosure-regression.test.ts",
+  ]);
+  assert.equal(
+    contract.productionReadinessStatus,
+    "pending_runtime_staging_evidence",
+  );
+
+  const jointEvidence = readSource(contract.requiredTestEvidence[0]);
+  for (const marker of [
+    "Particular Access unifica missing y foreign, ignora selectores hostiles y redacta secretos",
+    "Particular Access unifica report foreign y missing y redacta fallos repository",
+    "Report Access publico ejecuta la matriz M35b sin enumeracion ni disclosure",
+  ]) {
+    assert.equal(jointEvidence.includes(marker), true, marker);
+  }
 });
 
 test("cross-tenant IDOR contract file does not contain dangerous inline secrets or real credentials", () => {

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -1,0 +1,378 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const root = process.cwd();
+const evidence =
+  "test/security/token-access-enumeration-disclosure-regression.test.ts";
+const closeout =
+  "docs/implementation/m35b-token-access-enumeration-disclosure-closeout.md";
+
+const featureLayers = [
+  {
+    feature: "server/features/particular-access",
+    required: [
+      "README.md",
+      "domain",
+      "application",
+      "infrastructure",
+      "particular-access-route-composition.ts",
+    ],
+  },
+  {
+    feature: "server/features/report-access",
+    required: [
+      "README.md",
+      "domain",
+      "application",
+      "infrastructure",
+      "composition",
+    ],
+  },
+] as const;
+
+const ownRoutes = [
+  "server/routes/admin-particular-tokens.fastify.ts",
+  "server/routes/particular-tokens.fastify.ts",
+  "server/routes/admin-report-access-tokens.fastify.ts",
+  "server/routes/report-access-tokens.fastify.ts",
+  "server/routes/public-report-access.fastify.ts",
+] as const;
+
+const globalGuardAnchors = [
+  {
+    path: "test/architecture/security/security-access-lifecycle-boundaries.test.ts",
+    anchors: [
+      "server/features/report-access/application/public-report-access-operations.ts",
+      "server/routes/public-report-access.fastify.ts",
+    ],
+  },
+  {
+    path: "test/architecture/security/security-rate-limit-isolation-boundaries.test.ts",
+    anchors: [
+      "server/routes/public-report-access.fastify.ts",
+      "server/lib/public-report-access-rate-limit.ts",
+    ],
+  },
+  {
+    path: "test/architecture/security/security-resource-ownership-boundaries.test.ts",
+    anchors: [
+      "server/features/particular-access/application/clinic-particular-access-operations.ts",
+      "server/features/report-access/application/clinic-report-access-operations.ts",
+    ],
+  },
+  {
+    path: "test/architecture/security/security-response-disclosure-boundaries.test.ts",
+    anchors: [
+      "server/routes/public-report-access.fastify.ts",
+      "server/routes/report-access-tokens.fastify.ts",
+    ],
+  },
+  {
+    path: "test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts",
+    anchors: [
+      "server/routes/public-report-access.fastify.ts",
+      "server/features/report-access/application/public-report-access-operations.ts",
+    ],
+  },
+  {
+    path: "test/architecture/security/security-write-attribution-boundaries.test.ts",
+    anchors: [
+      "server/features/particular-access/application/clinic-particular-access-operations.ts",
+      "server/features/report-access/application/public-report-access-operations.ts",
+    ],
+  },
+  {
+    path: "test/architecture/security/security-cross-tenant-idor-contract.test.ts",
+    anchors: [evidence, "CTIDOR-018"],
+  },
+  {
+    path: "test/architecture/security/security-boundary-suite-completeness.test.ts",
+    anchors: [
+      evidence,
+      "test/architecture/token-access-m35b-closeout.test.ts",
+    ],
+  },
+] as const;
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), "utf8").replace(/\r\n/g, "\n");
+}
+
+function walk(path: string): string[] {
+  const absolute = resolve(root, path);
+  if (!existsSync(absolute)) return [];
+  return readdirSync(absolute, { withFileTypes: true }).flatMap((entry) => {
+    const child = `${path}/${entry.name}`;
+    return entry.isDirectory() ? walk(child) : [child];
+  });
+}
+
+function parse(path: string): ts.SourceFile {
+  return ts.createSourceFile(
+    path,
+    read(path),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function resolveImportTarget(path: string, specifier: string): string {
+  return specifier.startsWith(".")
+    ? relative(root, resolve(root, dirname(path), specifier)).replaceAll("\\", "/")
+    : specifier;
+}
+
+function executableImportTargets(path: string): string[] {
+  const targets: string[] = [];
+  function visit(node: ts.Node): void {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const clause = node.importClause;
+      const namedBindings = clause?.namedBindings;
+      const onlyTypeSpecifiers =
+        namedBindings &&
+        ts.isNamedImports(namedBindings) &&
+        namedBindings.elements.length > 0 &&
+        namedBindings.elements.every((element) => element.isTypeOnly);
+      if (
+        !clause?.isTypeOnly &&
+        (clause?.name || !onlyTypeSpecifiers)
+      ) {
+        targets.push(
+          resolveImportTarget(path, node.moduleSpecifier.text),
+        );
+      }
+    } else if (
+      ts.isExportDeclaration(node) &&
+      !node.isTypeOnly &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      targets.push(resolveImportTarget(path, node.moduleSpecifier.text));
+    } else if (
+      ts.isCallExpression(node) &&
+      node.expression.kind === ts.SyntaxKind.ImportKeyword &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      targets.push(resolveImportTarget(path, node.arguments[0].text));
+    }
+    node.forEachChild(visit);
+  }
+  parse(path).forEachChild(visit);
+  return targets;
+}
+
+function testNames(path: string): string[] {
+  const names: string[] = [];
+  function visit(node: ts.Node): void {
+    if (
+      ts.isCallExpression(node) &&
+      ts.isIdentifier(node.expression) &&
+      node.expression.text === "test" &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0])
+    ) {
+      names.push(node.arguments[0].text);
+    }
+    node.forEachChild(visit);
+  }
+  parse(path).forEachChild(visit);
+  return names;
+}
+
+function scenarioNames(path: string, variableName: string): string[] {
+  const names: string[] = [];
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === variableName &&
+      node.initializer
+    ) {
+      function collectNameProperties(child: ts.Node): void {
+        if (
+          ts.isPropertyAssignment(child) &&
+          ts.isIdentifier(child.name) &&
+          child.name.text === "name" &&
+          ts.isStringLiteral(child.initializer)
+        ) {
+          names.push(child.initializer.text);
+        }
+        child.forEachChild(collectNameProperties);
+      }
+      node.initializer.forEachChild(collectNameProperties);
+    }
+    node.forEachChild(visit);
+  }
+  parse(path).forEachChild(visit);
+  return names;
+}
+
+function stringArrayInitializer(path: string, variableName: string): string[] {
+  let values: string[] | undefined;
+  function visit(node: ts.Node): void {
+    if (
+      ts.isVariableDeclaration(node) &&
+      ts.isIdentifier(node.name) &&
+      node.name.text === variableName &&
+      node.initializer
+    ) {
+      const initializer =
+        ts.isCallExpression(node.initializer) &&
+        ts.isPropertyAccessExpression(node.initializer.expression) &&
+        node.initializer.expression.name.text === "sort"
+          ? node.initializer.expression.expression
+          : node.initializer;
+      if (ts.isArrayLiteralExpression(initializer)) {
+        values = initializer.elements
+          .filter(ts.isStringLiteral)
+          .map((element) => element.text);
+      }
+    }
+    node.forEachChild(visit);
+  }
+  parse(path).forEachChild(visit);
+  assert.ok(values, `${variableName} must remain an explicit string array`);
+  return values;
+}
+
+test("M35b conserva features, closeouts y evidencia canónicos", () => {
+  for (const { feature, required } of featureLayers) {
+    for (const layer of required) {
+      assert.equal(existsSync(resolve(root, feature, layer)), true, `${feature}/${layer}`);
+    }
+  }
+
+  for (const path of [
+    "test/architecture/particular-access-m33-closeout.test.ts",
+    "test/architecture/report-access-m34-closeout.test.ts",
+    "docs/implementation/m33-particular-access-domain-repository-thin-closeout.md",
+    "docs/implementation/m34-report-access-domain-repository-thin-closeout.md",
+    evidence,
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
+});
+
+test("M35b ancla la matriz ejecutable conjunta por tests y escenarios concretos", () => {
+  const names = testNames(evidence);
+  for (const expected of [
+    "Particular Access unifica missing y foreign, ignora selectores hostiles y redacta secretos",
+    "Particular Access unifica report foreign y missing y redacta fallos repository",
+    "Report Access publico ejecuta la matriz M35b sin enumeracion ni disclosure",
+    "Report Access publico aplica rate limit antes de parse, hash y repository",
+  ]) {
+    assert.equal(names.includes(expected), true, expected);
+  }
+
+  assert.deepEqual(scenarioNames(evidence, "scenarios"), [
+    "malformed",
+    "missing",
+    "revoked",
+    "expired",
+    "cross-clinic",
+    "unavailable",
+    "success",
+    "repository-failure",
+    "storage-failure",
+  ]);
+
+  const source = read(evidence);
+  assert.equal(
+    source.includes('"/api/public/report-access/[REDACTED]"'),
+    true,
+    "Report repository/storage failures must assert a redacted response.path",
+  );
+});
+
+test("M35b prohíbe repositories legacy e imports ejecutables directos desde rutas", () => {
+  assert.equal(existsSync(resolve(root, "server/db-report-access.ts")), false);
+
+  for (const path of walk("server").filter((file) => file.endsWith(".ts"))) {
+    assert.equal(
+      executableImportTargets(path).includes("server/db-report-access.ts"),
+      false,
+      path,
+    );
+  }
+
+  for (const route of ownRoutes) {
+    for (const target of executableImportTargets(route)) {
+      assert.equal(target.includes("drizzle"), false, `${route}: ${target}`);
+      assert.equal(
+        target.includes("/infrastructure/") ||
+          target.endsWith("/db-particular.ts") ||
+          target.endsWith("/db-report-access.ts"),
+        false,
+        `${route}: ${target}`,
+      );
+    }
+  }
+});
+
+test("M35b reutiliza la allowlist M33 de shims Particular sin ampliarla", () => {
+  const m33Guard = "test/architecture/particular-access-m33-closeout.test.ts";
+  const expected = stringArrayInitializer(m33Guard, "particularShimConsumers")
+    .slice()
+    .sort();
+  assert.equal(expected.length, 9);
+
+  const actual = walk("server")
+    .filter((file) => file.endsWith(".ts") && file !== "server/db-particular.ts")
+    .filter((file) =>
+      executableImportTargets(file).includes("server/db-particular.ts"),
+    )
+    .sort();
+  assert.deepEqual(actual, expected);
+
+  const source = read(m33Guard);
+  assert.equal(
+    source.includes(
+      'test("shims conservan una línea y allowlists residuales exactas"',
+    ),
+    true,
+  );
+});
+
+test("M35b mantiene conectados los guards globales de token access", () => {
+  for (const guard of globalGuardAnchors) {
+    assert.equal(existsSync(resolve(root, guard.path)), true, guard.path);
+    const source = read(guard.path);
+    for (const anchor of guard.anchors) {
+      assert.equal(source.includes(anchor), true, `${guard.path}: ${anchor}`);
+    }
+  }
+});
+
+test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
+  for (const path of [
+    "docs/implementation/public-report-access-error-path-redaction-hotfix.md",
+    closeout,
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
+
+  const source = read(closeout);
+  for (const marker of [
+    "M33: cerrado",
+    "M34: cerrado",
+    "PR #1573",
+    "Fase H: cerrada",
+    "M36: no iniciado",
+    "Reports Phase I: no iniciada",
+  ]) {
+    assert.equal(source.includes(marker), true, marker);
+  }
+
+  const futureCloseouts = walk("docs/implementation").filter((path) =>
+    /\/(?:m36-|reports-phase-i)/i.test(path),
+  );
+  assert.deepEqual(futureCloseouts, []);
+});


### PR DESCRIPTION
## Summary

- closes M35b and Phase H with joint executable security evidence for Particular Access and Report Access
- certifies indistinguishable missing/foreign token behavior, hostile-selector resistance, lifecycle handling, cross-clinic isolation, and internal-error redaction
- certifies public Report Access rate-limit ordering and record-access → signed URLs → audit ordering
- registers the joint evidence in the cross-tenant IDOR matrix as CTIDOR-018
- registers the M35b security and architecture owners in suite completeness
- adds a source-aware closeout guard without changing runtime
- preserves M36 and Reports Phase I as not started

## Scope

- [x] Tests

Security tests, architecture guards, registries, and implementation documentation supporting the single tests scope.

Included:

- `test/security/token-access-enumeration-disclosure-regression.test.ts` as existing joint runtime evidence
- M35b architecture closeout guard
- CTIDOR-018
- security suite completeness registration
- M35b implementation record

No runtime, frontend, schema, migration, dependency, lockfile, workflow, script, authentication, cookie, session, CORS, or rate-limit implementation changes.

## Validation

- M35b joint cohort: PASSED, 10/10
- five Particular Access and Report Access controller integrations: PASSED, 49/49
- security suite completeness: PASSED, 6/6
- CTIDOR final: PASSED, 9/9
- `pnpm typecheck:test`: PASSED
- `pnpm validate:local`: PASSED, 3732 pass, 1 skip, 0 fail, build included
- `pnpm security:public-surface`: PASSED
- `pnpm audit --prod`: PASSED, no known vulnerabilities
- `pnpm audit`: PASSED, no known vulnerabilities
- `git diff --check`: PASSED
- Playwright: NOT_RUN, frontend unchanged
- staging, real database, migrations, and production: NOT_RUN

The initial directed failures were limited to source-aware test parsing and a textual self-contract collision. Both test-only causes were corrected, and their exact final cohorts passed.

## Rollback

Revert the M35b commit as one unit to remove the Phase H closeout guard, CTIDOR-018, suite registrations, and implementation record. Runtime behavior and the previously merged security hotfix remain unchanged. No schema, migration, data, dependency, credential, or infrastructure rollback is required.