### PR TITLE
refactor(reports): establish command use cases

### DIFF
--- a/docs/implementation/m38-reports-create-edit-transition-use-cases.md
+++ b/docs/implementation/m38-reports-create-edit-transition-use-cases.md
@@ -1,0 +1,264 @@
+# M38 — Reports create, edit and status transition use cases
+
+## Identificación
+
+- Milestone: M38.
+- Rama:
+  `refactor/backend-modularization-m38-reports-create-edit-transition-use-cases`.
+- Baseline exacto: `d27fa22d1d98fa83b24a51a8521d7c634a7adeb4`.
+- Predecesor: M37 / PR #1576 / merge
+  `d27fa22d1d98fa83b24a51a8521d7c634a7adeb4`.
+- Programa: Fase I Reports abierta.
+- Riesgo: R2 estructural backend autorizado específicamente para M38.
+- Git/GitHub: stage, commit, push, PR y merge reservados a Nico.
+- Commit inicial M38: `2ec8829d9796a7af2d6bea3edd2cc370dd4fab3b`.
+- PR #1577: abierto durante la corrección local P2.
+
+## Corrección P2 posterior al commit inicial
+
+Codex Review detectó una carrera TOCTOU válida en las transiciones. Dos
+requests podían leer `uploaded`, validar contra el mismo estado y persistir en
+orden inverso porque el UPDATE sólo filtraba por `reportId`. Así, después de
+`uploaded → delivered`, un write obsoleto todavía podía ejecutar
+`uploaded → ready` y registrar historial desde un estado fresco incorrecto.
+
+La corrección local agrega compare-and-set sin modificar rutas, schema ni
+payloads. No se ejecutan amend, commit, push, resolución del thread, CI final ni
+merge desde Codex.
+
+## Problema y censo inicial
+
+Los writes generales de Reports residían en `server/db.ts`:
+`upsertReport` concentraba creación/edición e historial inicial, mientras
+`updateReportStatus` concentraba update e historial de transición. La regla
+`canTransitionReportStatus` era ejecutada por
+`server/routes/reports-status.fastify.ts`; no existía un resultado application
+explícito para ausencia, mismo estado, rechazo o desaparición concurrente.
+
+Consumidores runtime iniciales:
+
+- `server/routes/admin-reports.fastify.ts`: `db.getReportById` y
+  `db.upsertReport`;
+- `server/routes/reports-status.fastify.ts`:
+  `db.getClinicScopedReportById` y `db.updateReportStatus`;
+- rutas y compositions de Admin Study Tracking, Particular Access y Report
+  Access: `db.getReportById`;
+- rutas clínicas, Particular Access, Report Access y Study Tracking:
+  `db.getClinicScopedReportById`;
+- `server/routes/reports.fastify.ts`: reads generales e historial.
+
+Los tests de integración inyectan `getReportById`, `getClinicScopedReportById`,
+`upsertReport` y `updateReportStatus` mediante Options. Los contratos de
+catálogo y admin auth leen literalmente `server/db.ts`. Los guards de Reports
+fijaban inventario, paths y ausencia temporal de M38; guards de seguridad y
+auditoría fijan las llamadas de write en rutas, no las transacciones.
+Documentos bajo `docs/audit`, `docs/changelog` y `docs/pr-history` son
+históricos y no se reescriben.
+
+## Arquitectura final
+
+```text
+server/features/reports/
+  domain/                                      # M36 intacto
+  application/
+    ports/
+      report-command-repository.ts
+    report-command-use-cases.ts
+  infrastructure/
+    report-command-repository.ts
+  composition/
+    report-command-composition.ts
+```
+
+El puerto expone exclusivamente `findReportById`, `createOrEditReport` y
+`persistReportStatusTransition`, con tipos application mínimos. La factory
+`createReportCommandUseCases` delega creación/edición y modela transición con
+resultados `not_found`, `same_status`, `transition_not_allowed`,
+`concurrent_not_found` y `persisted`.
+
+El input público de transición no contiene `expectedFromStatus`. Application
+lo construye desde `report.currentStatus` después del read y la validación. El
+comando interno de persistencia sí lo exige, impidiendo que un caller HTTP lo
+controle.
+
+Application importa sólo ports y el domain canónico. Infrastructure implementa
+el puerto y es owner único de DB, Drizzle, tablas, transacciones y SQL M38.
+Composition es el único bridge application → infrastructure; inyecta el reloj
+runtime y no ejecuta queries durante import.
+
+`server/db.ts` conserva compatibilidad temporal reexportando `getReportById` y
+`upsertReport` desde infrastructure, y `updateReportStatus` desde composition.
+Ese adapter legacy atraviesa application y traduce `persisted` a la fila; los
+resultados ausentes, rechazados o concurrentes se traducen a `undefined`.
+Composition construye el wiring de forma lazy para evitar queries y ciclos de
+inicialización durante import. Las rutas continúan con las mismas Options y
+dynamic imports.
+
+## Equivalencia de persistencia
+
+### Create y edit
+
+El lookup continúa por igualdad exacta de `storagePath` con `limit(1)`.
+Si existe, sólo actualiza `uploadDate`, `studyType`, `patientName`, `fileName`
+y `updatedAt`, usando `?? null`, y devuelve la primera fila de `returning()`.
+No crea historial ni altera clínica, path, estado o autoría.
+
+Si no existe, inserta clínica, metadatos nullable, path, URLs nulas, estado
+`uploaded`, autoría y un único timestamp para `statusChangedAt`, `createdAt` y
+`updatedAt`. En la misma transacción crea exactamente un historial con estado
+previo nulo, estado destino `uploaded` y nota
+`Informe cargado inicialmente`.
+
+### Transition
+
+La application lee el informe, rechaza mismo estado y usa exclusivamente
+`canTransitionReportStatus`. Una transición válida delega un write. El
+repository abre una transacción, relee por ID con `limit(1)`, evita writes ante
+ausencia y compara el estado fresco con `expectedFromStatus`. Luego ejecuta un
+UPDATE CAS cuyo predicado combina `reportId` y `currentStatus =
+expectedFromStatus`. Si el estado fresco difiere o `returning()` no devuelve
+fila, retorna ausencia concurrente sin historial. Sólo después de un CAS
+exitoso inserta historial y devuelve la fila actualizada.
+
+### Historial, reloj y errores
+
+Create y transition conservan el INSERT SQL compatible con columnas legacy y
+nuevas de `report_status_history`, el orden de valores y
+`createdAt.toISOString()`. La prioridad de actor sigue siendo clinic user,
+admin user y system, con tipos exactos `clinic_user`, `admin_user` y `system`.
+`note` usa `?? null`; update e historial comparten el mismo timestamp. El
+`fromStatus` del historial exitoso procede de `expectedFromStatus`.
+
+Sólo el error PostgreSQL `42703` activa el fallback Drizzle con `reportId`,
+`fromStatus`, `toStatus`, ambos IDs de autor, nota y `createdAt`. Cualquier otro
+error se relanza. Application y infrastructure no capturan errores generales,
+no auditan, no envían email, no usan storage y no registran console.
+
+## Referencias finales
+
+- `upsertReport` y `getReportById`: implementación canónica en infrastructure
+  y reexports compatibility en `server/db.ts`;
+- `updateReportStatus`: compatibility desde composition, siempre atravesando
+  application y el CAS del repository;
+- `getClinicScopedReportById`, `getReportStatusHistory` y reads generales:
+  permanecen en `server/db.ts`;
+- `REPORT_STATUSES` y `canTransitionReportStatus`: permanecen en domain M36;
+- Options y rutas: intactos;
+- tests application, infrastructure y persistence contract: owners M38;
+- guard M38: inventario y frontera default-deny;
+- docs históricas: intactas.
+
+## Rutas y superficies intactas
+
+La revisión final exige diff vacío para:
+
+- `server/routes/admin-reports.fastify.ts`;
+- `server/routes/reports.fastify.ts`;
+- `server/routes/reports-status.fastify.ts`;
+- `server/routes/admin-report-workflow.fastify.ts`;
+- `server/fastify-app.ts`;
+- `server/features/reports/domain/**`;
+- `server/db-report-workflow.ts`;
+- `server/lib/report-workflow-communication.ts`.
+
+Los guards evitan depender de hashes raw sensibles a EOL y fijan Options,
+imports, exports y anchors runtime por path resuelto.
+
+## Guards
+
+Clasificación prevista de archivos source-aware:
+
+- A: realineaciones temporales de
+  `reports-domain-boundary-guard.test.ts`,
+  `reports-workflow-ports-boundary-guard.test.ts`,
+  `reports-suite-completeness.test.ts`,
+  `report-access-m34-closeout.test.ts` y
+  `token-access-m35b-closeout.test.ts`;
+- B: nuevos tests application, infrastructure, persistence contract y guard
+  M38;
+- C: 0.
+
+Los guards de seguridad/auditoría se auditan y sólo se modifican si el move
+cambia un anchor. Como las rutas permanecen intactas, sus anchors de auth,
+permissions, trusted origin, auditoría posterior al write y superficie única
+de upload no cambian.
+
+## Exclusiones
+
+No forman parte de M38: M39–M41, route thinning, upload/storage, Particular
+Token, Study Tracking, auditoría, auth, sesiones, permisos, CORS, rate limits,
+email, schema, migraciones, frontend, dependencias, CI, DB real, staging o
+producción. Tampoco se mueven reads generales de Reports.
+
+## Validación
+
+Estados canónicos usados: PASSED, FAILED, NOT_RUN, NOT_AVAILABLE y BLOCKED.
+
+Evidencia final:
+
+- application M38: PASSED, exit code 0, 14/14;
+- infrastructure + persistence contract, primera corrida: FAILED, exit code 1,
+  8/9 por un falso positivo del test sobre `storagePath`;
+- repetición del test fallido: PASSED, exit code 0, 1/1;
+- infrastructure + persistence contract final: PASSED, exit code 0, 9/9;
+- guards Reports, primera corrida: FAILED, exit code 1, 37/39 por dos
+  realineaciones incompletas de tests;
+- repetición de ambos tests fallidos: PASSED, exit code 0, 2/2;
+- guards Reports final: PASSED, exit code 0, 39/39;
+- guards históricos M34/M35b: PASSED, exit code 0, 11/11;
+- integraciones Admin Reports, Reports Status y ownership: PASSED, exit code 0,
+  29/29;
+- seguridad y auditoría materialmente afectadas: PASSED, exit code 0, 41/41;
+- cohorte acumulativa: PASSED, exit code 0, 73/73;
+- `pnpm typecheck`, primera corrida: FAILED, exit code 2, firma compatibility
+  de `getReportById` demasiado amplia;
+- `pnpm typecheck` final: PASSED, exit code 0;
+- `pnpm typecheck:test`: PASSED, exit code 0;
+- `pnpm validate:local`: PASSED, exit code 0, 3.801 pass, 1 skip, 0 fail y
+  build completado;
+- `pnpm security:public-surface`: PASSED, exit code 0, sin findings públicos y
+  dos markers server-only esperados;
+- `pnpm audit --prod`: PASSED, exit code 0, sin vulnerabilidades conocidas;
+- `pnpm audit`: PASSED, exit code 0, sin vulnerabilidades conocidas;
+- `git diff --check`: PASSED, exit code 0, sin errores de whitespace.
+
+Evidencia de la corrección P2 posterior a `2ec8829`:
+
+- application con `expectedFromStatus`: PASSED, exit code 0, 15/15;
+- infrastructure + persistence contract, primera corrida: FAILED, exit code 1,
+  12/13 por una expectativa source-aware que todavía permitía el import
+  type-only infrastructure → application;
+- repetición del test fallido: PASSED, exit code 0, 1/1;
+- infrastructure + persistence contract final: PASSED, exit code 0, 13/13;
+- guards Reports: PASSED, exit code 0, 39/39;
+- integraciones Admin Reports, Reports Status y ownership: PASSED, exit code 0,
+  29/29;
+- cohorte acumulativa P2: PASSED, exit code 0, 67/67;
+- `pnpm typecheck`, primera corrida: FAILED, exit code 2, una anotación
+  `Report` resolvió al tipo DOM después de retirar schema de composition;
+- `pnpm typecheck` final: PASSED, exit code 0;
+- `pnpm typecheck:test`: PASSED, exit code 0;
+- `pnpm validate:local`: PASSED, exit code 0, 3.806 pass, 1 skip, 0 fail y
+  build completado;
+- `pnpm security:public-surface`: PASSED, exit code 0, sin findings públicos;
+- `pnpm audit --prod`: PASSED, exit code 0, sin vulnerabilidades conocidas;
+- `pnpm audit`: PASSED, exit code 0, sin vulnerabilidades conocidas.
+
+Playwright, migraciones, DB real, staging, producción, dev servers y watchers:
+NOT_RUN por exclusión explícita.
+
+## Riesgo residual y rollback
+
+Las rutas aún consumen exports temporales de `server/db.ts`; reads generales
+siguen legacy y M39/M40 permanecen pendientes. DB real, staging y producción no
+se ejecutan en M38.
+
+El rollback es estructural y no requiere schema ni datos: restaurar las tres
+implementaciones en la sección Reports de `server/db.ts`, retirar puerto,
+application, repository, composition, pruebas, guard y documentación M38, y
+revertir sólo las realineaciones temporales de guards.
+
+## Estado final
+
+M38 queda implementado localmente con los gates seleccionados PASSED. M39 no se
+inicia. Commit, push, PR, CI remoto y merge no se ejecutan ni se afirman.

--- a/server/db.ts
+++ b/server/db.ts
@@ -19,6 +19,13 @@ import {
 } from "../drizzle/schema.ts";
 import { ENV } from "./lib/env.ts";
 import { normalizeClinicUserRole } from "./lib/permissions.ts";
+export {
+  getReportById,
+  upsertReport,
+} from "./features/reports/infrastructure/index.ts";
+export {
+  updateReportStatus,
+} from "./features/reports/composition/index.ts";
 
 const client = postgres(ENV.databaseUrl, {
   prepare: false,
@@ -506,16 +513,6 @@ export async function deleteExpiredAdminSessions(): Promise<number> {
 
 /* ========================= REPORTS ========================= */
 
-export async function getReportById(id: number) {
-  const result = await db
-    .select()
-    .from(reports)
-    .where(eq(reports.id, id))
-    .limit(1);
-
-  return result[0];
-}
-
 export async function getClinicScopedReportById(id: number, clinicId: number) {
   const result = await db
     .select()
@@ -532,227 +529,6 @@ export async function getReportStatusHistory(reportId: number) {
     .from(reportStatusHistory)
     .where(eq(reportStatusHistory.reportId, reportId))
     .orderBy(desc(reportStatusHistory.createdAt), desc(reportStatusHistory.id));
-}
-
-export async function upsertReport(input: {
-  clinicId: number;
-  uploadDate?: Date | null;
-  studyType?: string | null;
-  patientName?: string | null;
-  fileName?: string | null;
-  storagePath: string;
-  createdByClinicUserId?: number | null;
-  createdByAdminUserId?: number | null;
-}) {
-  const now = new Date();
-
-  return db.transaction(async (tx) => {
-    const existing = await tx
-      .select()
-      .from(reports)
-      .where(eq(reports.storagePath, input.storagePath))
-      .limit(1);
-
-    if (existing[0]) {
-      const updated = await tx
-        .update(reports)
-        .set({
-          uploadDate: input.uploadDate ?? null,
-          studyType: input.studyType ?? null,
-          patientName: input.patientName ?? null,
-          fileName: input.fileName ?? null,
-          updatedAt: now,
-        })
-        .where(eq(reports.id, existing[0].id))
-        .returning();
-
-      return updated[0];
-    }
-
-    const inserted = await tx
-      .insert(reports)
-      .values({
-        clinicId: input.clinicId,
-        uploadDate: input.uploadDate ?? null,
-        studyType: input.studyType ?? null,
-        patientName: input.patientName ?? null,
-        fileName: input.fileName ?? null,
-        storagePath: input.storagePath,
-        previewUrl: null,
-        downloadUrl: null,
-        currentStatus: "uploaded",
-        statusChangedAt: now,
-        statusChangedByClinicUserId: input.createdByClinicUserId ?? null,
-        statusChangedByAdminUserId: input.createdByAdminUserId ?? null,
-        createdAt: now,
-        updatedAt: now,
-      })
-      .returning();
-
-    const report = inserted[0];
-
-    const initialChangedBy =
-      input.createdByClinicUserId ?? input.createdByAdminUserId ?? null;
-    const initialChangedByType =
-      input.createdByClinicUserId != null
-        ? "clinic_user"
-        : input.createdByAdminUserId != null
-          ? "admin_user"
-          : "system";
-
-    try {
-      await tx.execute(sql`
-        INSERT INTO "report_status_history" (
-          "report_id",
-          "status",
-          "previous_status",
-          "changed_by",
-          "changed_by_type",
-          "notes",
-          "created_at",
-          "from_status",
-          "to_status",
-          "changed_by_clinic_user_id",
-          "changed_by_admin_user_id",
-          "note"
-        )
-        VALUES (
-          ${report.id},
-          ${"uploaded"},
-          ${null},
-          ${initialChangedBy},
-          ${initialChangedByType},
-          ${"Informe cargado inicialmente"},
-          ${now.toISOString()},
-          ${null},
-          ${"uploaded"},
-          ${input.createdByClinicUserId ?? null},
-          ${input.createdByAdminUserId ?? null},
-          ${"Informe cargado inicialmente"}
-        )
-      `);
-    } catch (error) {
-      if (
-        typeof error !== "object" ||
-        error === null ||
-        !("code" in error) ||
-        error.code !== "42703"
-      ) {
-        throw error;
-      }
-
-      await tx.insert(reportStatusHistory).values({
-        reportId: report.id,
-        fromStatus: null,
-        toStatus: "uploaded",
-        changedByClinicUserId: input.createdByClinicUserId ?? null,
-        changedByAdminUserId: input.createdByAdminUserId ?? null,
-        note: "Informe cargado inicialmente",
-        createdAt: now,
-      });
-    }
-
-    return report;
-  });
-}
-
-export async function updateReportStatus(input: {
-  reportId: number;
-  toStatus: ReportStatus;
-  note?: string | null;
-  changedByClinicUserId?: number | null;
-  changedByAdminUserId?: number | null;
-}) {
-  const now = new Date();
-
-  return db.transaction(async (tx) => {
-    const existing = await tx
-      .select()
-      .from(reports)
-      .where(eq(reports.id, input.reportId))
-      .limit(1);
-
-    const report = existing[0];
-
-    if (!report) {
-      return undefined;
-    }
-
-    const updated = await tx
-      .update(reports)
-      .set({
-        currentStatus: input.toStatus,
-        statusChangedAt: now,
-        statusChangedByClinicUserId: input.changedByClinicUserId ?? null,
-        statusChangedByAdminUserId: input.changedByAdminUserId ?? null,
-        updatedAt: now,
-      })
-      .where(eq(reports.id, input.reportId))
-      .returning();
-
-    const changedBy =
-      input.changedByClinicUserId ?? input.changedByAdminUserId ?? null;
-    const changedByType =
-      input.changedByClinicUserId != null
-        ? "clinic_user"
-        : input.changedByAdminUserId != null
-          ? "admin_user"
-          : "system";
-
-    try {
-      await tx.execute(sql`
-        INSERT INTO "report_status_history" (
-          "report_id",
-          "status",
-          "previous_status",
-          "changed_by",
-          "changed_by_type",
-          "notes",
-          "created_at",
-          "from_status",
-          "to_status",
-          "changed_by_clinic_user_id",
-          "changed_by_admin_user_id",
-          "note"
-        )
-        VALUES (
-          ${report.id},
-          ${input.toStatus},
-          ${report.currentStatus},
-          ${changedBy},
-          ${changedByType},
-          ${input.note ?? null},
-          ${now.toISOString()},
-          ${report.currentStatus},
-          ${input.toStatus},
-          ${input.changedByClinicUserId ?? null},
-          ${input.changedByAdminUserId ?? null},
-          ${input.note ?? null}
-        )
-      `);
-    } catch (error) {
-      if (
-        typeof error !== "object" ||
-        error === null ||
-        !("code" in error) ||
-        error.code !== "42703"
-      ) {
-        throw error;
-      }
-
-      await tx.insert(reportStatusHistory).values({
-        reportId: report.id,
-        fromStatus: report.currentStatus,
-        toStatus: input.toStatus,
-        changedByClinicUserId: input.changedByClinicUserId ?? null,
-        changedByAdminUserId: input.changedByAdminUserId ?? null,
-        note: input.note ?? null,
-        createdAt: now,
-      });
-    }
-
-    return updated[0];
-  });
 }
 
 export async function getReportsByClinicId(

--- a/server/features/reports/README.md
+++ b/server/features/reports/README.md
@@ -1,7 +1,8 @@
 # Reports
 
-M36 estableció la frontera de dominio y M37 desacopla la comunicación interna
-del workflow sin cambiar comportamiento runtime.
+M36 estableció la frontera de dominio, M37 desacopló la comunicación interna
+del workflow y M38 agrega los comandos de creación/edición y transición de
+estado sin cambiar las rutas.
 
 ## Superficie disponible
 
@@ -9,22 +10,27 @@ del workflow sin cambiar comportamiento runtime.
 - `domain/report-status.ts` conserva el catálogo y las transiciones de estado.
 - `domain/report-study-types.ts` conserva el catálogo de tipos de estudio.
 - `domain/reports.ts` conserva parsing, scoping y serialización segura.
-- `application/index.ts` expone la operación inyectable y sus dos puertos.
-- `infrastructure/index.ts` expone los adapters de datos y notificación.
-- `composition/index.ts` es el entrypoint runtime de
-  `createReportWorkflowNotification`.
+- `application/index.ts` expone las operaciones inyectables y sus puertos.
+- `infrastructure/index.ts` expone los adapters de workflow y el repository
+  canónico de comandos.
+- `composition/index.ts` es el entrypoint runtime de comunicación y comandos:
+  `createReportWorkflowNotification`, `createOrEditReport` y
+  `transitionReportStatus`.
 
 ## Dependencias entre capas
 
 El dominio sólo puede depender de archivos de su propia capa y de
-`drizzle/schema.ts` mediante `import type`. Application sólo depende de sus
-puertos. Infrastructure implementa esos puertos y es la única capa M37 con DB,
-Drizzle, schema y tablas de Study Tracking. Composition es el único bridge
-application → infrastructure.
+`drizzle/schema.ts` mediante `import type`. Application depende de sus puertos
+y, para transiciones, del barrel canónico de domain. Infrastructure implementa
+los puertos y es la única capa M38 con DB, Drizzle, tablas Reports,
+transacciones y SQL de historial. Composition es el único bridge application
+→ infrastructure.
 
 `server/lib/report-workflow-communication.ts` permanece como shim temporal de
-una línea hasta M41. Ningún consumidor runtime ni test de comportamiento debe
-usarlo.
+una línea. `server/db.ts` reexporta temporalmente `getReportById` y
+`upsertReport` desde infrastructure. `updateReportStatus` atraviesa composition
+y application, que agrega `expectedFromStatus`, antes del UPDATE compare-and-set
+de infrastructure. Las rutas mantienen sus Options y dependencias actuales.
 
-M38–M41 siguen pendientes: M38 contiene los casos de uso generales de Reports,
-M39/M40 las rutas delgadas y M41 el closeout y retiro final de shims.
+M39/M40 siguen pendientes para rutas delgadas y reads generales; M41 realizará
+el closeout y retiro final de compatibilidad.

--- a/server/features/reports/application/README.md
+++ b/server/features/reports/application/README.md
@@ -1,9 +1,15 @@
 # Reports application
 
-M37 contiene únicamente la orquestación de comunicación del workflow. La
-factory `createReportWorkflowCommunication` depende de los puertos de datos y
-notificación y de un reloj inyectado; no conoce Drizzle, schema, DB, Fastify ni
-adapters concretos.
+M37 contiene la orquestación de comunicación del workflow. M38 agrega
+`createReportCommandUseCases`, que expone creación/edición por upsert y
+transición de estado con resultados discriminados.
 
-`index.ts` es el entrypoint de la capa. Los casos de uso generales de Reports
-pertenecen a M38 y no forman parte de este inventario.
+El puerto `report-command-repository.ts` contiene sólo `findReportById`,
+`createOrEditReport` y `persistReportStatusTransition`. La transición consume
+`canTransitionReportStatus` desde domain y construye `expectedFromStatus` desde
+el informe leído; ese valor no forma parte del input público. No conoce
+Drizzle, schema, DB, Fastify, rutas ni adapters concretos y no captura errores
+de persistencia.
+
+`index.ts` es el entrypoint de la capa. Reads generales, autorización,
+auditoría, storage y side effects de rutas quedan fuera de M38.

--- a/server/features/reports/application/index.ts
+++ b/server/features/reports/application/index.ts
@@ -1,2 +1,3 @@
 export * from "./ports/index.ts";
+export * from "./report-command-use-cases.ts";
 export * from "./report-workflow-communication.ts";

--- a/server/features/reports/application/ports/index.ts
+++ b/server/features/reports/application/ports/index.ts
@@ -1,2 +1,3 @@
 export * from "./report-workflow-data-port.ts";
 export * from "./report-workflow-notification-port.ts";
+export * from "./report-command-repository.ts";

--- a/server/features/reports/application/ports/report-command-repository.ts
+++ b/server/features/reports/application/ports/report-command-repository.ts
@@ -1,0 +1,40 @@
+export type ReportCommandStatus =
+  | "uploaded"
+  | "processing"
+  | "ready"
+  | "delivered";
+
+export type ReportCommandRecord = {
+  id: number;
+  currentStatus: ReportCommandStatus;
+};
+
+export type CreateOrEditReportInput = {
+  clinicId: number;
+  uploadDate?: Date | null;
+  studyType?: string | null;
+  patientName?: string | null;
+  fileName?: string | null;
+  storagePath: string;
+  createdByClinicUserId?: number | null;
+  createdByAdminUserId?: number | null;
+};
+
+export type PersistReportStatusTransitionInput = {
+  reportId: number;
+  expectedFromStatus: ReportCommandStatus;
+  toStatus: ReportCommandStatus;
+  note?: string | null;
+  changedByClinicUserId?: number | null;
+  changedByAdminUserId?: number | null;
+};
+
+export type ReportCommandRepository<
+  TReport extends ReportCommandRecord = ReportCommandRecord,
+> = {
+  findReportById: (reportId: number) => Promise<TReport | null | undefined>;
+  createOrEditReport: (input: CreateOrEditReportInput) => Promise<TReport>;
+  persistReportStatusTransition: (
+    input: PersistReportStatusTransitionInput,
+  ) => Promise<TReport | null | undefined>;
+};

--- a/server/features/reports/application/report-command-use-cases.ts
+++ b/server/features/reports/application/report-command-use-cases.ts
@@ -1,0 +1,78 @@
+import { canTransitionReportStatus } from "../domain/index.ts";
+import type {
+  CreateOrEditReportInput,
+  PersistReportStatusTransitionInput,
+  ReportCommandRecord,
+  ReportCommandRepository,
+  ReportCommandStatus,
+} from "./ports/index.ts";
+
+export type TransitionReportStatusInput = Omit<
+  PersistReportStatusTransitionInput,
+  "expectedFromStatus"
+>;
+
+export type TransitionReportStatusResult<
+  TReport extends ReportCommandRecord = ReportCommandRecord,
+> =
+  | { type: "not_found"; reportId: number }
+  | {
+      type: "same_status";
+      currentStatus: ReportCommandStatus;
+      requestedStatus: ReportCommandStatus;
+    }
+  | {
+      type: "transition_not_allowed";
+      currentStatus: ReportCommandStatus;
+      requestedStatus: ReportCommandStatus;
+    }
+  | { type: "concurrent_not_found"; reportId: number }
+  | { type: "persisted"; report: TReport };
+
+export function createReportCommandUseCases<
+  TReport extends ReportCommandRecord,
+>(repository: ReportCommandRepository<TReport>) {
+  return {
+    createOrEditReport(input: CreateOrEditReportInput): Promise<TReport> {
+      return repository.createOrEditReport(input);
+    },
+
+    async transitionReportStatus(
+      input: TransitionReportStatusInput,
+    ): Promise<TransitionReportStatusResult<TReport>> {
+      const report = await repository.findReportById(input.reportId);
+
+      if (!report) {
+        return { type: "not_found", reportId: input.reportId };
+      }
+
+      if (report.currentStatus === input.toStatus) {
+        return {
+          type: "same_status",
+          currentStatus: report.currentStatus,
+          requestedStatus: input.toStatus,
+        };
+      }
+
+      if (!canTransitionReportStatus(report.currentStatus, input.toStatus)) {
+        return {
+          type: "transition_not_allowed",
+          currentStatus: report.currentStatus,
+          requestedStatus: input.toStatus,
+        };
+      }
+
+      const updated =
+        await repository.persistReportStatusTransition({
+          ...input,
+          expectedFromStatus: report.currentStatus,
+        });
+
+      if (!updated) {
+        return { type: "concurrent_not_found", reportId: input.reportId };
+      }
+
+      return { type: "persisted", report: updated };
+    },
+  };
+}

--- a/server/features/reports/composition/README.md
+++ b/server/features/reports/composition/README.md
@@ -4,4 +4,12 @@ M37 conecta los adapters concretos con la factory de application e inyecta el
 reloj runtime. `index.ts` exporta la operación pública
 `createReportWorkflowNotification` y sus tipos compatibles.
 
-La composición no consulta DB durante el import y no mantiene estado mutable.
+M38 agrega `report-command-composition.ts`: instancia el repository de comandos
+con `() => new Date()`, construye los casos de uso y exporta
+`createOrEditReport` y `transitionReportStatus` para M39/M40. También expone el
+adapter compatible `updateReportStatus`, que traduce `persisted` a la fila y
+los resultados rechazados o concurrentes a `undefined`.
+
+La composición construye sus dependencias de forma lazy, no consulta DB durante
+el import, no mantiene estado mutable y no importa Fastify, rutas, auth,
+auditoría, storage ni email.

--- a/server/features/reports/composition/index.ts
+++ b/server/features/reports/composition/index.ts
@@ -1,1 +1,2 @@
+export * from "./report-command-composition.ts";
 export * from "./report-workflow-communication-composition.ts";

--- a/server/features/reports/composition/report-command-composition.ts
+++ b/server/features/reports/composition/report-command-composition.ts
@@ -1,0 +1,31 @@
+import {
+  createReportCommandUseCases,
+  type CreateOrEditReportInput,
+  type TransitionReportStatusInput,
+} from "../application/index.ts";
+import { createReportCommandRepository } from "../infrastructure/index.ts";
+
+function createRuntimeReportCommandUseCases() {
+  return createReportCommandUseCases(
+    createReportCommandRepository({
+      now: () => new Date(),
+    }),
+  );
+}
+
+export function createOrEditReport(input: CreateOrEditReportInput) {
+  return createRuntimeReportCommandUseCases().createOrEditReport(input);
+}
+
+export function transitionReportStatus(
+  input: TransitionReportStatusInput,
+) {
+  return createRuntimeReportCommandUseCases().transitionReportStatus(input);
+}
+
+export async function updateReportStatus(
+  input: TransitionReportStatusInput,
+) {
+  const result = await transitionReportStatus(input);
+  return result.type === "persisted" ? result.report : undefined;
+}

--- a/server/features/reports/infrastructure/README.md
+++ b/server/features/reports/infrastructure/README.md
@@ -4,5 +4,13 @@ M37 implementa aquí los dos puertos de workflow communication. El adapter de
 datos consulta el contexto de Study Tracking por `reportId`; el adapter de
 notificación inserta una notificación interna y devuelve su ID o `null`.
 
-Esta capa es la única superficie M37 que importa DB, Drizzle, schema y tablas
-de Study Tracking. No contiene email, auditoría, auth ni transporte HTTP.
+M38 agrega `report-command-repository.ts`, implementación canónica única de
+`getReportById`, upsert y persistencia de transición. Conserva las dos
+transacciones, el SQL dual de historial y el fallback exclusivo PostgreSQL
+`42703`; la transición usa compare-and-set por ID y `expectedFromStatus`, y
+sólo crea historial después de un `returning()` exitoso. Acepta DB y reloj
+inyectables para pruebas deterministas.
+
+Esta capa es la única superficie M38 que importa DB, Drizzle, schema y tablas
+Reports para comandos. No contiene email, auditoría, auth, storage ni
+transporte HTTP. `server/db.ts` sólo reexporta compatibilidad temporal.

--- a/server/features/reports/infrastructure/index.ts
+++ b/server/features/reports/infrastructure/index.ts
@@ -1,2 +1,3 @@
+export * from "./report-command-repository.ts";
 export * from "./report-workflow-data-adapter.ts";
 export * from "./report-workflow-notification-adapter.ts";

--- a/server/features/reports/infrastructure/report-command-repository.ts
+++ b/server/features/reports/infrastructure/report-command-repository.ts
@@ -1,0 +1,259 @@
+import { and, eq, sql } from "drizzle-orm";
+
+import { db } from "../../../db.ts";
+import {
+  reports,
+  reportStatusHistory,
+  type Report,
+  type ReportStatus,
+} from "../../../../drizzle/schema.ts";
+type ReportCommandDatabase = typeof db;
+type ReportCommandTransaction = Parameters<
+  Parameters<ReportCommandDatabase["transaction"]>[0]
+>[0];
+
+type HistoryInput = {
+  reportId: number;
+  fromStatus: ReportStatus | null;
+  toStatus: ReportStatus;
+  changedByClinicUserId: number | null;
+  changedByAdminUserId: number | null;
+  note: string | null;
+  createdAt: Date;
+};
+
+type CreateOrEditReportPersistenceInput = {
+  clinicId: number;
+  uploadDate?: Date | null;
+  studyType?: string | null;
+  patientName?: string | null;
+  fileName?: string | null;
+  storagePath: string;
+  createdByClinicUserId?: number | null;
+  createdByAdminUserId?: number | null;
+};
+
+type PersistReportStatusTransitionCommand = {
+  reportId: number;
+  expectedFromStatus: ReportStatus;
+  toStatus: ReportStatus;
+  note?: string | null;
+  changedByClinicUserId?: number | null;
+  changedByAdminUserId?: number | null;
+};
+
+async function insertCompatibleReportStatusHistory(
+  tx: ReportCommandTransaction,
+  input: HistoryInput,
+) {
+  const changedBy =
+    input.changedByClinicUserId ?? input.changedByAdminUserId ?? null;
+  const changedByType =
+    input.changedByClinicUserId != null
+      ? "clinic_user"
+      : input.changedByAdminUserId != null
+        ? "admin_user"
+        : "system";
+
+  try {
+    await tx.execute(sql`
+      INSERT INTO "report_status_history" (
+        "report_id",
+        "status",
+        "previous_status",
+        "changed_by",
+        "changed_by_type",
+        "notes",
+        "created_at",
+        "from_status",
+        "to_status",
+        "changed_by_clinic_user_id",
+        "changed_by_admin_user_id",
+        "note"
+      )
+      VALUES (
+        ${input.reportId},
+        ${input.toStatus},
+        ${input.fromStatus},
+        ${changedBy},
+        ${changedByType},
+        ${input.note},
+        ${input.createdAt.toISOString()},
+        ${input.fromStatus},
+        ${input.toStatus},
+        ${input.changedByClinicUserId},
+        ${input.changedByAdminUserId},
+        ${input.note}
+      )
+    `);
+  } catch (error) {
+    if (
+      typeof error !== "object" ||
+      error === null ||
+      !("code" in error) ||
+      error.code !== "42703"
+    ) {
+      throw error;
+    }
+
+    await tx.insert(reportStatusHistory).values({
+      reportId: input.reportId,
+      fromStatus: input.fromStatus,
+      toStatus: input.toStatus,
+      changedByClinicUserId: input.changedByClinicUserId,
+      changedByAdminUserId: input.changedByAdminUserId,
+      note: input.note,
+      createdAt: input.createdAt,
+    });
+  }
+}
+
+export function createReportCommandRepository(dependencies?: {
+  database?: ReportCommandDatabase;
+  now?: () => Date;
+}) {
+  const database = dependencies?.database ?? db;
+  const now = dependencies?.now ?? (() => new Date());
+
+  return {
+    async findReportById(reportId: number) {
+      const result = await database
+        .select()
+        .from(reports)
+        .where(eq(reports.id, reportId))
+        .limit(1);
+
+      return result[0];
+    },
+
+    async createOrEditReport(input: CreateOrEditReportPersistenceInput) {
+      const operationTimestamp = now();
+
+      return database.transaction(async (tx) => {
+        const existing = await tx
+          .select()
+          .from(reports)
+          .where(eq(reports.storagePath, input.storagePath))
+          .limit(1);
+
+        if (existing[0]) {
+          const updated = await tx
+            .update(reports)
+            .set({
+              uploadDate: input.uploadDate ?? null,
+              studyType: input.studyType ?? null,
+              patientName: input.patientName ?? null,
+              fileName: input.fileName ?? null,
+              updatedAt: operationTimestamp,
+            })
+            .where(eq(reports.id, existing[0].id))
+            .returning();
+
+          return updated[0];
+        }
+
+        const inserted = await tx
+          .insert(reports)
+          .values({
+            clinicId: input.clinicId,
+            uploadDate: input.uploadDate ?? null,
+            studyType: input.studyType ?? null,
+            patientName: input.patientName ?? null,
+            fileName: input.fileName ?? null,
+            storagePath: input.storagePath,
+            previewUrl: null,
+            downloadUrl: null,
+            currentStatus: "uploaded",
+            statusChangedAt: operationTimestamp,
+            statusChangedByClinicUserId:
+              input.createdByClinicUserId ?? null,
+            statusChangedByAdminUserId: input.createdByAdminUserId ?? null,
+            createdAt: operationTimestamp,
+            updatedAt: operationTimestamp,
+          })
+          .returning();
+        const report = inserted[0];
+
+        await insertCompatibleReportStatusHistory(tx, {
+          reportId: report.id,
+          fromStatus: null,
+          toStatus: "uploaded",
+          changedByClinicUserId: input.createdByClinicUserId ?? null,
+          changedByAdminUserId: input.createdByAdminUserId ?? null,
+          note: "Informe cargado inicialmente",
+          createdAt: operationTimestamp,
+        });
+
+        return report;
+      });
+    },
+
+    async persistReportStatusTransition(
+      input: PersistReportStatusTransitionCommand,
+    ) {
+      const operationTimestamp = now();
+
+      return database.transaction(async (tx) => {
+        const existing = await tx
+          .select()
+          .from(reports)
+          .where(eq(reports.id, input.reportId))
+          .limit(1);
+        const report = existing[0];
+
+        if (!report) {
+          return undefined;
+        }
+
+        if (report.currentStatus !== input.expectedFromStatus) {
+          return undefined;
+        }
+
+        const updated = await tx
+          .update(reports)
+          .set({
+            currentStatus: input.toStatus,
+            statusChangedAt: operationTimestamp,
+            statusChangedByClinicUserId:
+              input.changedByClinicUserId ?? null,
+            statusChangedByAdminUserId: input.changedByAdminUserId ?? null,
+            updatedAt: operationTimestamp,
+          })
+          .where(
+            and(
+              eq(reports.id, input.reportId),
+              eq(reports.currentStatus, input.expectedFromStatus),
+            ),
+          )
+          .returning();
+        const updatedReport = updated[0];
+
+        if (!updatedReport) {
+          return undefined;
+        }
+
+        await insertCompatibleReportStatusHistory(tx, {
+          reportId: report.id,
+          fromStatus: input.expectedFromStatus,
+          toStatus: input.toStatus,
+          changedByClinicUserId: input.changedByClinicUserId ?? null,
+          changedByAdminUserId: input.changedByAdminUserId ?? null,
+          note: input.note ?? null,
+          createdAt: operationTimestamp,
+        });
+
+        return updatedReport;
+      });
+    },
+  };
+}
+
+export function getReportById(id: number): Promise<Report> {
+  return createReportCommandRepository().findReportById(
+    id,
+  ) as Promise<Report>;
+}
+
+export function upsertReport(input: CreateOrEditReportPersistenceInput) {
+  return createReportCommandRepository().createOrEditReport(input);
+}

--- a/test/architecture/report-access-m34-closeout.test.ts
+++ b/test/architecture/report-access-m34-closeout.test.ts
@@ -61,7 +61,7 @@ function importTargets(path: string): string[] {
   return result;
 }
 
-test("M34 conserva sólo su feature y Reports avanza independientemente hasta M37", () => {
+test("M34 conserva sólo su feature y Reports avanza independientemente hasta M38", () => {
   for (const path of [
     `${feature}/README.md`,
     `${domain}/report-access.ts`,
@@ -88,6 +88,15 @@ test("M34 conserva sólo su feature y Reports avanza independientemente hasta M3
     true,
   );
   assert.ok(read("server/features/reports/README.md").includes("M37"));
+  assert.equal(
+    existsSync(
+      resolve(
+        root,
+        "server/features/reports/application/report-command-use-cases.ts",
+      ),
+    ),
+    true,
+  );
   assert.equal(
     existsSync(
       resolve(

--- a/test/architecture/reports-command-use-cases-boundary-guard.test.ts
+++ b/test/architecture/reports-command-use-cases-boundary-guard.test.ts
@@ -1,0 +1,360 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const root = process.cwd();
+const feature = "server/features/reports";
+const domain = `${feature}/domain`;
+const application = `${feature}/application`;
+const ports = `${application}/ports`;
+const infrastructure = `${feature}/infrastructure`;
+const composition = `${feature}/composition`;
+
+const expectedApplication = [
+  `${application}/README.md`,
+  `${application}/index.ts`,
+  `${application}/report-command-use-cases.ts`,
+  `${application}/report-workflow-communication.ts`,
+  `${ports}/index.ts`,
+  `${ports}/report-command-repository.ts`,
+  `${ports}/report-workflow-data-port.ts`,
+  `${ports}/report-workflow-notification-port.ts`,
+].sort();
+const expectedInfrastructure = [
+  `${infrastructure}/README.md`,
+  `${infrastructure}/index.ts`,
+  `${infrastructure}/report-command-repository.ts`,
+  `${infrastructure}/report-workflow-data-adapter.ts`,
+  `${infrastructure}/report-workflow-notification-adapter.ts`,
+].sort();
+const expectedComposition = [
+  `${composition}/README.md`,
+  `${composition}/index.ts`,
+  `${composition}/report-command-composition.ts`,
+  `${composition}/report-workflow-communication-composition.ts`,
+].sort();
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), "utf8")
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n");
+}
+
+function walk(directory: string): string[] {
+  if (!existsSync(resolve(root, directory))) {
+    return [];
+  }
+  return readdirSync(resolve(root, directory), { withFileTypes: true }).flatMap(
+    (entry) => {
+      const path = `${directory}/${entry.name}`;
+      return entry.isDirectory() ? walk(path) : [path];
+    },
+  );
+}
+
+function imports(path: string): string[] {
+  const source = ts.createSourceFile(
+    path,
+    read(path),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const result: string[] = [];
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      result.push(node.moduleSpecifier.text);
+    }
+    if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) &&
+          node.expression.text === "require"))
+    ) {
+      const argument = node.arguments[0];
+      if (argument && ts.isStringLiteral(argument)) {
+        result.push(argument.text);
+      }
+    }
+    node.forEachChild(visit);
+  }
+  visit(source);
+  return [...new Set(result)];
+}
+
+function target(path: string, specifier: string): string {
+  if (!specifier.startsWith(".")) {
+    return specifier;
+  }
+  const normalized = relative(
+    root,
+    resolve(root, dirname(path), specifier),
+  ).replaceAll("\\", "/");
+  if (normalized.endsWith(".ts")) {
+    return normalized;
+  }
+  if (existsSync(resolve(root, `${normalized}.ts`))) {
+    return `${normalized}.ts`;
+  }
+  return existsSync(resolve(root, `${normalized}/index.ts`))
+    ? `${normalized}/index.ts`
+    : normalized;
+}
+
+test("M38 fija inventario productivo exacto de Reports", () => {
+  assert.deepEqual(walk(application).sort(), expectedApplication);
+  assert.deepEqual(walk(infrastructure).sort(), expectedInfrastructure);
+  assert.deepEqual(walk(composition).sort(), expectedComposition);
+});
+
+test("M38 crea puerto, casos de uso, repository y composition separados", () => {
+  const port = read(`${ports}/report-command-repository.ts`);
+  const useCases = read(`${application}/report-command-use-cases.ts`);
+  const repository = read(`${infrastructure}/report-command-repository.ts`);
+  const bridge = read(`${composition}/report-command-composition.ts`);
+
+  for (const marker of [
+    "findReportById",
+    "createOrEditReport",
+    "persistReportStatusTransition",
+    "expectedFromStatus: ReportCommandStatus",
+  ]) {
+    assert.ok(port.includes(marker), marker);
+  }
+  for (const marker of [
+    "createReportCommandUseCases",
+    "canTransitionReportStatus",
+    '"not_found"',
+    '"same_status"',
+    '"transition_not_allowed"',
+    '"concurrent_not_found"',
+    '"persisted"',
+  ]) {
+    assert.ok(useCases.includes(marker), marker);
+  }
+  assert.ok(repository.includes("PersistReportStatusTransitionCommand"));
+  assert.equal(repository.includes("../application/"), false);
+  assert.equal(repository.includes("../composition/"), false);
+  assert.ok(bridge.includes("createReportCommandRepository"));
+  assert.ok(bridge.includes("createReportCommandUseCases"));
+});
+
+test("application y ports aplican default deny con único acceso al domain canónico", () => {
+  const violations: string[] = [];
+  for (const path of walk(application).filter((file) => file.endsWith(".ts"))) {
+    for (const specifier of imports(path)) {
+      const resolved = target(path, specifier);
+      const allowed =
+        resolved.startsWith(`${application}/`) ||
+        (path === `${application}/report-command-use-cases.ts` &&
+          resolved === `${domain}/index.ts`);
+      if (!allowed) {
+        violations.push(`${path}: ${specifier} -> ${resolved}`);
+      }
+    }
+    const source = read(path).toLowerCase();
+    for (const marker of [
+      "drizzle",
+      "schema.ts",
+      "db.ts",
+      "fastify",
+      "routes/",
+      "infrastructure/",
+      "auth",
+      "audit",
+      "email",
+      "cors",
+      "rate-limit",
+      "supabase",
+      "console.",
+      ".transaction(",
+    ]) {
+      if (source.includes(marker)) {
+        violations.push(`${path}: forbidden ${marker}`);
+      }
+    }
+  }
+  assert.deepEqual(violations, []);
+});
+
+test("composition contiene los únicos bridges application a infrastructure", () => {
+  const bridges = walk(feature)
+    .filter((path) => path.endsWith(".ts"))
+    .filter((path) => {
+      const targets = imports(path).map((specifier) => target(path, specifier));
+      return (
+        targets.some((value) => value.startsWith(`${application}/`)) &&
+        targets.some((value) => value.startsWith(`${infrastructure}/`))
+      );
+    })
+    .sort();
+
+  assert.deepEqual(bridges, [
+    `${composition}/report-command-composition.ts`,
+    `${composition}/report-workflow-communication-composition.ts`,
+  ]);
+  assert.equal(read(`${composition}/report-command-composition.ts`).includes(".select("), false);
+  assert.equal(read(`${composition}/report-command-composition.ts`).includes(".transaction("), false);
+});
+
+test("infrastructure es owner único de DB transacciones tablas y SQL M38", () => {
+  const repositoryPath = `${infrastructure}/report-command-repository.ts`;
+  const repository = read(repositoryPath);
+  const outsideSources = [
+    ...walk(application),
+    ...walk(composition),
+    "server/db.ts",
+  ]
+    .filter((path) => path.endsWith(".ts"))
+    .map((path) => [path, read(path)] as const);
+
+  assert.equal(repository.match(/database\.transaction\(/g)?.length, 2);
+  assert.equal(repository.match(/INSERT INTO "report_status_history"/g)?.length, 1);
+  for (const marker of [
+    'from "../../../db.ts"',
+    "reports,",
+    "reportStatusHistory",
+    ".where(eq(reports.storagePath, input.storagePath))",
+    ".where(eq(reports.id, input.reportId))",
+    "report.currentStatus !== input.expectedFromStatus",
+    "eq(reports.currentStatus, input.expectedFromStatus)",
+    "const updatedReport = updated[0]",
+    "if (!updatedReport)",
+    "fromStatus: input.expectedFromStatus",
+    ".limit(1)",
+    ".returning()",
+    'error.code !== "42703"',
+  ]) {
+    assert.ok(repository.includes(marker), marker);
+  }
+
+  for (const [path, source] of outsideSources) {
+    for (const marker of [
+      ".transaction(",
+      'INSERT INTO "report_status_history"',
+    ]) {
+      assert.equal(source.includes(marker), false, `${path}: ${marker}`);
+    }
+  }
+  assert.equal(repository.includes("../application/"), false);
+  assert.equal(repository.includes("../composition/"), false);
+});
+
+test("compatibilidad db y rutas M39 M40 permanecen conectadas como antes", () => {
+  const database = read("server/db.ts");
+  const admin = read("server/routes/admin-reports.fastify.ts");
+  const status = read("server/routes/reports-status.fastify.ts");
+  const reportsRoute = read("server/routes/reports.fastify.ts");
+  const workflow = read("server/routes/admin-report-workflow.fastify.ts");
+  const app = read("server/fastify-app.ts");
+
+  assert.ok(
+    database.includes(
+      'from "./features/reports/infrastructure/index.ts";',
+    ),
+  );
+  assert.ok(
+    database.includes(
+      'from "./features/reports/composition/index.ts";',
+    ),
+  );
+  for (const name of ["getReportById", "upsertReport"]) {
+    assert.match(
+      database,
+      new RegExp(`export \\{[\\s\\S]*?\\b${name}\\b[\\s\\S]*?\\} from`),
+    );
+  }
+  assert.match(
+    database,
+    /export \{\s*updateReportStatus,\s*\} from "\.\/features\/reports\/composition\/index\.ts";/,
+  );
+  const bridge = read(`${composition}/report-command-composition.ts`);
+  for (const marker of [
+    "export function transitionReportStatus",
+    "export async function updateReportStatus",
+    "const result = await transitionReportStatus(input)",
+    'result.type === "persisted" ? result.report : undefined',
+  ]) {
+    assert.ok(bridge.includes(marker), marker);
+  }
+  for (const [source, markers] of [
+    [admin, ["export type AdminReportsNativeRoutesOptions", "upsertReport: db.upsertReport"]],
+    [status, ["export type ReportsStatusNativeRoutesOptions", "updateReportStatus: db.updateReportStatus"]],
+    [reportsRoute, ["export type ReportsNativeRoutesOptions", "getReportStatusHistory: db.getReportStatusHistory"]],
+    [workflow, ["export type AdminReportWorkflowNativeRoutesOptions", 'await import("../db-report-workflow.ts")']],
+    [app, ['prefix: "/api/reports"', "reportsNativeRoutes", "reportsStatusNativeRoutes"]],
+  ] as const) {
+    for (const marker of markers) {
+      assert.ok(source.includes(marker), marker);
+    }
+    assert.equal(source.includes("report-command-composition"), false);
+  }
+});
+
+test("M36 y M37 permanecen intactos y M39 a M41 ausentes", () => {
+  assert.deepEqual(
+    walk(domain).sort(),
+    [
+      `${domain}/README.md`,
+      `${domain}/index.ts`,
+      `${domain}/report-status.ts`,
+      `${domain}/report-study-types.ts`,
+      `${domain}/reports.ts`,
+    ].sort(),
+  );
+  assert.ok(
+    read(`${application}/report-workflow-communication.ts`).includes(
+      "createReportWorkflowCommunication",
+    ),
+  );
+  assert.ok(
+    read(`${infrastructure}/report-workflow-data-adapter.ts`).includes(
+      "createReportWorkflowDataAdapter",
+    ),
+  );
+
+  for (const path of [
+    `${application}/report-query-use-cases.ts`,
+    `${application}/report-route-service.ts`,
+    `${composition}/report-route-composition.ts`,
+    `${infrastructure}/db-report-workflow.ts`,
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), false, path);
+  }
+});
+
+test("M38 excluye HTTP auth audit storage email y catch general", () => {
+  const files = [
+    `${application}/report-command-use-cases.ts`,
+    `${ports}/report-command-repository.ts`,
+    `${infrastructure}/report-command-repository.ts`,
+    `${composition}/report-command-composition.ts`,
+  ];
+  for (const path of files) {
+    const source = read(path).toLowerCase();
+    for (const marker of [
+      "fastify",
+      "routes/",
+      "writeaudit",
+      "sendemail",
+      "supabase",
+      "uploadreport",
+      "createsignedreport",
+      "cors",
+      "rate-limit",
+      "console.",
+    ]) {
+      assert.equal(source.includes(marker), false, `${path}: ${marker}`);
+    }
+  }
+
+  const repository = read(`${infrastructure}/report-command-repository.ts`);
+  assert.equal(repository.match(/\bcatch\s*\(/g)?.length, 1);
+  assert.ok(repository.includes('error.code !== "42703"'));
+});

--- a/test/architecture/reports-domain-boundary-guard.test.ts
+++ b/test/architecture/reports-domain-boundary-guard.test.ts
@@ -342,7 +342,7 @@ test("domain no contiene transporte infraestructura I/O ni side effects", () => 
   assert.deepEqual(violations, []);
 });
 
-test("M37 queda fuera del dominio y M38 permanece ausente", () => {
+test("M37 y M38 quedan fuera del dominio y M39 permanece ausente", () => {
   for (const path of [
     `${featureDir}/application`,
     `${featureDir}/infrastructure`,
@@ -369,8 +369,17 @@ test("M37 queda fuera del dominio y M38 permanece ausente", () => {
     false,
   );
   assert.equal(
+    existsSync(
+      join(
+        repoRoot,
+        `${featureDir}/application/report-command-use-cases.ts`,
+      ),
+    ),
+    true,
+  );
+  assert.equal(
     walkTsFiles(`${featureDir}/application`).some((file) =>
-      /(?:create|update|transition)-report/i.test(file)
+      /report-query|route-service/i.test(file),
     ),
     false,
   );

--- a/test/architecture/reports-suite-completeness.test.ts
+++ b/test/architecture/reports-suite-completeness.test.ts
@@ -371,7 +371,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "Reports conserva domain M36 y admite inventario M37 autorizado",
           "consumidores externos usan exclusivamente el barrel canonico",
           "domain aplica default-deny",
-          "M38 permanece ausente",
+          "M39 permanece ausente",
         ],
       },
       {
@@ -398,6 +398,38 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
         markers: [
           "data adapter preserva consulta y mapping minimo",
           "notification adapter preserva tabla values y returning exactos",
+        ],
+      },
+      {
+        path: "test/unit/application/reports/report-command-use-cases.test.ts",
+        markers: [
+          "createOrEditReport delega una vez",
+          "transitionReportStatus devuelve not_found",
+          "transitionReportStatus modela desaparici\u00f3n concurrente",
+        ],
+      },
+      {
+        path: "test/unit/infrastructure/reports/report-command-repository-contract.test.ts",
+        markers: [
+          "upsert update conserva transacci\u00f3n",
+          "fallback Drizzle corre s\u00f3lo ante PostgreSQL 42703",
+          "source contract fija SQL dual",
+        ],
+      },
+      {
+        path: "test/unit/contracts/reports/report-command-persistence-contract.test.ts",
+        markers: [
+          "server/db.ts conserva exports compatibles",
+          "infrastructure es owner \u00fanico",
+          "rutas conservan Options",
+        ],
+      },
+      {
+        path: "test/architecture/reports-command-use-cases-boundary-guard.test.ts",
+        markers: [
+          "M38 fija inventario productivo exacto",
+          "application y ports aplican default deny",
+          "M39 a M41 ausentes",
         ],
       },
       {
@@ -530,6 +562,10 @@ test("reports suite registers canonical reports guardrail files", () => {
     "reports-workflow-ports-boundary-guard.test.ts",
     "report-workflow-communication.test.ts",
     "report-workflow-adapters-contract.test.ts",
+    "report-command-use-cases.test.ts",
+    "report-command-repository-contract.test.ts",
+    "report-command-persistence-contract.test.ts",
+    "reports-command-use-cases-boundary-guard.test.ts",
   ]) {
     assert.equal(
       registeredFiles.includes(requiredFile),

--- a/test/architecture/reports-workflow-ports-boundary-guard.test.ts
+++ b/test/architecture/reports-workflow-ports-boundary-guard.test.ts
@@ -18,20 +18,24 @@ const route = "server/routes/admin-report-workflow.fastify.ts";
 const expectedApplication = [
   `${application}/README.md`,
   `${application}/index.ts`,
+  `${application}/report-command-use-cases.ts`,
   `${application}/report-workflow-communication.ts`,
   `${ports}/index.ts`,
+  `${ports}/report-command-repository.ts`,
   `${ports}/report-workflow-data-port.ts`,
   `${ports}/report-workflow-notification-port.ts`,
 ] as const;
 const expectedInfrastructure = [
   `${infrastructure}/README.md`,
   `${infrastructure}/index.ts`,
+  `${infrastructure}/report-command-repository.ts`,
   `${infrastructure}/report-workflow-data-adapter.ts`,
   `${infrastructure}/report-workflow-notification-adapter.ts`,
 ] as const;
 const expectedComposition = [
   `${composition}/README.md`,
   `${composition}/index.ts`,
+  `${composition}/report-command-composition.ts`,
   `${composition}/report-workflow-communication-composition.ts`,
 ] as const;
 
@@ -191,7 +195,13 @@ test("application y ports aplican default deny sin DB Drizzle schema ni capas su
   for (const path of walk(application).filter((candidate) => candidate.endsWith(".ts"))) {
     for (const reference of imports(path)) {
       const resolved = target(path, reference.specifier);
-      if (!resolved.startsWith(`${application}/`)) {
+      if (
+        !resolved.startsWith(`${application}/`) &&
+        !(
+          path === `${application}/report-command-use-cases.ts` &&
+          resolved === `${domain}/index.ts`
+        )
+      ) {
         violations.push(`${path}: dependency not allowed "${reference.specifier}"`);
       }
     }
@@ -277,6 +287,7 @@ test("composition es el unico bridge M37 entre application e infrastructure", ()
     });
 
   assert.deepEqual(bridgeFiles, [
+    `${composition}/report-command-composition.ts`,
     `${composition}/report-workflow-communication-composition.ts`,
   ]);
 });
@@ -361,16 +372,25 @@ test("fastify app conserva el registro actual sin imports M37", () => {
   );
 });
 
-test("M38 permanece ausente y db-report-workflow no se mueve prematuramente", () => {
+test("M38 agrega comandos separados y db-report-workflow no se mueve prematuramente", () => {
   assert.equal(existsSync(resolve(root, workflow)), true);
   assert.equal(
     existsSync(resolve(root, `${infrastructure}/db-report-workflow.ts`)),
     false,
   );
 
+  for (const path of [
+    `${application}/report-command-use-cases.ts`,
+    `${ports}/report-command-repository.ts`,
+    `${infrastructure}/report-command-repository.ts`,
+    `${composition}/report-command-composition.ts`,
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
   const forbiddenFiles = walk(feature).filter((path) =>
-    /(?:create|update|transition).*(?:report|status)|reports?-repository|handlers?|controllers?|services?/i
-      .test(path.slice(feature.length + 1))
+    /handlers?|controllers?|route-services?|report-query/i.test(
+      path.slice(feature.length + 1),
+    ),
   );
   assert.deepEqual(forbiddenFiles, []);
 });
@@ -427,5 +447,12 @@ test("best effort catch y logging seguro permanecen solo en db workflow", () => 
   const catches = walk(feature)
     .filter((path) => path.endsWith(".ts"))
     .filter((path) => /\bcatch\b/.test(read(path)));
-  assert.deepEqual(catches, []);
+  assert.deepEqual(catches, [
+    `${infrastructure}/report-command-repository.ts`,
+  ]);
+  const commandRepository = read(
+    `${infrastructure}/report-command-repository.ts`,
+  );
+  assert.equal(commandRepository.match(/\bcatch\s*\(/g)?.length, 1);
+  assert.ok(commandRepository.includes('error.code !== "42703"'));
 });

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -13,6 +13,8 @@ const reportsM36Closeout =
   "docs/implementation/m36-reports-domain-moves-catalog-census.md";
 const reportsM37Closeout =
   "docs/implementation/m37-reports-workflow-data-notification-ports.md";
+const reportsM38Closeout =
+  "docs/implementation/m38-reports-create-edit-transition-use-cases.md";
 
 const featureLayers = [
   {
@@ -377,6 +379,7 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
 
   assert.equal(existsSync(resolve(root, reportsM36Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM37Closeout)), true);
+  assert.equal(existsSync(resolve(root, reportsM38Closeout)), true);
 
   for (const path of [
     "server/features/reports/application",
@@ -387,7 +390,7 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
   }
 
   const futureCloseouts = walk("docs/implementation").filter((path) =>
-    /\/(?:m(?:38|39|40|41)-|reports-phase-i)/i.test(path),
+    /\/(?:m(?:39|40|41)-|reports-phase-i)/i.test(path),
   );
   assert.deepEqual(futureCloseouts, []);
 });

--- a/test/unit/application/reports/report-command-use-cases.test.ts
+++ b/test/unit/application/reports/report-command-use-cases.test.ts
@@ -1,0 +1,294 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createReportCommandUseCases,
+  type CreateOrEditReportInput,
+  type PersistReportStatusTransitionInput,
+  type ReportCommandRecord,
+  type ReportCommandRepository,
+  type TransitionReportStatusInput,
+} from "../../../../server/features/reports/application/index.ts";
+
+type FixtureReport = ReportCommandRecord & {
+  clinicId: number;
+  marker: string;
+};
+
+function report(
+  currentStatus: FixtureReport["currentStatus"] = "uploaded",
+): FixtureReport {
+  return { id: 41, clinicId: 7, currentStatus, marker: "fixture" };
+}
+
+function repository(
+  overrides: Partial<ReportCommandRepository<FixtureReport>> = {},
+): ReportCommandRepository<FixtureReport> {
+  return {
+    findReportById: async () => report(),
+    createOrEditReport: async () => report(),
+    persistReportStatusTransition: async (input) =>
+      report(input.toStatus),
+    ...overrides,
+  };
+}
+
+test("createOrEditReport delega una vez, preserva input y devuelve el resultado", async () => {
+  const calls: CreateOrEditReportInput[] = [];
+  const expected = report("processing");
+  const useCases = createReportCommandUseCases(
+    repository({
+      createOrEditReport: async (input) => {
+        calls.push(input);
+        return expected;
+      },
+    }),
+  );
+  const input: CreateOrEditReportInput = {
+    clinicId: 7,
+    uploadDate: new Date("2026-07-27T10:00:00.000Z"),
+    studyType: "histopatologia",
+    patientName: "Luna",
+    fileName: "luna.pdf",
+    storagePath: "reports/7/luna.pdf",
+    createdByClinicUserId: null,
+    createdByAdminUserId: 3,
+  };
+
+  const result = await useCases.createOrEditReport(input);
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0], input);
+  assert.equal(result, expected);
+});
+
+test("createOrEditReport propaga errores del repository", async () => {
+  const failure = new Error("write failed");
+  const useCases = createReportCommandUseCases(
+    repository({
+      createOrEditReport: async () => {
+        throw failure;
+      },
+    }),
+  );
+
+  await assert.rejects(
+    useCases.createOrEditReport({
+      clinicId: 7,
+      storagePath: "reports/7/luna.pdf",
+    }),
+    (error) => error === failure,
+  );
+});
+
+test("transitionReportStatus devuelve not_found sin persistir", async () => {
+  let writes = 0;
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => null,
+      persistReportStatusTransition: async () => {
+        writes += 1;
+        return report("ready");
+      },
+    }),
+  );
+
+  assert.deepEqual(
+    await useCases.transitionReportStatus({
+      reportId: 41,
+      toStatus: "ready",
+      note: null,
+    }),
+    { type: "not_found", reportId: 41 },
+  );
+  assert.equal(writes, 0);
+});
+
+test("transitionReportStatus devuelve same_status sin persistir", async () => {
+  let writes = 0;
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => report("ready"),
+      persistReportStatusTransition: async () => {
+        writes += 1;
+        return report("ready");
+      },
+    }),
+  );
+
+  assert.deepEqual(
+    await useCases.transitionReportStatus({
+      reportId: 41,
+      toStatus: "ready",
+      note: null,
+    }),
+    {
+      type: "same_status",
+      currentStatus: "ready",
+      requestedStatus: "ready",
+    },
+  );
+  assert.equal(writes, 0);
+});
+
+test("transitionReportStatus devuelve transition_not_allowed con ambos estados", async () => {
+  let writes = 0;
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => report("delivered"),
+      persistReportStatusTransition: async () => {
+        writes += 1;
+        return report("processing");
+      },
+    }),
+  );
+
+  assert.deepEqual(
+    await useCases.transitionReportStatus({
+      reportId: 41,
+      toStatus: "processing",
+      note: "retry",
+    }),
+    {
+      type: "transition_not_allowed",
+      currentStatus: "delivered",
+      requestedStatus: "processing",
+    },
+  );
+  assert.equal(writes, 0);
+});
+
+const allowedTransitions = [
+  ["uploaded", "processing"],
+  ["uploaded", "ready"],
+  ["uploaded", "delivered"],
+  ["processing", "ready"],
+  ["processing", "delivered"],
+  ["ready", "delivered"],
+] as const;
+
+for (const [fromStatus, toStatus] of allowedTransitions) {
+  test(`transitionReportStatus persiste exactamente una vez ${fromStatus} -> ${toStatus}`, async () => {
+    const calls: PersistReportStatusTransitionInput[] = [];
+    const expected = report(toStatus);
+    const useCases = createReportCommandUseCases(
+      repository({
+        findReportById: async () => report(fromStatus),
+        persistReportStatusTransition: async (input) => {
+          calls.push(input);
+          return expected;
+        },
+      }),
+    );
+    const input: TransitionReportStatusInput = {
+      reportId: 41,
+      toStatus,
+      note: "nota exacta",
+      changedByClinicUserId: 9,
+      changedByAdminUserId: null,
+    };
+
+    const result = await useCases.transitionReportStatus(input);
+
+    assert.equal(calls.length, 1);
+    assert.deepEqual(calls[0], {
+      ...input,
+      expectedFromStatus: fromStatus,
+    });
+    assert.deepEqual(result, { type: "persisted", report: expected });
+  });
+}
+
+test("transitionReportStatus ignora expectedFromStatus forjado por el caller", async () => {
+  const calls: PersistReportStatusTransitionInput[] = [];
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => report("uploaded"),
+      persistReportStatusTransition: async (input) => {
+        calls.push(input);
+        return report(input.toStatus);
+      },
+    }),
+  );
+  const forgedInput = {
+    reportId: 41,
+    toStatus: "ready",
+    note: "caller externo",
+    changedByClinicUserId: 9,
+    changedByAdminUserId: null,
+    expectedFromStatus: "delivered",
+  } as const;
+
+  const result = await useCases.transitionReportStatus(forgedInput);
+
+  assert.deepEqual(calls, [
+    {
+      reportId: 41,
+      toStatus: "ready",
+      note: "caller externo",
+      changedByClinicUserId: 9,
+      changedByAdminUserId: null,
+      expectedFromStatus: "uploaded",
+    },
+  ]);
+  assert.equal(result.type, "persisted");
+});
+
+test("transitionReportStatus modela desaparición concurrente", async () => {
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => report("processing"),
+      persistReportStatusTransition: async () => undefined,
+    }),
+  );
+
+  assert.deepEqual(
+    await useCases.transitionReportStatus({
+      reportId: 41,
+      toStatus: "ready",
+      note: null,
+    }),
+    { type: "concurrent_not_found", reportId: 41 },
+  );
+});
+
+test("transitionReportStatus propaga error de lectura", async () => {
+  const failure = new Error("read failed");
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => {
+        throw failure;
+      },
+    }),
+  );
+
+  await assert.rejects(
+    useCases.transitionReportStatus({
+      reportId: 41,
+      toStatus: "ready",
+      note: null,
+    }),
+    (error) => error === failure,
+  );
+});
+
+test("transitionReportStatus propaga error de persistencia", async () => {
+  const failure = new Error("write failed");
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async () => report("processing"),
+      persistReportStatusTransition: async () => {
+        throw failure;
+      },
+    }),
+  );
+
+  await assert.rejects(
+    useCases.transitionReportStatus({
+      reportId: 41,
+      toStatus: "ready",
+      note: null,
+    }),
+    (error) => error === failure,
+  );
+});

--- a/test/unit/contracts/reports/report-command-persistence-contract.test.ts
+++ b/test/unit/contracts/reports/report-command-persistence-contract.test.ts
@@ -1,0 +1,171 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), "utf8").replace(/\r\n/g, "\n");
+}
+
+function walk(directory: string): string[] {
+  return readdirSync(resolve(root, directory), { withFileTypes: true }).flatMap(
+    (entry) => {
+      const path = `${directory}/${entry.name}`;
+      return entry.isDirectory() ? walk(path) : [path];
+    },
+  );
+}
+
+test("server/db.ts conserva exports compatibles sin duplicar persistencia M38", () => {
+  const source = read("server/db.ts");
+  const reportsSection = source.slice(
+    source.indexOf("/* ========================= REPORTS"),
+  );
+
+  assert.ok(
+    source.includes(
+      'from "./features/reports/infrastructure/index.ts";',
+    ),
+  );
+  assert.ok(
+    source.includes(
+      'from "./features/reports/composition/index.ts";',
+    ),
+  );
+  for (const name of ["getReportById", "upsertReport"]) {
+    assert.match(
+      source,
+      new RegExp(`export \\{[\\s\\S]*?\\b${name}\\b[\\s\\S]*?\\} from`),
+    );
+    assert.equal(
+      reportsSection.includes(`export async function ${name}`),
+      false,
+      name,
+    );
+  }
+  assert.match(
+    source,
+    /export \{\s*updateReportStatus,\s*\} from "\.\/features\/reports\/composition\/index\.ts";/,
+  );
+  assert.equal(
+    reportsSection.includes("export async function updateReportStatus"),
+    false,
+  );
+  assert.equal(reportsSection.includes(".transaction("), false);
+  assert.equal(
+    reportsSection.includes('INSERT INTO "report_status_history"'),
+    false,
+  );
+});
+
+test("infrastructure es owner único de transacciones y SQL M38", () => {
+  const source = read(
+    "server/features/reports/infrastructure/report-command-repository.ts",
+  );
+
+  assert.equal(source.match(/database\.transaction\(/g)?.length, 2);
+  assert.equal(
+    source.match(/INSERT INTO "report_status_history"/g)?.length,
+    1,
+  );
+  assert.ok(source.includes("export function createReportCommandRepository"));
+  assert.ok(source.includes("export function getReportById"));
+  assert.ok(source.includes("export function upsertReport"));
+  assert.equal(source.includes("export function updateReportStatus"), false);
+  assert.equal(source.includes("../application/"), false);
+  assert.equal(source.includes("../composition/"), false);
+});
+
+test("transition persistence usa expectedFromStatus y CAS antes del historial", () => {
+  const source = read(
+    "server/features/reports/infrastructure/report-command-repository.ts",
+  );
+
+  for (const marker of [
+    "report.currentStatus !== input.expectedFromStatus",
+    "and(",
+    "eq(reports.id, input.reportId)",
+    "eq(reports.currentStatus, input.expectedFromStatus)",
+    "const updatedReport = updated[0]",
+    "if (!updatedReport)",
+    "fromStatus: input.expectedFromStatus",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+  assert.ok(
+    source.indexOf("if (!updatedReport)") <
+      source.lastIndexOf("await insertCompatibleReportStatusHistory"),
+  );
+});
+
+test("rutas conservan Options y exports compatibility previos", () => {
+  const admin = read("server/routes/admin-reports.fastify.ts");
+  const status = read("server/routes/reports-status.fastify.ts");
+  const reads = read("server/routes/reports.fastify.ts");
+
+  for (const marker of [
+    "export type AdminReportsNativeRoutesOptions",
+    "const db = await import(\"../db.ts\")",
+    "getReportById: db.getReportById",
+    "upsertReport: db.upsertReport",
+    "const report = await deps.upsertReport({",
+  ]) {
+    assert.ok(admin.includes(marker), marker);
+  }
+  for (const marker of [
+    "export type ReportsStatusNativeRoutesOptions",
+    "const db = await import(\"../db.ts\")",
+    "getClinicScopedReportById: db.getClinicScopedReportById",
+    "updateReportStatus: db.updateReportStatus",
+    "const updated = await deps.updateReportStatus({",
+  ]) {
+    assert.ok(status.includes(marker), marker);
+  }
+  assert.ok(reads.includes("getReportStatusHistory: db.getReportStatusHistory"));
+  assert.equal(admin.includes("report-command-composition"), false);
+  assert.equal(status.includes("report-command-composition"), false);
+});
+
+test("compatibility update atraviesa composition y application sin queries", () => {
+  const composition = read(
+    "server/features/reports/composition/report-command-composition.ts",
+  );
+
+  for (const marker of [
+    "export function transitionReportStatus",
+    "export async function updateReportStatus",
+    "const result = await transitionReportStatus(input)",
+    'result.type === "persisted" ? result.report : undefined',
+  ]) {
+    assert.ok(composition.includes(marker), marker);
+  }
+
+  const files = [
+    ...walk("server/features/reports/application"),
+    ...walk("server/features/reports/composition"),
+  ].filter((path) => path.endsWith(".ts"));
+
+  for (const path of files) {
+    const source = read(path);
+    for (const forbidden of [
+      ".select(",
+      ".insert(",
+      ".update(",
+      ".transaction(",
+      "drizzle-orm",
+      "reportStatusHistory",
+    ]) {
+      assert.equal(source.includes(forbidden), false, `${path}: ${forbidden}`);
+    }
+  }
+
+  for (const absent of [
+    "server/features/reports/application/report-query-use-cases.ts",
+    "server/features/reports/application/report-route-service.ts",
+    "server/features/reports/composition/report-route-composition.ts",
+  ]) {
+    assert.equal(existsSync(resolve(root, absent)), false, absent);
+  }
+});

--- a/test/unit/infrastructure/reports/report-command-repository-contract.test.ts
+++ b/test/unit/infrastructure/reports/report-command-repository-contract.test.ts
@@ -1,0 +1,429 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+process.env.NODE_ENV ??= "development";
+process.env.SUPABASE_URL ??= "https://example.supabase.co";
+process.env.SUPABASE_ANON_KEY ??= "test-anon-key";
+process.env.SUPABASE_SERVICE_ROLE_KEY ??= "test-service-role-key";
+process.env.DATABASE_URL ??=
+  "postgresql://postgres:postgres@127.0.0.1:5432/postgres";
+process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
+
+const { createReportCommandRepository } = await import(
+  "../../../../server/features/reports/infrastructure/report-command-repository.ts"
+);
+
+type FakeState = {
+  transactionCalls: number;
+  selectResults: unknown[][];
+  selectLimits: number[];
+  updateSets: Array<Record<string, unknown>>;
+  updateWhereCalls: number;
+  updateRows?: Array<Array<Record<string, unknown>>>;
+  insertValues: Array<Record<string, unknown>>;
+  executeCalls: unknown[];
+  executeError?: unknown;
+  updateResult: Record<string, unknown>;
+  insertResult: Record<string, unknown>;
+};
+
+function fakeDatabase(overrides: Partial<FakeState> = {}) {
+  const state: FakeState = {
+    transactionCalls: 0,
+    selectResults: [],
+    selectLimits: [],
+    updateSets: [],
+    updateWhereCalls: 0,
+    insertValues: [],
+    executeCalls: [],
+    updateResult: { id: 41, currentStatus: "ready" },
+    insertResult: { id: 41, currentStatus: "uploaded" },
+    ...overrides,
+  };
+
+  const select = () => ({
+    from: () => ({
+      where: () => ({
+        limit: async (limit: number) => {
+          state.selectLimits.push(limit);
+          return state.selectResults.shift() ?? [];
+        },
+      }),
+    }),
+  });
+  const update = () => ({
+    set: (values: Record<string, unknown>) => {
+      state.updateSets.push(values);
+      return {
+        where: () => ({
+          returning: async () => {
+            state.updateWhereCalls += 1;
+            return state.updateRows?.shift() ?? [state.updateResult];
+          },
+        }),
+      };
+    },
+  });
+  const insert = () => ({
+    values: (values: Record<string, unknown>) => {
+      state.insertValues.push(values);
+      const thenable = {
+        returning: async () => [state.insertResult],
+        then: (
+          resolvePromise: (value: undefined) => void,
+          _rejectPromise: (reason: unknown) => void,
+        ) => resolvePromise(undefined),
+      };
+      return thenable;
+    },
+  });
+  const tx = {
+    select,
+    update,
+    insert,
+    execute: async (query: unknown) => {
+      state.executeCalls.push(query);
+      if (state.executeError) {
+        throw state.executeError;
+      }
+    },
+  };
+  const database = {
+    select,
+    transaction: async <T>(operation: (transaction: typeof tx) => Promise<T>) => {
+      state.transactionCalls += 1;
+      return operation(tx);
+    },
+  };
+
+  return { database, state };
+}
+
+test("upsert update conserva transacción, lookup limit 1 y set exacto sin historial", async () => {
+  const timestamp = new Date("2026-07-27T12:00:00.000Z");
+  const existing = { id: 41, currentStatus: "processing" };
+  const expected = { ...existing, fileName: "new.pdf" };
+  const { database, state } = fakeDatabase({
+    selectResults: [[existing]],
+    updateResult: expected,
+  });
+  const repository = createReportCommandRepository({
+    database: database as never,
+    now: () => timestamp,
+  });
+
+  const result = await repository.createOrEditReport({
+    clinicId: 99,
+    storagePath: "reports/7/original.pdf",
+    uploadDate: undefined,
+    studyType: undefined,
+    patientName: undefined,
+    fileName: "new.pdf",
+    createdByClinicUserId: 5,
+    createdByAdminUserId: 6,
+  });
+
+  assert.equal(state.transactionCalls, 1);
+  assert.deepEqual(state.selectLimits, [1]);
+  assert.deepEqual(state.updateSets, [
+    {
+      uploadDate: null,
+      studyType: null,
+      patientName: null,
+      fileName: "new.pdf",
+      updatedAt: timestamp,
+    },
+  ]);
+  assert.equal(state.insertValues.length, 0);
+  assert.equal(state.executeCalls.length, 0);
+  assert.equal(result, expected);
+});
+
+test("upsert insert conserva payload, timestamp único e historial inicial único", async () => {
+  const timestamp = new Date("2026-07-27T12:00:00.000Z");
+  const inserted = { id: 41, currentStatus: "uploaded" };
+  const { database, state } = fakeDatabase({
+    selectResults: [[]],
+    insertResult: inserted,
+  });
+  const repository = createReportCommandRepository({
+    database: database as never,
+    now: () => timestamp,
+  });
+
+  const result = await repository.createOrEditReport({
+    clinicId: 7,
+    storagePath: "reports/7/new.pdf",
+    createdByClinicUserId: 5,
+    createdByAdminUserId: 6,
+  });
+
+  assert.equal(state.transactionCalls, 1);
+  assert.deepEqual(state.selectLimits, [1]);
+  assert.deepEqual(state.insertValues, [
+    {
+      clinicId: 7,
+      uploadDate: null,
+      studyType: null,
+      patientName: null,
+      fileName: null,
+      storagePath: "reports/7/new.pdf",
+      previewUrl: null,
+      downloadUrl: null,
+      currentStatus: "uploaded",
+      statusChangedAt: timestamp,
+      statusChangedByClinicUserId: 5,
+      statusChangedByAdminUserId: 6,
+      createdAt: timestamp,
+      updatedAt: timestamp,
+    },
+  ]);
+  assert.equal(state.executeCalls.length, 1);
+  assert.equal(result, inserted);
+});
+
+test("transition ausente no escribe y transición válida conserva set exacto", async () => {
+  const missing = fakeDatabase({ selectResults: [[]] });
+  const missingRepository = createReportCommandRepository({
+    database: missing.database as never,
+  });
+
+  assert.equal(
+    await missingRepository.persistReportStatusTransition({
+      reportId: 41,
+      expectedFromStatus: "processing",
+      toStatus: "ready",
+    }),
+    undefined,
+  );
+  assert.equal(missing.state.transactionCalls, 1);
+  assert.deepEqual(missing.state.selectLimits, [1]);
+  assert.equal(missing.state.updateSets.length, 0);
+  assert.equal(missing.state.executeCalls.length, 0);
+
+  const timestamp = new Date("2026-07-27T13:00:00.000Z");
+  const updated = { id: 41, currentStatus: "ready" };
+  const valid = fakeDatabase({
+    selectResults: [[{ id: 41, currentStatus: "processing" }]],
+    updateResult: updated,
+  });
+  const validRepository = createReportCommandRepository({
+    database: valid.database as never,
+    now: () => timestamp,
+  });
+
+  assert.equal(
+    await validRepository.persistReportStatusTransition({
+      reportId: 41,
+      expectedFromStatus: "processing",
+      toStatus: "ready",
+      note: undefined,
+      changedByClinicUserId: 5,
+      changedByAdminUserId: 6,
+    }),
+    updated,
+  );
+  assert.equal(valid.state.transactionCalls, 1);
+  assert.deepEqual(valid.state.selectLimits, [1]);
+  assert.deepEqual(valid.state.updateSets, [
+    {
+      currentStatus: "ready",
+      statusChangedAt: timestamp,
+      statusChangedByClinicUserId: 5,
+      statusChangedByAdminUserId: 6,
+      updatedAt: timestamp,
+    },
+  ]);
+  assert.equal(valid.state.executeCalls.length, 1);
+});
+
+test("transition rechaza estado fresco distinto sin update ni historial", async () => {
+  const stale = fakeDatabase({
+    selectResults: [[{ id: 41, currentStatus: "delivered" }]],
+  });
+  const repository = createReportCommandRepository({
+    database: stale.database as never,
+  });
+
+  assert.equal(
+    await repository.persistReportStatusTransition({
+      reportId: 41,
+      expectedFromStatus: "uploaded",
+      toStatus: "ready",
+    }),
+    undefined,
+  );
+  assert.equal(stale.state.updateSets.length, 0);
+  assert.equal(stale.state.updateWhereCalls, 0);
+  assert.equal(stale.state.executeCalls.length, 0);
+  assert.equal(stale.state.insertValues.length, 0);
+});
+
+test("transition no crea historial cuando el UPDATE CAS devuelve cero filas", async () => {
+  const lost = fakeDatabase({
+    selectResults: [[{ id: 41, currentStatus: "uploaded" }]],
+    updateRows: [[]],
+  });
+  const repository = createReportCommandRepository({
+    database: lost.database as never,
+  });
+
+  assert.equal(
+    await repository.persistReportStatusTransition({
+      reportId: 41,
+      expectedFromStatus: "uploaded",
+      toStatus: "ready",
+      note: "stale",
+    }),
+    undefined,
+  );
+  assert.equal(lost.state.updateSets.length, 1);
+  assert.equal(lost.state.updateWhereCalls, 1);
+  assert.equal(lost.state.executeCalls.length, 0);
+  assert.equal(lost.state.insertValues.length, 0);
+});
+
+test("dos transiciones con el mismo expected status sólo persisten una", async () => {
+  const shared = fakeDatabase({
+    selectResults: [
+      [{ id: 41, currentStatus: "uploaded" }],
+      [{ id: 41, currentStatus: "uploaded" }],
+    ],
+    updateRows: [
+      [{ id: 41, currentStatus: "delivered" }],
+      [],
+    ],
+  });
+  const repository = createReportCommandRepository({
+    database: shared.database as never,
+  });
+  const input = {
+    reportId: 41,
+    expectedFromStatus: "uploaded" as const,
+    toStatus: "delivered" as const,
+    note: null,
+  };
+
+  const first = await repository.persistReportStatusTransition(input);
+  const second = await repository.persistReportStatusTransition(input);
+
+  assert.equal(first?.currentStatus, "delivered");
+  assert.equal(second, undefined);
+  assert.equal(shared.state.transactionCalls, 2);
+  assert.equal(shared.state.updateWhereCalls, 2);
+  assert.equal(shared.state.executeCalls.length, 1);
+  assert.equal(shared.state.insertValues.length, 0);
+});
+
+test("fallback Drizzle corre sólo ante PostgreSQL 42703", async () => {
+  const timestamp = new Date("2026-07-27T14:00:00.000Z");
+  const fallback = fakeDatabase({
+    selectResults: [[{ id: 41, currentStatus: "ready" }]],
+    executeError: { code: "42703" },
+  });
+  const repository = createReportCommandRepository({
+    database: fallback.database as never,
+    now: () => timestamp,
+  });
+
+  await repository.persistReportStatusTransition({
+    reportId: 41,
+    expectedFromStatus: "ready",
+    toStatus: "delivered",
+    note: undefined,
+    changedByClinicUserId: null,
+    changedByAdminUserId: 6,
+  });
+
+  assert.deepEqual(fallback.state.insertValues, [
+    {
+      reportId: 41,
+      fromStatus: "ready",
+      toStatus: "delivered",
+      changedByClinicUserId: null,
+      changedByAdminUserId: 6,
+      note: null,
+      createdAt: timestamp,
+    },
+  ]);
+
+  const failure = { code: "23505" };
+  const nonFallback = fakeDatabase({
+    selectResults: [[{ id: 41, currentStatus: "ready" }]],
+    executeError: failure,
+  });
+  const nonFallbackRepository = createReportCommandRepository({
+    database: nonFallback.database as never,
+  });
+
+  await assert.rejects(
+    nonFallbackRepository.persistReportStatusTransition({
+      reportId: 41,
+      expectedFromStatus: "ready",
+      toStatus: "delivered",
+    }),
+    (error) => error === failure,
+  );
+  assert.equal(nonFallback.state.insertValues.length, 0);
+});
+
+test("source contract fija SQL dual, autoría, límites y ausencia de side effects", () => {
+  const source = readFileSync(
+    resolve(
+      process.cwd(),
+      "server/features/reports/infrastructure/report-command-repository.ts",
+    ),
+    "utf8",
+  ).replace(/\r\n/g, "\n");
+
+  for (const marker of [
+    '.where(eq(reports.storagePath, input.storagePath))',
+    ".where(eq(reports.id, input.reportId))",
+    "report.currentStatus !== input.expectedFromStatus",
+    "and(\n              eq(reports.id, input.reportId),\n              eq(reports.currentStatus, input.expectedFromStatus),",
+    "const updatedReport = updated[0]",
+    "if (!updatedReport)",
+    "fromStatus: input.expectedFromStatus",
+    ".limit(1)",
+    'INSERT INTO "report_status_history"',
+    '"status"',
+    '"previous_status"',
+    '"changed_by"',
+    '"changed_by_type"',
+    '"notes"',
+    '"from_status"',
+    '"to_status"',
+    '"changed_by_clinic_user_id"',
+    '"changed_by_admin_user_id"',
+    '"note"',
+    "input.createdAt.toISOString()",
+    'error.code !== "42703"',
+    "input.changedByClinicUserId ?? input.changedByAdminUserId ?? null",
+    'input.changedByClinicUserId != null\n      ? "clinic_user"',
+    ': input.changedByAdminUserId != null\n        ? "admin_user"\n        : "system"',
+  ]) {
+    assert.ok(source.includes(marker), `missing source contract: ${marker}`);
+  }
+
+  for (const forbidden of [
+    "Fastify",
+    "writeAudit",
+    "sendEmail",
+    "supabase",
+    "console.",
+    "uploadReport",
+    "createSignedReport",
+  ]) {
+    assert.equal(source.includes(forbidden), false, forbidden);
+  }
+  assert.equal(
+    source.match(/database\.transaction\(/g)?.length,
+    2,
+  );
+  assert.equal(
+    source.match(/INSERT INTO "report_status_history"/g)?.length,
+    1,
+  );
+});


### PR DESCRIPTION
## Summary

- establishes Reports command use cases for create/edit and status transitions
- moves command persistence from `server/db.ts` into canonical Reports infrastructure
- introduces application ports, use cases, composition, and compatibility exports
- makes status transitions atomic through compare-and-set on report ID and expected prior status
- prevents stale concurrent transitions from overwriting newer states or creating misleading history
- preserves the dual status-history SQL contract and PostgreSQL `42703` fallback
- preserves routes, HTTP contracts, auth, permissions, audit, storage, schema, and registration order
- preserves M39–M41 as not started

## Concurrency correction

The review P2 was addressed by:

- keeping `expectedFromStatus` internal to application/repository
- deriving it from the report read and validated by application
- re-reading inside the transaction
- updating with `WHERE report_id = ? AND current_status = expectedFromStatus`
- treating a stale read or zero-row update as a concurrent result
- inserting history only after a successful compare-and-set update
- routing legacy `updateReportStatus` compatibility through composition/application
- adding simulated concurrent-transition and zero-row CAS coverage

## Scope

- [x] Backend Runtime

Included:

- Reports command repository port
- create/edit use case
- explicit status-transition use case results
- canonical Drizzle command repository
- lazy command composition
- compatibility exports from `server/db.ts`
- atomic status transition compare-and-set
- M38 tests, contracts, guard, READMEs, and implementation record

Excluded:

- route changes or route thinning
- `server/fastify-app.ts`
- Reports read/query use cases
- upload/storage orchestration
- Particular Token or Study Tracking orchestration
- audit relocation
- authentication, permissions, sessions, CORS, rate limits, email, or signed URLs
- Reports domain changes
- M39, M40, or M41 implementation
- schema, migrations, dependencies, frontend, scripts, and CI configuration

## Validation

- application command use cases: PASSED, 15/15
- infrastructure plus persistence contract: PASSED, 13/13
- Reports architecture guards: PASSED, 39/39
- route integrations plus write ownership: PASSED, 29/29
- corrected M38 cumulative cohort: PASSED, 67/67
- `pnpm typecheck`: PASSED
- `pnpm typecheck:test`: PASSED
- `pnpm validate:local`: PASSED, 3806 pass, 1 skip, 0 fail, build included
- `pnpm security:public-surface`: PASSED
- `pnpm audit --prod`: PASSED, no known vulnerabilities
- `pnpm audit`: PASSED, no known vulnerabilities
- `git diff --check`: PASSED
- Playwright: NOT_RUN
- migrations and real database: NOT_RUN
- staging and production: NOT_RUN

## Rollback

Revert the M38 commit as one unit. No schema, migration, data, credential, route, dependency, or infrastructure rollback is required.