### PR TITLE
refactor(reports): modularize query use cases and routes

### DIFF
--- a/docs/implementation/m40-reports-query-use-cases-thin-routes.md
+++ b/docs/implementation/m40-reports-query-use-cases-thin-routes.md
@@ -1,0 +1,196 @@
+# M40 — Reports query use cases + clinic thin routes
+
+## Identificación
+
+- Milestone: M40.
+- Rama:
+  `refactor/backend-modularization-m40-reports-query-use-cases-thin-routes`.
+- Baseline exacto: `9e1664ee6c73f02a2a484ec2a697831e40225013`.
+- Predecesor: M39 / PR #1578 / squash merge
+  `9e1664ee6c73f02a2a484ec2a697831e40225013`.
+- Riesgo: R2 estructural backend autorizado específicamente para M40.
+- Git/GitHub: stage, commit, amend, push, PR y merge reservados a Nico.
+- M41: `NOT_RUN`.
+
+## Censo inicial
+
+Las ocho queries generales residían en la sección Reports de `server/db.ts`:
+lookup clinic-scoped, historial, listado, count de listado, búsqueda, count de
+búsqueda y los dos nombres públicos del catálogo. `reports.fastify.ts`
+cargaba `db.ts` y Supabase, coordinaba list+count, ownership, historial y
+signed URLs. `reports-status.fastify.ts` cargaba los mismos defaults,
+duplicaba validación de transición M38 y llamaba el adapter compatibility
+`db.updateReportStatus`.
+
+Consumidores runtime directos: las dos rutas clínicas, seis superficies
+legacy que consumen `getClinicScopedReportById` mediante `db.ts` y los
+consumidores de `getReportById` M38. Tests de integración inyectaban todas las
+Options. Guards M36–M39, catálogo, persistencia, seguridad, auditoría,
+ownership, disclosure, timing y sesión leían fuentes por path.
+
+Clasificación:
+
+- A: guards y contracts source-aware que apuntaban a `server/db.ts`, a
+  coordinación en rutas o exigían M40 ausente;
+- B: unit de query use cases, contract de repository y guard M40;
+- C: integraciones HTTP, auth, CORS/preflight, sesión, timing/logging,
+  transición/CAS, auditoría, cross-tenant/IDOR, disclosure, ownership,
+  suite completeness y closeouts previos; no se redujeron assertions.
+
+## Arquitectura antes y después
+
+Antes:
+
+```text
+route HTTP -> server/db.ts + Supabase + lógica inline
+```
+
+Después:
+
+```text
+route HTTP
+  -> report-query-composition.ts (lazy)
+    -> report-query-use-cases.ts
+      -> report-query-repository port
+        -> report-query-repository.ts (Drizzle)
+```
+
+Application modela listados paginados, búsqueda, catálogo, lookup
+clinic-scoped, historial, preview, download y lookup previo a transición. Usa
+la serialización segura del domain, resultados `not_found`, no captura errores
+generales y no conoce framework, DB, Drizzle, schema, storage ni audit
+concretos.
+
+Composition adapta las Options históricas a puertos M40. La inyección completa
+evita defaults; el fallback `getReportById` valida `clinicId`. El runtime
+default de status reutiliza `transitionReportStatus` M38. La compatibilidad
+inyectada de `updateReportStatus` se adapta mediante
+`createReportCommandUseCases`, por lo que la validación de transición sigue
+teniendo owner único.
+
+## Persistencia y equivalencia
+
+`report-query-repository.ts` es owner único de:
+
+- `getClinicScopedReportById`;
+- `getReportStatusHistory`;
+- `getReportsByClinicId`;
+- `countReportsByClinicId`;
+- `searchReports`;
+- `countSearchReports`;
+- `getReportStudyTypes`;
+- `getStudyTypes`.
+
+Se preservan filtros simultáneos report/clinic, `limit(1)`, orden de historial
+por `createdAt` e `id` descendentes, filtros opcionales, orden de informes,
+limit/offset, `ilike` sobre los tres campos con patrón `%query%`, equivalencia
+query/count, `count(*)`, conversión numérica y catálogo domain sin consulta DB.
+
+`server/db.ts` conserva sólo reexports temporales de estas operaciones hasta
+M41. No conserva queries, filtros, orden, paginación, SQL de counts ni catálogo
+duplicado en su sección Reports.
+
+## Contratos HTTP preservados
+
+`ReportsNativeRoutesOptions` y `ReportsStatusNativeRoutesOptions` conservan
+todos sus campos y firmas, incluidos `getReportById`,
+`getClinicScopedReportById` y `updateReportStatus`.
+
+Se preservan los seis OPTIONS y seis GET de reads, además de OPTIONS/PATCH de
+status; métodos, paths, orden de registro, parsing, defaults 50/100/0, filtros,
+payloads, mensajes, status codes, CORS, cookies, auth, session-last-access,
+permisos, timing y logging.
+
+La transición status mantiene trusted origin antes de auth/write, ownership
+antes de M38, resultados `not_found`, `same_status`,
+`transition_not_allowed`, `concurrent_not_found` y `persisted`, CAS M38 y
+auditoría `REPORT_STATUS_CHANGED` después de persistir y antes de responder.
+
+`server/fastify-app.ts` no se modifica. Su doble registro permanece exactamente
+en este orden:
+
+1. `reportsNativeRoutes`, prefix `/api/reports`;
+2. `reportsStatusNativeRoutes`, prefix `/api/reports`.
+
+## Archivos
+
+Creados:
+
+- `server/features/reports/application/ports/report-query-repository.ts`;
+- `server/features/reports/application/report-query-use-cases.ts`;
+- `server/features/reports/infrastructure/report-query-repository.ts`;
+- `server/features/reports/composition/report-query-composition.ts`;
+- `test/unit/application/reports/report-query-use-cases.test.ts`;
+- `test/unit/infrastructure/reports/report-query-repository-contract.test.ts`;
+- `test/architecture/reports-query-use-cases-boundary-guard.test.ts`;
+- este documento.
+
+Modificados: barrels y READMEs de Reports, `server/db.ts`, las dos rutas
+clínicas, guards A y registry de suite. Eliminados: ninguno.
+
+Permanecen para M41: `server/db-report-workflow.ts`,
+`server/lib/report-workflow-communication.ts`,
+`server/lib/report-status.ts`, `server/lib/report-study-types.ts`,
+`server/lib/reports.ts` y reexports compatibility en `server/db.ts`.
+
+## Side effects
+
+Reads no agregan side effects. History, preview y download sólo ejecutan su
+operación posterior después de ownership. Status ejecuta lookup tenant-scoped,
+comando M38, auditoría y respuesta en ese orden. Errores de DB, storage o audit
+se propagan; no se agregan retries, cache, queue, outbox ni compensación.
+
+## Validación
+
+Estados canónicos: `PASSED`, `FAILED`, `NOT_RUN`, `NOT_AVAILABLE`, `BLOCKED`.
+
+Secuencia fail-fast real:
+
+- primer `pnpm typecheck`: `FAILED`, exit code 2, por colisión del alias
+  `getReportStudyTypes`; corregido sin avanzar a gates dependientes;
+- `pnpm typecheck` repetido: `PASSED`, exit code 0;
+- integraciones reads+status: `PASSED`, exit code 0, 29/29;
+- tests B M40 iniciales: `FAILED`, exit code 1, 18/19 por regex del propio
+  contract de `count(*)`; runtime intacto;
+- tests B M40 finales: `PASSED`, exit code 0, 19/19;
+- guards A iniciales: `FAILED`, exit code 1, 42/60, por anchors que exigían
+  M40 ausente o owners legacy;
+- guards A+B finales: `PASSED`, exit code 0, 79/79;
+- contratos C iniciales: `FAILED`, exit code 1, 132/141, por nueve anchors
+  source-aware legacy;
+- contratos C focales finales: `PASSED`, exit code 0, 55/55;
+- cohorte acumulativa inicial: `FAILED`, exit code 1, 299/301, por dos anchors
+  restantes; repetición focal: `PASSED`, exit code 0, 15/15;
+- cohorte acumulativa final M36–M40: `PASSED`, exit code 0, 301/301;
+- `pnpm typecheck` final: `PASSED`, exit code 0;
+- `pnpm typecheck:test` final: `PASSED`, exit code 0;
+- primer `pnpm validate:local`: `FAILED`, exit code 1, 3.847 pass, 1 skip,
+  1 fail, por registry global con `getAuthorizedReport` legacy;
+- guard global repetido: `PASSED`, exit code 0, 6/6;
+- segundo `pnpm validate:local`: `FAILED`, exit code 1, 3.819 pass, 1 skip,
+  1 fail al cargar un test Logistics ajeno; repetición aislada:
+  `PASSED`, exit code 0, 29/29, sin cambios fuera de scope;
+- `pnpm validate:local` final: `PASSED`, exit code 0, 3.848 pass, 1 skip,
+  0 fail y build completado;
+- `pnpm security:public-surface`: `PASSED`, exit code 0, sin findings
+  públicos y dos markers server-only esperados;
+- `pnpm audit --prod`: `PASSED`, exit code 0, sin vulnerabilidades conocidas;
+- `pnpm audit`: `PASSED`, exit code 0, sin vulnerabilidades conocidas.
+- `git diff --check`: `PASSED`, exit code 0, sin errores de whitespace;
+- revisión de scope y artefactos: `PASSED`, `server/fastify-app.ts` intacto,
+  cero paths fuera de scope y cero artefactos Playwright/Next.
+
+## Exclusiones, riesgos y rollback
+
+Schema, migraciones, DB real, frontend, Playwright, dependencias, CI,
+workflows, auth compartida, staging, producción, dev servers y watchers:
+`NOT_RUN`. `server/fastify-app.ts`: intacto. M41: `NOT_RUN`.
+
+Riesgo residual: equivalencia del wiring lazy y mantenimiento de los shims
+hasta M41. Los contratos application/infrastructure, integraciones HTTP y
+guards source-aware cubren el riesgo local; no se ejecuta DB real.
+
+Rollback: restaurar las ocho implementaciones en `server/db.ts`, devolver la
+resolución y coordinación a las dos rutas, retirar puerto/use cases/repository/
+composition M40 y revertir sólo guards, READMEs y documento M40. No requiere
+schema, migraciones ni compensación de datos.

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,7 +1,6 @@
-import { getReportStudyTypes as getCanonicalReportStudyTypes, REPORT_STUDY_TYPE_LABELS } from "./features/reports/domain/index.ts";
 import postgres from "postgres";
 import { drizzle } from "drizzle-orm/postgres-js";
-import { and, desc, eq, ilike, isNotNull, lt, lte, or, sql } from "drizzle-orm";
+import { eq, lt, lte, or, sql } from "drizzle-orm";
 import {
   activeSessions,
   adminSessions,
@@ -10,17 +9,22 @@ import {
   clinics,
   loginFailedAttempts,
   loginRateLimits,
-  reports,
-  reportStatusHistory,
   type ClinicUserRole,
   type LoginFailedAttemptReason,
   type LoginFailedAttemptSurface,
-  type ReportStatus,
 } from "../drizzle/schema.ts";
 import { ENV } from "./lib/env.ts";
 import { normalizeClinicUserRole } from "./lib/permissions.ts";
 export {
+  countReportsByClinicId,
+  countSearchReports,
+  getClinicScopedReportById,
+  getReportsByClinicId,
+  getReportStatusHistory,
   getReportById,
+  getReportStudyTypes,
+  getStudyTypes,
+  searchReports,
   upsertReport,
 } from "./features/reports/infrastructure/index.ts";
 export {
@@ -510,140 +514,3 @@ export async function deleteExpiredAdminSessions(): Promise<number> {
 
   return result.length;
 }
-
-/* ========================= REPORTS ========================= */
-
-export async function getClinicScopedReportById(id: number, clinicId: number) {
-  const result = await db
-    .select()
-    .from(reports)
-    .where(and(eq(reports.id, id), eq(reports.clinicId, clinicId)))
-    .limit(1);
-
-  return result[0];
-}
-
-export async function getReportStatusHistory(reportId: number) {
-  return db
-    .select()
-    .from(reportStatusHistory)
-    .where(eq(reportStatusHistory.reportId, reportId))
-    .orderBy(desc(reportStatusHistory.createdAt), desc(reportStatusHistory.id));
-}
-
-export async function getReportsByClinicId(
-  clinicId: number,
-  limit = 50,
-  offset = 0,
-  currentStatus?: ReportStatus,
-) {
-  const filters = [eq(reports.clinicId, clinicId)];
-
-  if (currentStatus) {
-    filters.push(eq(reports.currentStatus, currentStatus));
-  }
-
-  return db
-    .select()
-    .from(reports)
-    .where(and(...filters))
-    .orderBy(desc(reports.createdAt))
-    .limit(limit)
-    .offset(offset);
-}
-
-export async function searchReports(
-  clinicId: number,
-  query?: string,
-  studyType?: string,
-  limit = 50,
-  offset = 0,
-  currentStatus?: ReportStatus,
-) {
-  const filters = [eq(reports.clinicId, clinicId)];
-
-  if (studyType) {
-    filters.push(eq(reports.studyType, studyType));
-  }
-
-  if (currentStatus) {
-    filters.push(eq(reports.currentStatus, currentStatus));
-  }
-
-  if (query) {
-    filters.push(
-      or(
-        ilike(reports.patientName, "%" + query + "%"),
-        ilike(reports.fileName, "%" + query + "%"),
-        ilike(reports.studyType, "%" + query + "%"),
-      )!,
-    );
-  }
-
-  return db
-    .select()
-    .from(reports)
-    .where(and(...filters))
-    .orderBy(desc(reports.createdAt))
-    .limit(limit)
-    .offset(offset);
-}
-
-export async function countReportsByClinicId(
-  clinicId: number,
-  currentStatus?: ReportStatus,
-): Promise<number> {
-  const filters = [eq(reports.clinicId, clinicId)];
-
-  if (currentStatus) {
-    filters.push(eq(reports.currentStatus, currentStatus));
-  }
-
-  const result = await db
-    .select({ value: sql<string>`count(*)` })
-    .from(reports)
-    .where(and(...filters));
-
-  return Number(result[0]?.value ?? 0);
-}
-
-export async function countSearchReports(
-  clinicId: number,
-  query?: string,
-  studyType?: string,
-  currentStatus?: ReportStatus,
-): Promise<number> {
-  const filters = [eq(reports.clinicId, clinicId)];
-
-  if (studyType) {
-    filters.push(eq(reports.studyType, studyType));
-  }
-
-  if (currentStatus) {
-    filters.push(eq(reports.currentStatus, currentStatus));
-  }
-
-  if (query) {
-    filters.push(
-      or(
-        ilike(reports.patientName, "%" + query + "%"),
-        ilike(reports.fileName, "%" + query + "%"),
-        ilike(reports.studyType, "%" + query + "%"),
-      )!,
-    );
-  }
-
-  const result = await db
-    .select({ value: sql<string>`count(*)` })
-    .from(reports)
-    .where(and(...filters));
-
-  return Number(result[0]?.value ?? 0);
-}
-
-export async function getReportStudyTypes(_clinicId: number) {
-  void REPORT_STUDY_TYPE_LABELS;
-  return getCanonicalReportStudyTypes();
-}
-
-export const getStudyTypes = getReportStudyTypes;

--- a/server/features/reports/README.md
+++ b/server/features/reports/README.md
@@ -2,7 +2,8 @@
 
 M36 estableció la frontera de dominio, M37 desacopló la comunicación interna
 del workflow, M38 agregó los comandos de creación/edición y transición de
-estado, y M39 adelgaza las rutas administrativas de Reports.
+estado, M39 adelgazó las rutas administrativas y M40 materializa queries y
+adelgaza las rutas clínicas.
 
 ## Superficie disponible
 
@@ -11,11 +12,12 @@ estado, y M39 adelgaza las rutas administrativas de Reports.
 - `domain/report-study-types.ts` conserva el catálogo de tipos de estudio.
 - `domain/reports.ts` conserva parsing, scoping y serialización segura.
 - `application/index.ts` expone las operaciones inyectables, sus puertos y
-  `createReportRouteService`.
+  los casos de uso de commands, queries y rutas administrativas.
 - `infrastructure/index.ts` expone los adapters de workflow, el repository
-  canónico de comandos y el repository administrativo de workflow.
+  canónico de comandos, el repository de queries y el repository
+  administrativo de workflow.
 - `composition/index.ts` es el único bridge runtime para comunicación,
-  comandos y rutas administrativas.
+  comandos y rutas administrativas y clínicas.
 
 ## Dependencias entre capas
 
@@ -28,12 +30,11 @@ application → infrastructure y carga defaults concretos de forma lazy.
 
 `server/lib/report-workflow-communication.ts` y
 `server/db-report-workflow.ts` permanecen como shims temporales hasta M41.
-`server/db.ts` reexporta temporalmente `getReportById` y
-`upsertReport` desde infrastructure. `updateReportStatus` atraviesa composition
-y application, que agrega `expectedFromStatus`, antes del UPDATE compare-and-set
-de infrastructure. Las rutas administrativas conservan Options y contratos
-HTTP, pero delegan storage, persistencia, tracking, comunicación y auditoría a
-`report-route-service.ts`.
+`server/db.ts` reexporta temporalmente commands y las ocho queries M40 desde
+infrastructure. `updateReportStatus` atraviesa composition y application, que
+agrega `expectedFromStatus`, antes del UPDATE compare-and-set. Las rutas
+administrativas y clínicas conservan Options y contratos HTTP; las clínicas
+delegan listado, búsqueda, catálogo, ownership, historial, signed URLs y
+transición a `report-query-use-cases.ts`.
 
-M40 permanece pendiente para reads generales; M41 realizará el closeout y
-retiro final de compatibilidad.
+M41 realizará el closeout y retiro final de compatibilidad.

--- a/server/features/reports/application/README.md
+++ b/server/features/reports/application/README.md
@@ -11,6 +11,12 @@ los writes. Recibe el contexto de auditoría como valor opaco, modela errores
 esperables con resultados discriminados y sólo captura la notificación
 `report_delivered` best-effort.
 
+M40 agrega `createReportQueryUseCases`: coordina list+count y search+count,
+serializa mediante domain, modela ownership clinic-scoped con `not_found` y
+garantiza que history, preview, download y transición sólo ocurran después del
+lookup tenant-scoped. La transición reutiliza el resultado M38 y no captura
+errores de infraestructura.
+
 El puerto `report-command-repository.ts` contiene sólo `findReportById`,
 `createOrEditReport` y `persistReportStatusTransition`. La transición consume
 `canTransitionReportStatus` desde domain y construye `expectedFromStatus` desde
@@ -18,7 +24,9 @@ el informe leído; ese valor no forma parte del input público. No conoce
 Drizzle, schema, DB, Fastify, rutas ni adapters concretos y no captura errores
 de persistencia.
 
+El puerto `report-query-repository.ts` modela las queries reales con records
+estructurales propios de application; no importa schema, Drizzle ni adapters.
+
 `index.ts` es el entrypoint de la capa. La capa no importa Fastify, DB,
 Drizzle, schema runtime, storage o audit concretos, auth ni adapters. Parsing
-HTTP, serialización final, CORS, sesión y mapping de status codes permanecen en
-las rutas. Reads generales permanecen fuera de M39.
+HTTP, parsing, CORS, sesión y mapping de status codes permanecen en las rutas.

--- a/server/features/reports/application/index.ts
+++ b/server/features/reports/application/index.ts
@@ -1,4 +1,5 @@
 export * from "./ports/index.ts";
 export * from "./report-command-use-cases.ts";
+export * from "./report-query-use-cases.ts";
 export * from "./report-route-service.ts";
 export * from "./report-workflow-communication.ts";

--- a/server/features/reports/application/ports/index.ts
+++ b/server/features/reports/application/ports/index.ts
@@ -1,3 +1,4 @@
 export * from "./report-workflow-data-port.ts";
 export * from "./report-workflow-notification-port.ts";
 export * from "./report-command-repository.ts";
+export * from "./report-query-repository.ts";

--- a/server/features/reports/application/ports/report-query-repository.ts
+++ b/server/features/reports/application/ports/report-query-repository.ts
@@ -1,0 +1,57 @@
+export type ReportQueryStatus =
+  | "uploaded"
+  | "processing"
+  | "ready"
+  | "delivered";
+
+export type ReportQueryRecord = {
+  id: number;
+  clinicId: number;
+  clinicName?: string | null;
+  patientName: string | null;
+  studyType: string | null;
+  currentStatus: ReportQueryStatus;
+  uploadDate: Date | null;
+  fileName: string | null;
+  storagePath: string;
+  createdAt: Date;
+  updatedAt: Date;
+  statusChangedAt: Date;
+};
+
+export type ReportSearchFilters = {
+  query?: string;
+  studyType?: string;
+  currentStatus?: ReportQueryStatus;
+};
+
+export type ReportQueryRepository = {
+  findClinicScopedReportById: (
+    reportId: number,
+    clinicId: number,
+  ) => Promise<ReportQueryRecord | null | undefined>;
+  listReportsByClinicId: (
+    clinicId: number,
+    limit: number,
+    offset: number,
+    currentStatus?: ReportQueryStatus,
+  ) => Promise<ReportQueryRecord[]>;
+  countReportsByClinicId: (
+    clinicId: number,
+    currentStatus?: ReportQueryStatus,
+  ) => Promise<number>;
+  searchReports: (
+    clinicId: number,
+    filters: ReportSearchFilters,
+    limit: number,
+    offset: number,
+  ) => Promise<ReportQueryRecord[]>;
+  countSearchReports: (
+    clinicId: number,
+    filters: ReportSearchFilters,
+  ) => Promise<number>;
+  getReportStatusHistory: (
+    reportId: number,
+  ) => Promise<unknown[]>;
+  getStudyTypes: (clinicId: number) => Promise<string[]>;
+};

--- a/server/features/reports/application/report-query-use-cases.ts
+++ b/server/features/reports/application/report-query-use-cases.ts
@@ -1,0 +1,234 @@
+import { serializeSafeReport } from "../domain/index.ts";
+import type {
+  ReportQueryRecord,
+  ReportQueryRepository,
+  ReportSearchFilters,
+  ReportQueryStatus,
+} from "./ports/index.ts";
+import type {
+  TransitionReportStatusInput,
+  TransitionReportStatusResult,
+} from "./report-command-use-cases.ts";
+
+type ClinicScopedResult =
+  | { type: "not_found"; reportId: number }
+  | { type: "found"; report: ReportQueryRecord };
+
+type SignedPreviewResult =
+  | { type: "not_found"; reportId: number }
+  | { type: "found"; previewUrl: string };
+
+type SignedDownloadResult =
+  | { type: "not_found"; reportId: number }
+  | { type: "found"; downloadUrl: string };
+
+export function createReportQueryUseCases(dependencies: {
+  repository: ReportQueryRepository;
+  createSignedReportUrl: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+  transitionReportStatus: (
+    input: TransitionReportStatusInput,
+    clinicScopedReport: ReportQueryRecord,
+  ) => Promise<TransitionReportStatusResult<ReportQueryRecord>>;
+}) {
+  async function findClinicScopedReport(
+    reportId: number,
+    clinicId: number,
+  ): Promise<ClinicScopedResult> {
+    const report = await dependencies.repository.findClinicScopedReportById(
+      reportId,
+      clinicId,
+    );
+
+    return report
+      ? { type: "found", report }
+      : { type: "not_found", reportId };
+  }
+
+  async function listClinicReports(input: {
+    clinicId: number;
+    limit: number;
+    offset: number;
+    currentStatus?: ReportQueryStatus;
+  }) {
+    const [reports, total] = await Promise.all([
+      dependencies.repository.listReportsByClinicId(
+        input.clinicId,
+        input.limit,
+        input.offset,
+        input.currentStatus,
+      ),
+      dependencies.repository.countReportsByClinicId(
+        input.clinicId,
+        input.currentStatus,
+      ),
+    ]);
+
+    return {
+      count: reports.length,
+      total,
+      totalPages: input.limit > 0 ? Math.ceil(total / input.limit) : 0,
+      reports: reports.map((report) => serializeSafeReport(report)),
+      filters: {
+        status: input.currentStatus ?? null,
+      },
+      pagination: {
+        limit: input.limit,
+        offset: input.offset,
+      },
+    };
+  }
+
+  async function searchClinicReports(input: {
+    clinicId: number;
+    query?: string;
+    studyType?: string;
+    currentStatus?: ReportQueryStatus;
+    limit: number;
+    offset: number;
+  }) {
+    const filters: ReportSearchFilters = {
+      query: input.query,
+      studyType: input.studyType,
+      currentStatus: input.currentStatus,
+    };
+    const [reports, total] = await Promise.all([
+      dependencies.repository.searchReports(
+        input.clinicId,
+        filters,
+        input.limit,
+        input.offset,
+      ),
+      dependencies.repository.countSearchReports(input.clinicId, filters),
+    ]);
+
+    return {
+      count: reports.length,
+      total,
+      totalPages: input.limit > 0 ? Math.ceil(total / input.limit) : 0,
+      reports: reports.map((report) => serializeSafeReport(report)),
+      filters: {
+        query: input.query ?? null,
+        studyType: input.studyType ?? null,
+        status: input.currentStatus ?? null,
+      },
+      pagination: {
+        limit: input.limit,
+        offset: input.offset,
+      },
+    };
+  }
+
+  async function getClinicReportHistory(
+    reportId: number,
+    clinicId: number,
+  ) {
+    const scoped = await findClinicScopedReport(reportId, clinicId);
+
+    if (scoped.type === "not_found") {
+      return scoped;
+    }
+
+    const history =
+      await dependencies.repository.getReportStatusHistory(reportId);
+
+    return {
+      type: "found" as const,
+      reportId,
+      currentStatus: scoped.report.currentStatus,
+      count: history.length,
+      history,
+    };
+  }
+
+  async function getClinicReportPreview(
+    reportId: number,
+    clinicId: number,
+  ): Promise<SignedPreviewResult> {
+    const scoped = await findClinicScopedReport(reportId, clinicId);
+
+    if (scoped.type === "not_found") {
+      return scoped;
+    }
+
+    return {
+      type: "found",
+      previewUrl: await dependencies.createSignedReportUrl(
+        scoped.report.storagePath,
+      ),
+    };
+  }
+
+  async function getClinicReportDownload(
+    reportId: number,
+    clinicId: number,
+  ): Promise<SignedDownloadResult> {
+    const scoped = await findClinicScopedReport(reportId, clinicId);
+
+    if (scoped.type === "not_found") {
+      return scoped;
+    }
+
+    return {
+      type: "found",
+      downloadUrl: await dependencies.createSignedReportDownloadUrl(
+        scoped.report.storagePath,
+        scoped.report.fileName ?? undefined,
+      ),
+    };
+  }
+
+  async function transitionClinicReportStatus(input: {
+    clinicId: number;
+    reportId: number;
+    toStatus: ReportQueryStatus;
+    note: string | null;
+    changedByClinicUserId?: number | null;
+    changedByAdminUserId?: number | null;
+  }) {
+    const scoped = await findClinicScopedReport(
+      input.reportId,
+      input.clinicId,
+    );
+
+    if (scoped.type === "not_found") {
+      return scoped;
+    }
+
+    const result = await dependencies.transitionReportStatus(
+      {
+        reportId: input.reportId,
+        toStatus: input.toStatus,
+        note: input.note,
+        changedByClinicUserId: input.changedByClinicUserId,
+        changedByAdminUserId: input.changedByAdminUserId,
+      },
+      scoped.report,
+    );
+
+    return result.type === "persisted"
+      ? {
+          type: result.type,
+          report: serializeSafeReport(result.report),
+          previousStatus: scoped.report.currentStatus,
+        }
+      : {
+          ...result,
+          previousStatus: scoped.report.currentStatus,
+        };
+  }
+
+  return {
+    listClinicReports,
+    searchClinicReports,
+    getStudyTypes: dependencies.repository.getStudyTypes,
+    findClinicScopedReport,
+    getClinicReportHistory,
+    getClinicReportPreview,
+    getClinicReportDownload,
+    transitionClinicReportStatus,
+  };
+}

--- a/server/features/reports/composition/README.md
+++ b/server/features/reports/composition/README.md
@@ -16,5 +16,10 @@ Particular Token, Study Tracking, el comando M38 `createOrEditReport`, el read
 canónico `getReportById`, la comunicación M37 y el repository workflow M39.
 Una Options completamente inyectada evita cargar defaults.
 
+M40 agrega `report-query-composition.ts`, bridge lazy para ambas rutas
+clínicas. Adapta sus Options históricas a los puertos M40, conserva el fallback
+`getReportById` tenant-scoped y reutiliza `transitionReportStatus` M38. La
+inyección completa no carga DB, storage, audit ni auth concretos.
+
 La composición construye sus dependencias de forma lazy, no consulta DB durante
 el import, no mantiene estado mutable y no importa Fastify ni rutas.

--- a/server/features/reports/composition/index.ts
+++ b/server/features/reports/composition/index.ts
@@ -1,3 +1,4 @@
 export * from "./report-command-composition.ts";
+export * from "./report-query-composition.ts";
 export * from "./report-route-composition.ts";
 export * from "./report-workflow-communication-composition.ts";

--- a/server/features/reports/composition/report-query-composition.ts
+++ b/server/features/reports/composition/report-query-composition.ts
@@ -1,0 +1,432 @@
+import {
+  createReportCommandUseCases,
+  createReportQueryUseCases,
+  type ReportQueryRecord,
+  type ReportQueryStatus,
+  type TransitionReportStatusInput,
+  type TransitionReportStatusResult,
+} from "../application/index.ts";
+
+type ClinicUserRecord = {
+  id: number;
+  clinicId: number;
+  username: string;
+  authProId?: string | null;
+  role: unknown;
+};
+
+type ActiveSessionRecord = {
+  clinicUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type AuditWriteInput = {
+  event: string;
+  clinicId?: number | null;
+  reportId?: number | null;
+  metadata?: Record<string, unknown>;
+  actor?: {
+    type: string;
+    clinicUserId?: number | null;
+  };
+};
+
+type SharedClinicRouteOptions = {
+  deleteActiveSession?: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken?: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById?: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getReportById?: (reportId: number) => Promise<ReportQueryRecord | null>;
+  getClinicScopedReportById?: (
+    reportId: number,
+    clinicId: number,
+  ) => Promise<ReportQueryRecord | null | undefined>;
+};
+
+export type ClinicReportsRouteCompositionOptions = SharedClinicRouteOptions & {
+  getReportsByClinicId?: (
+    clinicId: number,
+    limit: number,
+    offset: number,
+    currentStatus?: ReportQueryStatus,
+  ) => Promise<ReportQueryRecord[]>;
+  countReportsByClinicId?: (
+    clinicId: number,
+    currentStatus?: ReportQueryStatus,
+  ) => Promise<number>;
+  searchReports?: (
+    clinicId: number,
+    query: string | undefined,
+    studyType: string | undefined,
+    limit: number,
+    offset: number,
+    currentStatus?: ReportQueryStatus,
+  ) => Promise<ReportQueryRecord[]>;
+  countSearchReports?: (
+    clinicId: number,
+    query: string | undefined,
+    studyType: string | undefined,
+    currentStatus?: ReportQueryStatus,
+  ) => Promise<number>;
+  getStudyTypes?: (clinicId: number) => Promise<string[]>;
+  getReportStatusHistory?: (
+    reportId: number,
+  ) => Promise<unknown[]>;
+  createSignedReportUrl?: (storagePath: string) => Promise<string>;
+  createSignedReportDownloadUrl?: (
+    storagePath: string,
+    fileName?: string,
+  ) => Promise<string>;
+};
+
+export type ClinicReportStatusRouteCompositionOptions =
+  SharedClinicRouteOptions & {
+    updateReportStatus?: (input: {
+      reportId: number;
+      toStatus: ReportQueryStatus;
+      note: string | null;
+      changedByClinicUserId?: number | null;
+      changedByAdminUserId?: number | null;
+    }) => Promise<ReportQueryRecord | null | undefined>;
+    writeAuditLog?: (
+      req: unknown,
+      input: AuditWriteInput,
+    ) => Promise<void>;
+  };
+
+type AuthDependencies = {
+  deleteActiveSession: (tokenHash: string) => Promise<void>;
+  getActiveSessionByToken: (
+    tokenHash: string,
+  ) => Promise<ActiveSessionRecord | null>;
+  getClinicUserById: (
+    clinicUserId: number,
+  ) => Promise<ClinicUserRecord | null>;
+  updateSessionLastAccess: (tokenHash: string) => Promise<void>;
+  hashSessionToken: (token: string) => string;
+};
+
+type ReportsDependencies = AuthDependencies & {
+  getReportsByClinicId: NonNullable<
+    ClinicReportsRouteCompositionOptions["getReportsByClinicId"]
+  >;
+  countReportsByClinicId: NonNullable<
+    ClinicReportsRouteCompositionOptions["countReportsByClinicId"]
+  >;
+  searchReports: NonNullable<
+    ClinicReportsRouteCompositionOptions["searchReports"]
+  >;
+  countSearchReports: NonNullable<
+    ClinicReportsRouteCompositionOptions["countSearchReports"]
+  >;
+  getStudyTypes: NonNullable<
+    ClinicReportsRouteCompositionOptions["getStudyTypes"]
+  >;
+  getClinicScopedReportById: NonNullable<
+    SharedClinicRouteOptions["getClinicScopedReportById"]
+  >;
+  getReportStatusHistory: (
+    reportId: number,
+  ) => Promise<unknown[]>;
+  createSignedReportUrl: NonNullable<
+    ClinicReportsRouteCompositionOptions["createSignedReportUrl"]
+  >;
+  createSignedReportDownloadUrl: NonNullable<
+    ClinicReportsRouteCompositionOptions["createSignedReportDownloadUrl"]
+  >;
+};
+
+type StatusDependencies = AuthDependencies & {
+  getClinicScopedReportById: NonNullable<
+    SharedClinicRouteOptions["getClinicScopedReportById"]
+  >;
+  transitionReportStatus: (
+    input: TransitionReportStatusInput,
+    clinicScopedReport: ReportQueryRecord,
+  ) => Promise<TransitionReportStatusResult<ReportQueryRecord>>;
+  writeAuditLog: NonNullable<
+    ClinicReportStatusRouteCompositionOptions["writeAuditLog"]
+  >;
+};
+
+let defaultReportsDependenciesPromise: Promise<ReportsDependencies> | undefined;
+let defaultStatusDependenciesPromise: Promise<StatusDependencies> | undefined;
+
+function getInjectedClinicScopedLookup(options: SharedClinicRouteOptions) {
+  if (options.getClinicScopedReportById) {
+    return options.getClinicScopedReportById;
+  }
+
+  if (options.getReportById) {
+    return async (reportId: number, clinicId: number) => {
+      const report = await options.getReportById!(reportId);
+      return report?.clinicId === clinicId ? report : null;
+    };
+  }
+
+  return undefined;
+}
+
+function hasAllReportsDependencies(
+  options: ClinicReportsRouteCompositionOptions,
+) {
+  return (
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!options.getReportsByClinicId &&
+    !!options.countReportsByClinicId &&
+    !!options.searchReports &&
+    !!options.countSearchReports &&
+    !!options.getStudyTypes &&
+    !!getInjectedClinicScopedLookup(options) &&
+    !!options.getReportStatusHistory &&
+    !!options.createSignedReportUrl &&
+    !!options.createSignedReportDownloadUrl
+  );
+}
+
+function hasAllStatusDependencies(
+  options: ClinicReportStatusRouteCompositionOptions,
+) {
+  return (
+    !!options.deleteActiveSession &&
+    !!options.getActiveSessionByToken &&
+    !!options.getClinicUserById &&
+    !!options.updateSessionLastAccess &&
+    !!options.hashSessionToken &&
+    !!getInjectedClinicScopedLookup(options) &&
+    !!options.updateReportStatus &&
+    !!options.writeAuditLog
+  );
+}
+
+async function loadDefaultReportsDependencies(): Promise<ReportsDependencies> {
+  if (!defaultReportsDependenciesPromise) {
+    defaultReportsDependenciesPromise = (async () => {
+      const [db, authSecurity, storage, queries] = await Promise.all([
+        import("../../../db.ts"),
+        import("../../../lib/auth-security.ts"),
+        import("../../../lib/supabase.ts"),
+        import("../infrastructure/report-query-repository.ts"),
+      ]);
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getReportsByClinicId: queries.getReportsByClinicId,
+        countReportsByClinicId: queries.countReportsByClinicId,
+        searchReports: queries.searchReports,
+        countSearchReports: queries.countSearchReports,
+        getStudyTypes: queries.getStudyTypes,
+        getClinicScopedReportById: queries.getClinicScopedReportById,
+        getReportStatusHistory: queries.getReportStatusHistory,
+        createSignedReportUrl: storage.createSignedReportUrl,
+        createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
+      };
+    })();
+  }
+
+  return defaultReportsDependenciesPromise;
+}
+
+async function loadDefaultStatusDependencies(): Promise<StatusDependencies> {
+  if (!defaultStatusDependenciesPromise) {
+    defaultStatusDependenciesPromise = (async () => {
+      const [db, authSecurity, audit, queries, commands] = await Promise.all([
+        import("../../../db.ts"),
+        import("../../../lib/auth-security.ts"),
+        import("../../../lib/audit.ts"),
+        import("../infrastructure/report-query-repository.ts"),
+        import("./report-command-composition.ts"),
+      ]);
+
+      return {
+        deleteActiveSession: db.deleteActiveSession,
+        getActiveSessionByToken: db.getActiveSessionByToken,
+        getClinicUserById: db.getClinicUserById,
+        updateSessionLastAccess: db.updateSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getClinicScopedReportById: queries.getClinicScopedReportById,
+        transitionReportStatus: (input) =>
+          commands.transitionReportStatus(input) as Promise<
+            TransitionReportStatusResult<ReportQueryRecord>
+          >,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultStatusDependenciesPromise;
+}
+
+function resolveAuthDependencies(
+  options: SharedClinicRouteOptions,
+  defaults: AuthDependencies,
+): AuthDependencies {
+  return {
+    deleteActiveSession:
+      options.deleteActiveSession ?? defaults.deleteActiveSession,
+    getActiveSessionByToken:
+      options.getActiveSessionByToken ?? defaults.getActiveSessionByToken,
+    getClinicUserById:
+      options.getClinicUserById ?? defaults.getClinicUserById,
+    updateSessionLastAccess:
+      options.updateSessionLastAccess ?? defaults.updateSessionLastAccess,
+    hashSessionToken: options.hashSessionToken ?? defaults.hashSessionToken,
+  };
+}
+
+export async function createClinicReportsRouteComposition(
+  options: ClinicReportsRouteCompositionOptions,
+) {
+  const defaults = hasAllReportsDependencies(options)
+    ? undefined
+    : await loadDefaultReportsDependencies();
+  const injectedLookup = getInjectedClinicScopedLookup(options);
+  const dependencies: ReportsDependencies = {
+    ...resolveAuthDependencies(options, defaults ?? (options as ReportsDependencies)),
+    getReportsByClinicId:
+      options.getReportsByClinicId ?? defaults!.getReportsByClinicId,
+    countReportsByClinicId:
+      options.countReportsByClinicId ?? defaults!.countReportsByClinicId,
+    searchReports: options.searchReports ?? defaults!.searchReports,
+    countSearchReports:
+      options.countSearchReports ?? defaults!.countSearchReports,
+    getStudyTypes: options.getStudyTypes ?? defaults!.getStudyTypes,
+    getClinicScopedReportById:
+      injectedLookup ?? defaults!.getClinicScopedReportById,
+    getReportStatusHistory:
+      (options.getReportStatusHistory ??
+        defaults!.getReportStatusHistory) as (
+        reportId: number,
+      ) => Promise<unknown[]>,
+    createSignedReportUrl:
+      options.createSignedReportUrl ?? defaults!.createSignedReportUrl,
+    createSignedReportDownloadUrl:
+      options.createSignedReportDownloadUrl ??
+      defaults!.createSignedReportDownloadUrl,
+  };
+  const repository = {
+    findClinicScopedReportById: dependencies.getClinicScopedReportById,
+    listReportsByClinicId: dependencies.getReportsByClinicId,
+    countReportsByClinicId: dependencies.countReportsByClinicId,
+    searchReports: (
+      clinicId: number,
+      filters: {
+        query?: string;
+        studyType?: string;
+        currentStatus?: ReportQueryStatus;
+      },
+      limit: number,
+      offset: number,
+    ) =>
+      dependencies.searchReports(
+        clinicId,
+        filters.query,
+        filters.studyType,
+        limit,
+        offset,
+        filters.currentStatus,
+      ),
+    countSearchReports: (
+      clinicId: number,
+      filters: {
+        query?: string;
+        studyType?: string;
+        currentStatus?: ReportQueryStatus;
+      },
+    ) =>
+      dependencies.countSearchReports(
+        clinicId,
+        filters.query,
+        filters.studyType,
+        filters.currentStatus,
+      ),
+    getReportStatusHistory: dependencies.getReportStatusHistory,
+    getStudyTypes: dependencies.getStudyTypes,
+  };
+
+  return {
+    auth: resolveAuthDependencies(options, dependencies),
+    queries: createReportQueryUseCases({
+      repository,
+      createSignedReportUrl: dependencies.createSignedReportUrl,
+      createSignedReportDownloadUrl:
+        dependencies.createSignedReportDownloadUrl,
+      transitionReportStatus: async () => {
+        throw new Error("report status transition unavailable");
+      },
+    }),
+  };
+}
+
+export async function createClinicReportStatusRouteComposition(
+  options: ClinicReportStatusRouteCompositionOptions,
+) {
+  const defaults = hasAllStatusDependencies(options)
+    ? undefined
+    : await loadDefaultStatusDependencies();
+  const lookup =
+    getInjectedClinicScopedLookup(options) ??
+    defaults!.getClinicScopedReportById;
+  const transitionReportStatus = options.updateReportStatus
+    ? async (
+        input: TransitionReportStatusInput,
+        clinicScopedReport: ReportQueryRecord,
+      ) =>
+        createReportCommandUseCases<ReportQueryRecord>({
+          findReportById: async () => clinicScopedReport,
+          createOrEditReport: async () => {
+            throw new Error("report create unavailable");
+          },
+          persistReportStatusTransition: (command) =>
+            options.updateReportStatus!({
+              reportId: command.reportId,
+              toStatus: command.toStatus,
+              note: command.note ?? null,
+              changedByClinicUserId:
+                command.changedByClinicUserId ?? null,
+              changedByAdminUserId:
+                command.changedByAdminUserId ?? null,
+            }),
+        }).transitionReportStatus(input)
+    : defaults!.transitionReportStatus;
+  const authDefaults = defaults ?? (options as StatusDependencies);
+  const auth = resolveAuthDependencies(options, authDefaults);
+  const writeAuditLog = options.writeAuditLog ?? defaults!.writeAuditLog;
+  const unavailableRepository = {
+    findClinicScopedReportById: lookup,
+    listReportsByClinicId: async () => [],
+    countReportsByClinicId: async () => 0,
+    searchReports: async () => [],
+    countSearchReports: async () => 0,
+    getReportStatusHistory: async () => [],
+    getStudyTypes: async () => [],
+  };
+
+  return {
+    auth,
+    writeAuditLog,
+    queries: createReportQueryUseCases({
+      repository: unavailableRepository,
+      createSignedReportUrl: async () => "",
+      createSignedReportDownloadUrl: async () => "",
+      transitionReportStatus,
+    }),
+  };
+}

--- a/server/features/reports/domain/reports.ts
+++ b/server/features/reports/domain/reports.ts
@@ -1,7 +1,20 @@
 import type { Report, ReportStatus } from "../../../../drizzle/schema.ts";
 import { normalizeReportStatus } from "./report-status.ts";
 
-type ReportWithDisplayFields = Report & {
+type ReportWithDisplayFields = Pick<
+  Report,
+  | "id"
+  | "clinicId"
+  | "patientName"
+  | "studyType"
+  | "currentStatus"
+  | "uploadDate"
+  | "fileName"
+  | "storagePath"
+  | "createdAt"
+  | "updatedAt"
+  | "statusChangedAt"
+> & {
   clinicName?: string | null;
 };
 

--- a/server/features/reports/infrastructure/README.md
+++ b/server/features/reports/infrastructure/README.md
@@ -18,7 +18,12 @@ paginación 20/21, orden, updates y reload. La factory
 cada mutación ejecuta update → reload → comunicación best-effort → return sin
 consultar Study Tracking directamente.
 
+M40 agrega `report-query-repository.ts`, owner único de lookup clinic-scoped,
+historial, listado, búsqueda, counts y catálogo. Conserva filtros tenant,
+orden, paginación, `ilike`, `count(*)` y conversión numérica legacy. El
+catálogo delega al domain canónico y no consulta DB.
+
 Esta capa es la única superficie de Reports que importa DB, Drizzle, schema y
-tablas para comandos y workflow. No importa composition ni contiene auditoría,
-auth, storage o transporte HTTP. `server/db.ts` y
+tablas para comandos, queries y workflow. No importa composition ni contiene
+auditoría, auth, storage o transporte HTTP. `server/db.ts` y
 `server/db-report-workflow.ts` sólo preservan compatibilidad temporal.

--- a/server/features/reports/infrastructure/index.ts
+++ b/server/features/reports/infrastructure/index.ts
@@ -1,4 +1,5 @@
 export * from "./db-report-workflow.ts";
 export * from "./report-command-repository.ts";
+export * from "./report-query-repository.ts";
 export * from "./report-workflow-data-adapter.ts";
 export * from "./report-workflow-notification-adapter.ts";

--- a/server/features/reports/infrastructure/report-query-repository.ts
+++ b/server/features/reports/infrastructure/report-query-repository.ts
@@ -1,0 +1,239 @@
+import { and, desc, eq, ilike, or, sql } from "drizzle-orm";
+
+import { db } from "../../../db.ts";
+import {
+  reports,
+  reportStatusHistory,
+  type ReportStatus,
+} from "../../../../drizzle/schema.ts";
+import { getReportStudyTypes as getCanonicalReportStudyTypes } from "../domain/index.ts";
+
+type ReportQueryDatabase = typeof db;
+
+function buildSearchFilters(
+  clinicId: number,
+  query?: string,
+  studyType?: string,
+  currentStatus?: ReportStatus,
+) {
+  const filters = [eq(reports.clinicId, clinicId)];
+
+  if (studyType) {
+    filters.push(eq(reports.studyType, studyType));
+  }
+
+  if (currentStatus) {
+    filters.push(eq(reports.currentStatus, currentStatus));
+  }
+
+  if (query) {
+    filters.push(
+      or(
+        ilike(reports.patientName, "%" + query + "%"),
+        ilike(reports.fileName, "%" + query + "%"),
+        ilike(reports.studyType, "%" + query + "%"),
+      )!,
+    );
+  }
+
+  return filters;
+}
+
+export function createReportQueryRepository(dependencies?: {
+  database?: ReportQueryDatabase;
+}) {
+  const database = dependencies?.database ?? db;
+
+  return {
+    async findClinicScopedReportById(reportId: number, clinicId: number) {
+      const result = await database
+        .select()
+        .from(reports)
+        .where(
+          and(
+            eq(reports.id, reportId),
+            eq(reports.clinicId, clinicId),
+          ),
+        )
+        .limit(1);
+
+      return result[0];
+    },
+
+    listReportsByClinicId(
+      clinicId: number,
+      limit = 50,
+      offset = 0,
+      currentStatus?: ReportStatus,
+    ) {
+      const filters = [eq(reports.clinicId, clinicId)];
+
+      if (currentStatus) {
+        filters.push(eq(reports.currentStatus, currentStatus));
+      }
+
+      return database
+        .select()
+        .from(reports)
+        .where(and(...filters))
+        .orderBy(desc(reports.createdAt))
+        .limit(limit)
+        .offset(offset);
+    },
+
+    searchReports(
+      clinicId: number,
+      filters: {
+        query?: string;
+        studyType?: string;
+        currentStatus?: ReportStatus;
+      },
+      limit = 50,
+      offset = 0,
+    ) {
+      return database
+        .select()
+        .from(reports)
+        .where(
+          and(
+            ...buildSearchFilters(
+              clinicId,
+              filters.query,
+              filters.studyType,
+              filters.currentStatus,
+            ),
+          ),
+        )
+        .orderBy(desc(reports.createdAt))
+        .limit(limit)
+        .offset(offset);
+    },
+
+    async countReportsByClinicId(
+      clinicId: number,
+      currentStatus?: ReportStatus,
+    ): Promise<number> {
+      const filters = [eq(reports.clinicId, clinicId)];
+
+      if (currentStatus) {
+        filters.push(eq(reports.currentStatus, currentStatus));
+      }
+
+      const result = await database
+        .select({ value: sql<string>`count(*)` })
+        .from(reports)
+        .where(and(...filters));
+
+      return Number(result[0]?.value ?? 0);
+    },
+
+    async countSearchReports(
+      clinicId: number,
+      filters: {
+        query?: string;
+        studyType?: string;
+        currentStatus?: ReportStatus;
+      },
+    ): Promise<number> {
+      const result = await database
+        .select({ value: sql<string>`count(*)` })
+        .from(reports)
+        .where(
+          and(
+            ...buildSearchFilters(
+              clinicId,
+              filters.query,
+              filters.studyType,
+              filters.currentStatus,
+            ),
+          ),
+        );
+
+      return Number(result[0]?.value ?? 0);
+    },
+
+    getReportStatusHistory(reportId: number) {
+      return database
+        .select()
+        .from(reportStatusHistory)
+        .where(eq(reportStatusHistory.reportId, reportId))
+        .orderBy(
+          desc(reportStatusHistory.createdAt),
+          desc(reportStatusHistory.id),
+        );
+    },
+
+    async getStudyTypes(_clinicId: number) {
+      return getCanonicalReportStudyTypes();
+    },
+  };
+}
+
+const runtimeRepository = () => createReportQueryRepository();
+
+export function getClinicScopedReportById(
+  reportId: number,
+  clinicId: number,
+) {
+  return runtimeRepository().findClinicScopedReportById(reportId, clinicId);
+}
+
+export function getReportsByClinicId(
+  clinicId: number,
+  limit = 50,
+  offset = 0,
+  currentStatus?: ReportStatus,
+) {
+  return runtimeRepository().listReportsByClinicId(
+    clinicId,
+    limit,
+    offset,
+    currentStatus,
+  );
+}
+
+export function searchReports(
+  clinicId: number,
+  query?: string,
+  studyType?: string,
+  limit = 50,
+  offset = 0,
+  currentStatus?: ReportStatus,
+) {
+  return runtimeRepository().searchReports(
+    clinicId,
+    { query, studyType, currentStatus },
+    limit,
+    offset,
+  );
+}
+
+export function countReportsByClinicId(
+  clinicId: number,
+  currentStatus?: ReportStatus,
+) {
+  return runtimeRepository().countReportsByClinicId(clinicId, currentStatus);
+}
+
+export function countSearchReports(
+  clinicId: number,
+  query?: string,
+  studyType?: string,
+  currentStatus?: ReportStatus,
+) {
+  return runtimeRepository().countSearchReports(clinicId, {
+    query,
+    studyType,
+    currentStatus,
+  });
+}
+
+export function getReportStatusHistory(reportId: number) {
+  return runtimeRepository().getReportStatusHistory(reportId);
+}
+
+export function getReportStudyTypes(clinicId: number) {
+  return runtimeRepository().getStudyTypes(clinicId);
+}
+
+export const getStudyTypes = getReportStudyTypes;

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -15,12 +15,11 @@ import {
 } from "../lib/cors-headers.ts";
 import {
   REPORT_STATUSES,
-  canTransitionReportStatus,
   normalizeOptionalNote,
   parseReportId,
   parseReportStatus,
-  serializeSafeReport,
 } from "../features/reports/domain/index.ts";
+import { createClinicReportStatusRouteComposition } from "../features/reports/composition/index.ts";
 import {
   getClinicPermissions,
   normalizeClinicUserRole,
@@ -117,94 +116,8 @@ type NativeReportsStatusDeps = Required<
     | "getClinicUserById"
     | "updateSessionLastAccess"
     | "hashSessionToken"
-    | "getClinicScopedReportById"
-    | "updateReportStatus"
-    | "createSignedReportUrl"
-    | "createSignedReportDownloadUrl"
-    | "writeAuditLog"
   >
 >;
-
-let defaultDepsPromise: Promise<NativeReportsStatusDeps> | undefined;
-
-async function loadDefaultDeps(): Promise<NativeReportsStatusDeps> {
-  if (!defaultDepsPromise) {
-    defaultDepsPromise = (async () => {
-      const db = await import("../db.ts");
-      const authSecurity = await import("../lib/auth-security.ts");
-      const storage = await import("../lib/supabase.ts");
-      const audit = await import("../lib/audit.ts");
-
-      return {
-        deleteActiveSession: db.deleteActiveSession,
-        getActiveSessionByToken: db.getActiveSessionByToken,
-        getClinicUserById: db.getClinicUserById,
-        updateSessionLastAccess: db.updateSessionLastAccess,
-        hashSessionToken: authSecurity.hashSessionToken,
-        getClinicScopedReportById: db.getClinicScopedReportById,
-        updateReportStatus: db.updateReportStatus,
-        createSignedReportUrl: storage.createSignedReportUrl,
-        createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
-        writeAuditLog: audit.writeAuditLog as (
-          req: unknown,
-          input: AuditWriteInput,
-        ) => Promise<void>,
-      };
-    })();
-  }
-
-  return defaultDepsPromise!;
-}
-
-function hasAllInjectedDeps(options: ReportsStatusNativeRoutesOptions) {
-  return (
-    !!options.deleteActiveSession &&
-    !!options.getActiveSessionByToken &&
-    !!options.getClinicUserById &&
-    !!options.updateSessionLastAccess &&
-    !!options.hashSessionToken &&
-    (!!options.getClinicScopedReportById || !!options.getReportById) &&
-    !!options.updateReportStatus &&
-    !!options.createSignedReportUrl &&
-    !!options.createSignedReportDownloadUrl &&
-    !!options.writeAuditLog
-  );
-}
-
-async function resolveDeps(
-  options: ReportsStatusNativeRoutesOptions,
-): Promise<NativeReportsStatusDeps> {
-  const defaultDeps = hasAllInjectedDeps(options) ? undefined : await loadDefaultDeps();
-
-  return {
-    deleteActiveSession:
-      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
-    getActiveSessionByToken:
-      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
-    getClinicUserById:
-      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
-    updateSessionLastAccess:
-      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
-    hashSessionToken:
-      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
-    getClinicScopedReportById:
-      options.getClinicScopedReportById ??
-      (options.getReportById
-        ? async (reportId: number, clinicId: number) => {
-            const report = await options.getReportById!(reportId);
-            return report?.clinicId === clinicId ? report : null;
-          }
-        : defaultDeps!.getClinicScopedReportById),
-    updateReportStatus:
-      options.updateReportStatus ?? defaultDeps!.updateReportStatus,
-    createSignedReportUrl:
-      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
-    createSignedReportDownloadUrl:
-      options.createSignedReportDownloadUrl ??
-      defaultDeps!.createSignedReportDownloadUrl,
-    writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
-  };
-}
 
 function applyCorsHeaders(
   request: FastifyRequest,
@@ -416,29 +329,6 @@ function requireReportStatusWritePermission(
   return false;
 }
 
-async function getAuthorizedReport(
-  reportId: number,
-  clinicId: number,
-  deps: NativeReportsStatusDeps,
-): Promise<{ report: Report } | { status: 404; error: string }> {
-  const report = await deps.getClinicScopedReportById(reportId, clinicId);
-
-  if (!report) {
-    return {
-      status: 404,
-      error: "Informe no encontrado",
-    };
-  }
-
-  return {
-    report,
-  };
-}
-
-function serializeReport(report: Report, _deps: NativeReportsStatusDeps) {
-  return serializeSafeReport(report);
-}
-
 export const reportsStatusNativeRoutes: FastifyPluginAsync<
   ReportsStatusNativeRoutesOptions
 > = async (app, options) => {
@@ -513,8 +403,14 @@ export const reportsStatusNativeRoutes: FastifyPluginAsync<
       return reply;
     }
 
-    const deps = await resolveDeps(options);
-    const auth = await authenticateClinicUser(request, reply, deps, now);
+    const composition =
+      await createClinicReportStatusRouteComposition(options);
+    const auth = await authenticateClinicUser(
+      request,
+      reply,
+      composition.auth,
+      now,
+    );
 
     if (!auth) {
       return reply;
@@ -543,37 +439,8 @@ export const reportsStatusNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const reportResult = await getAuthorizedReport(
-      reportId,
-      auth.clinicId,
-      deps,
-    );
-
-    if (!("report" in reportResult)) {
-      return reply.code(reportResult.status).send({
-        success: false,
-        error: reportResult.error,
-      });
-    }
-
-    if (reportResult.report.currentStatus === nextStatus) {
-      return reply.code(400).send({
-        success: false,
-        error: "El informe ya se encuentra en ese estado",
-      });
-    }
-
-    if (!canTransitionReportStatus(reportResult.report.currentStatus, nextStatus)) {
-      return reply.code(400).send({
-        success: false,
-        error: "La transición de estado no está permitida",
-        currentStatus: reportResult.report.currentStatus,
-        requestedStatus: nextStatus,
-        allowedStatuses: REPORT_STATUSES,
-      });
-    }
-
-    const updated = await deps.updateReportStatus({
+    const result = await composition.queries.transitionClinicReportStatus({
+      clinicId: auth.clinicId,
       reportId,
       toStatus: nextStatus,
       note,
@@ -581,19 +448,36 @@ export const reportsStatusNativeRoutes: FastifyPluginAsync<
       changedByAdminUserId: null,
     });
 
-    if (!updated) {
+    if (result.type === "not_found" || result.type === "concurrent_not_found") {
       return reply.code(404).send({
         success: false,
         error: "Informe no encontrado",
       });
     }
 
-    await deps.writeAuditLog(createAuditRequestLike(request, auth), {
+    if (result.type === "same_status") {
+      return reply.code(400).send({
+        success: false,
+        error: "El informe ya se encuentra en ese estado",
+      });
+    }
+
+    if (result.type === "transition_not_allowed") {
+      return reply.code(400).send({
+        success: false,
+        error: "La transición de estado no está permitida",
+        currentStatus: result.currentStatus,
+        requestedStatus: result.requestedStatus,
+        allowedStatuses: REPORT_STATUSES,
+      });
+    }
+
+    await composition.writeAuditLog(createAuditRequestLike(request, auth), {
       event: AUDIT_EVENTS.REPORT_STATUS_CHANGED,
-      clinicId: updated.clinicId,
-      reportId: updated.id,
+      clinicId: result.report.clinicId,
+      reportId: result.report.id,
       metadata: {
-        fromStatus: reportResult.report.currentStatus,
+        fromStatus: result.previousStatus,
         toStatus: nextStatus,
         note,
       },
@@ -602,7 +486,7 @@ export const reportsStatusNativeRoutes: FastifyPluginAsync<
     return reply.code(200).send({
       success: true,
       message: "Estado de informe actualizado correctamente",
-      report: await serializeReport(updated, deps),
+      report: result.report,
     });
   });
 };

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -20,8 +20,8 @@ import {
   parseReportId,
   parseReportStatus,
   parseReportStudyType,
-  serializeSafeReport,
 } from "../features/reports/domain/index.ts";
+import { createClinicReportsRouteComposition } from "../features/reports/composition/index.ts";
 import { normalizeClinicUserRole } from "../lib/permissions.ts";
 import {
   buildRequestLogLine,
@@ -119,109 +119,8 @@ type NativeReportsDeps = Required<
     | "getClinicUserById"
     | "updateSessionLastAccess"
     | "hashSessionToken"
-    | "getReportsByClinicId"
-    | "countReportsByClinicId"
-    | "searchReports"
-    | "countSearchReports"
-    | "getStudyTypes"
-    | "getClinicScopedReportById"
-    | "getReportStatusHistory"
-    | "createSignedReportUrl"
-    | "createSignedReportDownloadUrl"
   >
 >;
-
-let defaultDepsPromise: Promise<NativeReportsDeps> | undefined;
-
-async function loadDefaultDeps(): Promise<NativeReportsDeps> {
-  if (!defaultDepsPromise) {
-    defaultDepsPromise = (async () => {
-      const db = await import("../db.ts");
-      const authSecurity = await import("../lib/auth-security.ts");
-      const storage = await import("../lib/supabase.ts");
-
-      return {
-        deleteActiveSession: db.deleteActiveSession,
-        getActiveSessionByToken: db.getActiveSessionByToken,
-        getClinicUserById: db.getClinicUserById,
-        updateSessionLastAccess: db.updateSessionLastAccess,
-        hashSessionToken: authSecurity.hashSessionToken,
-        getReportsByClinicId: db.getReportsByClinicId,
-        countReportsByClinicId: db.countReportsByClinicId,
-        searchReports: db.searchReports,
-        countSearchReports: db.countSearchReports,
-        getStudyTypes: db.getStudyTypes,
-        getClinicScopedReportById: db.getClinicScopedReportById,
-        getReportStatusHistory: db.getReportStatusHistory,
-        createSignedReportUrl: storage.createSignedReportUrl,
-        createSignedReportDownloadUrl: storage.createSignedReportDownloadUrl,
-      };
-    })();
-  }
-
-  return defaultDepsPromise;
-}
-
-function hasAllInjectedDeps(options: ReportsNativeRoutesOptions) {
-  return (
-    !!options.deleteActiveSession &&
-    !!options.getActiveSessionByToken &&
-    !!options.getClinicUserById &&
-    !!options.updateSessionLastAccess &&
-    !!options.hashSessionToken &&
-    !!options.getReportsByClinicId &&
-    !!options.countReportsByClinicId &&
-    !!options.searchReports &&
-    !!options.countSearchReports &&
-    !!options.getStudyTypes &&
-    (!!options.getClinicScopedReportById || !!options.getReportById) &&
-    !!options.getReportStatusHistory &&
-    !!options.createSignedReportUrl &&
-    !!options.createSignedReportDownloadUrl
-  );
-}
-
-async function resolveDeps(
-  options: ReportsNativeRoutesOptions,
-): Promise<NativeReportsDeps> {
-  const defaultDeps = hasAllInjectedDeps(options) ? undefined : await loadDefaultDeps();
-
-  return {
-    deleteActiveSession:
-      options.deleteActiveSession ?? defaultDeps!.deleteActiveSession,
-    getActiveSessionByToken:
-      options.getActiveSessionByToken ?? defaultDeps!.getActiveSessionByToken,
-    getClinicUserById:
-      options.getClinicUserById ?? defaultDeps!.getClinicUserById,
-    updateSessionLastAccess:
-      options.updateSessionLastAccess ?? defaultDeps!.updateSessionLastAccess,
-    hashSessionToken:
-      options.hashSessionToken ?? defaultDeps!.hashSessionToken,
-    getReportsByClinicId:
-      options.getReportsByClinicId ?? defaultDeps!.getReportsByClinicId,
-    countReportsByClinicId:
-      options.countReportsByClinicId ?? defaultDeps!.countReportsByClinicId,
-    searchReports: options.searchReports ?? defaultDeps!.searchReports,
-    countSearchReports:
-      options.countSearchReports ?? defaultDeps!.countSearchReports,
-    getStudyTypes: options.getStudyTypes ?? defaultDeps!.getStudyTypes,
-    getClinicScopedReportById:
-      options.getClinicScopedReportById ??
-      (options.getReportById
-        ? async (reportId: number, clinicId: number) => {
-            const report = await options.getReportById!(reportId);
-            return report?.clinicId === clinicId ? report : null;
-          }
-        : defaultDeps!.getClinicScopedReportById),
-    getReportStatusHistory:
-      options.getReportStatusHistory ?? defaultDeps!.getReportStatusHistory,
-    createSignedReportUrl:
-      options.createSignedReportUrl ?? defaultDeps!.createSignedReportUrl,
-    createSignedReportDownloadUrl:
-      options.createSignedReportDownloadUrl ??
-      defaultDeps!.createSignedReportDownloadUrl,
-  };
-}
 
 function applyCorsHeaders(
   request: FastifyRequest,
@@ -392,29 +291,6 @@ async function authenticateClinicUser(
   };
 }
 
-function serializeReports(reports: Report[], _deps: NativeReportsDeps) {
-  return reports.map((report) => serializeSafeReport(report));
-}
-
-async function getAuthorizedReport(
-  reportId: number,
-  clinicId: number,
-  deps: NativeReportsDeps,
-): Promise<{ report: Report } | { status: 404; error: string }> {
-  const report = await deps.getClinicScopedReportById(reportId, clinicId);
-
-  if (!report) {
-    return {
-      status: 404,
-      error: "Informe no encontrado",
-    };
-  }
-
-  return {
-    report,
-  };
-}
-
 function validateStatusQuery(status: unknown, currentStatus: ReportStatus | undefined) {
   return typeof status === "undefined" || !!currentStatus;
 }
@@ -492,8 +368,13 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         offset?: unknown;
       };
     }>("/", async (request, reply) => {
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
+      const composition = await createClinicReportsRouteComposition(options);
+      const auth = await authenticateClinicUser(
+        request,
+        reply,
+        composition.auth,
+        now,
+      );
 
       if (!auth) {
         return reply;
@@ -519,25 +400,16 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      const [reports, total] = await Promise.all([
-        deps.getReportsByClinicId(scope.clinicId, limit, offset, currentStatus),
-        deps.countReportsByClinicId(scope.clinicId, currentStatus),
-      ]);
-      const totalPages = limit > 0 ? Math.ceil(total / limit) : 0;
+      const result = await composition.queries.listClinicReports({
+        clinicId: scope.clinicId,
+        limit,
+        offset,
+        currentStatus,
+      });
 
       return reply.code(200).send({
         success: true,
-        count: reports.length,
-        total,
-        totalPages,
-        reports: await serializeReports(reports, deps),
-        filters: {
-          status: currentStatus ?? null,
-        },
-        pagination: {
-          limit,
-          offset,
-        },
+        ...result,
       });
     });
 
@@ -551,8 +423,13 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         offset?: unknown;
       };
     }>("/search", async (request, reply) => {
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
+      const composition = await createClinicReportsRouteComposition(options);
+      const auth = await authenticateClinicUser(
+        request,
+        reply,
+        composition.auth,
+        now,
+      );
 
       if (!auth) {
         return reply;
@@ -580,27 +457,18 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      const [reports, total] = await Promise.all([
-        deps.searchReports(scope.clinicId, query, studyType ?? undefined, limit, offset, currentStatus),
-        deps.countSearchReports(scope.clinicId, query, studyType ?? undefined, currentStatus),
-      ]);
-      const totalPages = limit > 0 ? Math.ceil(total / limit) : 0;
+      const result = await composition.queries.searchClinicReports({
+        clinicId: scope.clinicId,
+        query,
+        studyType: studyType ?? undefined,
+        currentStatus,
+        limit,
+        offset,
+      });
 
       return reply.code(200).send({
         success: true,
-        count: reports.length,
-        total,
-        totalPages,
-        reports: await serializeReports(reports, deps),
-        filters: {
-          query: query ?? null,
-          studyType: studyType ?? null,
-          status: currentStatus ?? null,
-        },
-        pagination: {
-          limit,
-          offset,
-        },
+        ...result,
       });
     });
 
@@ -609,8 +477,13 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         clinicId?: unknown;
       };
     }>("/study-types", async (request, reply) => {
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
+      const composition = await createClinicReportsRouteComposition(options);
+      const auth = await authenticateClinicUser(
+        request,
+        reply,
+        composition.auth,
+        now,
+      );
 
       if (!auth) {
         return reply;
@@ -625,7 +498,9 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      const studyTypes = await deps.getStudyTypes(scope.clinicId);
+      const studyTypes = await composition.queries.getStudyTypes(
+        scope.clinicId,
+      );
 
       return reply.code(200).send({
         success: true,
@@ -638,8 +513,13 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         reportId?: unknown;
       };
     }>("/:reportId/history", async (request, reply) => {
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
+      const composition = await createClinicReportsRouteComposition(options);
+      const auth = await authenticateClinicUser(
+        request,
+        reply,
+        composition.auth,
+        now,
+      );
 
       if (!auth) {
         return reply;
@@ -654,27 +534,24 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      const reportResult = await getAuthorizedReport(
+      const result = await composition.queries.getClinicReportHistory(
         reportId,
         auth.clinicId,
-        deps,
       );
 
-      if (!("report" in reportResult)) {
-        return reply.code(reportResult.status).send({
+      if (result.type === "not_found") {
+        return reply.code(404).send({
           success: false,
-          error: reportResult.error,
+          error: "Informe no encontrado",
         });
       }
 
-      const history = await deps.getReportStatusHistory(reportId);
-
       return reply.code(200).send({
         success: true,
-        reportId,
-        currentStatus: reportResult.report.currentStatus,
-        count: history.length,
-        history,
+        reportId: result.reportId,
+        currentStatus: result.currentStatus,
+        count: result.count,
+        history: result.history,
       });
     });
 
@@ -683,8 +560,13 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         reportId?: unknown;
       };
     }>("/:reportId/preview-url", async (request, reply) => {
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
+      const composition = await createClinicReportsRouteComposition(options);
+      const auth = await authenticateClinicUser(
+        request,
+        reply,
+        composition.auth,
+        now,
+      );
 
       if (!auth) {
         return reply;
@@ -699,26 +581,21 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      const reportResult = await getAuthorizedReport(
+      const result = await composition.queries.getClinicReportPreview(
         reportId,
         auth.clinicId,
-        deps,
       );
 
-      if (!("report" in reportResult)) {
-        return reply.code(reportResult.status).send({
+      if (result.type === "not_found") {
+        return reply.code(404).send({
           success: false,
-          error: reportResult.error,
+          error: "Informe no encontrado",
         });
       }
 
-      const previewUrl = await deps.createSignedReportUrl(
-        reportResult.report.storagePath,
-      );
-
       return reply.code(200).send({
         success: true,
-        previewUrl,
+        previewUrl: result.previewUrl,
       });
     });
 
@@ -727,8 +604,13 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         reportId?: unknown;
       };
     }>("/:reportId/download-url", async (request, reply) => {
-      const deps = await resolveDeps(options);
-      const auth = await authenticateClinicUser(request, reply, deps, now);
+      const composition = await createClinicReportsRouteComposition(options);
+      const auth = await authenticateClinicUser(
+        request,
+        reply,
+        composition.auth,
+        now,
+      );
 
       if (!auth) {
         return reply;
@@ -743,27 +625,21 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         });
       }
 
-      const reportResult = await getAuthorizedReport(
+      const result = await composition.queries.getClinicReportDownload(
         reportId,
         auth.clinicId,
-        deps,
       );
 
-      if (!("report" in reportResult)) {
-        return reply.code(reportResult.status).send({
+      if (result.type === "not_found") {
+        return reply.code(404).send({
           success: false,
-          error: reportResult.error,
+          error: "Informe no encontrado",
         });
       }
 
-      const downloadUrl = await deps.createSignedReportDownloadUrl(
-        reportResult.report.storagePath,
-        reportResult.report.fileName ?? undefined,
-      );
-
       return reply.code(200).send({
         success: true,
-        downloadUrl,
+        downloadUrl: result.downloadUrl,
       });
     });
   };

--- a/test/architecture/audit-critical-flow-writes.test.ts
+++ b/test/architecture/audit-critical-flow-writes.test.ts
@@ -102,8 +102,8 @@ test("report status crítico audita después de mutar estado exitosamente", () =
   assertContainsInOrder(
     source,
     [
-      "const updated = await deps.updateReportStatus({",
-      "await deps.writeAuditLog(createAuditRequestLike(request, auth), {",
+      "const result = await composition.queries.transitionClinicReportStatus({",
+      "await composition.writeAuditLog(createAuditRequestLike(request, auth), {",
       "event: AUDIT_EVENTS.REPORT_STATUS_CHANGED",
     ],
     "reports status audit order",
@@ -112,9 +112,9 @@ test("report status crítico audita después de mutar estado exitosamente", () =
   assertContainsAll(
     source,
     [
-      "clinicId: updated.clinicId",
-      "reportId: updated.id",
-      "fromStatus: reportResult.report.currentStatus",
+      "clinicId: result.report.clinicId",
+      "reportId: result.report.id",
+      "fromStatus: result.previousStatus",
       "toStatus: nextStatus",
       "note,",
     ],
@@ -265,11 +265,14 @@ test("rutas críticas auditadas mantienen writeAuditLog inyectable y default rea
   ] as const;
 
   for (const file of files) {
-    const source = readSource(file);
+    const source =
+      file === "server/routes/reports-status.fastify.ts"
+        ? `${readSource(file)}\n${readSource("server/features/reports/composition/report-query-composition.ts")}`
+        : readSource(file);
 
     assert.match(source, /writeAuditLog\?:/);
     assert.match(source, /writeAuditLog: audit\.writeAuditLog/);
-    assert.match(source, /options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog|writeAuditLog: options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog/);
+    assert.match(source, /options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog|writeAuditLog: options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog|options\.writeAuditLog \?\? defaults!\.writeAuditLog/);
   }
 });
 

--- a/test/architecture/reports-admin-thin-routes.test.ts
+++ b/test/architecture/reports-admin-thin-routes.test.ts
@@ -223,7 +223,7 @@ test("shim M41 no contiene implementación ni tiene consumidores runtime M39", (
   assert.equal(workflow.includes("db-report-workflow"), false);
 });
 
-test("M40 sigue ausente y los shims M41 siguen presentes", () => {
+test("M40 queda materializado y los shims M41 siguen presentes", () => {
   assert.equal(
     existsSync(
       resolve(
@@ -231,7 +231,7 @@ test("M40 sigue ausente y los shims M41 siguen presentes", () => {
         "server/features/reports/application/report-query-use-cases.ts",
       ),
     ),
-    false,
+    true,
   );
   for (const path of [
     "server/db-report-workflow.ts",

--- a/test/architecture/reports-command-use-cases-boundary-guard.test.ts
+++ b/test/architecture/reports-command-use-cases-boundary-guard.test.ts
@@ -16,10 +16,12 @@ const expectedApplication = [
   `${application}/README.md`,
   `${application}/index.ts`,
   `${application}/report-command-use-cases.ts`,
+  `${application}/report-query-use-cases.ts`,
   `${application}/report-route-service.ts`,
   `${application}/report-workflow-communication.ts`,
   `${ports}/index.ts`,
   `${ports}/report-command-repository.ts`,
+  `${ports}/report-query-repository.ts`,
   `${ports}/report-workflow-data-port.ts`,
   `${ports}/report-workflow-notification-port.ts`,
 ].sort();
@@ -28,6 +30,7 @@ const expectedInfrastructure = [
   `${infrastructure}/index.ts`,
   `${infrastructure}/db-report-workflow.ts`,
   `${infrastructure}/report-command-repository.ts`,
+  `${infrastructure}/report-query-repository.ts`,
   `${infrastructure}/report-workflow-data-adapter.ts`,
   `${infrastructure}/report-workflow-notification-adapter.ts`,
 ].sort();
@@ -35,6 +38,7 @@ const expectedComposition = [
   `${composition}/README.md`,
   `${composition}/index.ts`,
   `${composition}/report-command-composition.ts`,
+  `${composition}/report-query-composition.ts`,
   `${composition}/report-route-composition.ts`,
   `${composition}/report-workflow-communication-composition.ts`,
 ].sort();
@@ -110,7 +114,7 @@ function target(path: string, specifier: string): string {
     : normalized;
 }
 
-test("M39 fija inventario productivo exacto de Reports", () => {
+test("M40 fija inventario productivo exacto de Reports", () => {
   assert.deepEqual(walk(application).sort(), expectedApplication);
   assert.deepEqual(walk(infrastructure).sort(), expectedInfrastructure);
   assert.deepEqual(walk(composition).sort(), expectedComposition);
@@ -155,7 +159,7 @@ test("application y ports aplican default deny con único acceso al domain canó
       const resolved = target(path, specifier);
       const allowed =
         resolved.startsWith(`${application}/`) ||
-        (path === `${application}/report-command-use-cases.ts` &&
+        ([`${application}/report-command-use-cases.ts`, `${application}/report-query-use-cases.ts`].includes(path) &&
           resolved === `${domain}/index.ts`);
       if (!allowed) {
         violations.push(`${path}: ${specifier} -> ${resolved}`);
@@ -205,6 +209,7 @@ test("composition contiene los únicos bridges application a infrastructure", ()
 
   assert.deepEqual(bridges, [
     `${composition}/report-command-composition.ts`,
+    `${composition}/report-query-composition.ts`,
     `${composition}/report-route-composition.ts`,
     `${composition}/report-workflow-communication-composition.ts`,
   ]);
@@ -255,7 +260,7 @@ test("infrastructure es owner único de DB transacciones tablas y SQL M38", () =
   assert.equal(repository.includes("../composition/"), false);
 });
 
-test("compatibilidad db y rutas M39 quedan conectadas por composition", () => {
+test("compatibilidad db y rutas M40 quedan conectadas por composition", () => {
   const database = read("server/db.ts");
   const admin = read("server/routes/admin-reports.fastify.ts");
   const status = read("server/routes/reports-status.fastify.ts");
@@ -294,8 +299,8 @@ test("compatibilidad db y rutas M39 quedan conectadas por composition", () => {
   }
   for (const [source, markers] of [
     [admin, ["export type AdminReportsNativeRoutesOptions", "createAdminReportsRouteComposition"]],
-    [status, ["export type ReportsStatusNativeRoutesOptions", "updateReportStatus: db.updateReportStatus"]],
-    [reportsRoute, ["export type ReportsNativeRoutesOptions", "getReportStatusHistory: db.getReportStatusHistory"]],
+    [status, ["export type ReportsStatusNativeRoutesOptions", "createClinicReportStatusRouteComposition"]],
+    [reportsRoute, ["export type ReportsNativeRoutesOptions", "createClinicReportsRouteComposition"]],
     [workflow, ["export type AdminReportWorkflowNativeRoutesOptions", "createAdminReportWorkflowRouteComposition"]],
     [app, ['prefix: "/api/reports"', "reportsNativeRoutes", "reportsStatusNativeRoutes"]],
   ] as const) {
@@ -306,7 +311,7 @@ test("compatibilidad db y rutas M39 quedan conectadas por composition", () => {
   }
 });
 
-test("M36 a M39 permanecen materializados y M40 ausente", () => {
+test("M36 a M40 permanecen materializados", () => {
   assert.deepEqual(
     walk(domain).sort(),
     [
@@ -337,7 +342,7 @@ test("M36 a M39 permanecen materializados y M40 ausente", () => {
   }
   assert.equal(
     existsSync(resolve(root, `${application}/report-query-use-cases.ts`)),
-    false,
+    true,
   );
 });
 

--- a/test/architecture/reports-domain-boundary-guard.test.ts
+++ b/test/architecture/reports-domain-boundary-guard.test.ts
@@ -28,7 +28,8 @@ const runtimeConsumers = [
   "server/routes/admin-reports.fastify.ts",
   "server/routes/reports.fastify.ts",
   "server/routes/reports-status.fastify.ts",
-  "server/db.ts",
+  "server/features/reports/application/report-query-use-cases.ts",
+  "server/features/reports/infrastructure/report-query-repository.ts",
   "server/lib/particular-token.ts",
   "server/lib/report-access-token.ts",
 ] as const;
@@ -342,7 +343,7 @@ test("domain no contiene transporte infraestructura I/O ni side effects", () => 
   assert.deepEqual(violations, []);
 });
 
-test("M37 a M39 quedan fuera del dominio y M39 está materializado", () => {
+test("M37 a M40 quedan fuera del dominio y M40 está materializado", () => {
   for (const path of [
     `${featureDir}/application`,
     `${featureDir}/infrastructure`,
@@ -387,7 +388,7 @@ test("M37 a M39 quedan fuera del dominio y M39 está materializado", () => {
     walkTsFiles(`${featureDir}/application`).some((file) =>
       /report-query/i.test(file),
     ),
-    false,
+    true,
   );
 });
 

--- a/test/architecture/reports-query-use-cases-boundary-guard.test.ts
+++ b/test/architecture/reports-query-use-cases-boundary-guard.test.ts
@@ -1,0 +1,191 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const application =
+  "server/features/reports/application/report-query-use-cases.ts";
+const port =
+  "server/features/reports/application/ports/report-query-repository.ts";
+const repository =
+  "server/features/reports/infrastructure/report-query-repository.ts";
+const composition =
+  "server/features/reports/composition/report-query-composition.ts";
+const readsRoute = "server/routes/reports.fastify.ts";
+const statusRoute = "server/routes/reports-status.fastify.ts";
+
+function read(path: string) {
+  return readFileSync(resolve(root, path), "utf8").replace(/\r\n/g, "\n");
+}
+
+function tsFiles(directory: string): string[] {
+  return readdirSync(resolve(root, directory), {
+    recursive: true,
+    withFileTypes: true,
+  })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) =>
+      resolve(entry.parentPath, entry.name)
+        .slice(resolve(root).length + 1)
+        .replaceAll("\\", "/"),
+    );
+}
+
+test("M40 materializa inventario productivo exacto", () => {
+  for (const path of [application, port, repository, composition]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
+
+  assert.deepEqual(
+    tsFiles("server/features/reports/application").sort(),
+    [
+      "server/features/reports/application/index.ts",
+      "server/features/reports/application/ports/index.ts",
+      "server/features/reports/application/ports/report-command-repository.ts",
+      "server/features/reports/application/ports/report-query-repository.ts",
+      "server/features/reports/application/ports/report-workflow-data-port.ts",
+      "server/features/reports/application/ports/report-workflow-notification-port.ts",
+      "server/features/reports/application/report-command-use-cases.ts",
+      "server/features/reports/application/report-query-use-cases.ts",
+      "server/features/reports/application/report-route-service.ts",
+      "server/features/reports/application/report-workflow-communication.ts",
+    ],
+  );
+});
+
+test("M40 application aplica default deny de framework y persistencia", () => {
+  const source = read(application);
+
+  for (const forbidden of [
+    "fastify",
+    "drizzle-orm",
+    "../db.ts",
+    "supabase",
+    "reply.code",
+    ".select(",
+    ".insert(",
+    ".update(",
+    ".transaction(",
+    "console.",
+    "catch (",
+  ]) {
+    assert.equal(source.toLowerCase().includes(forbidden), false, forbidden);
+  }
+
+  assert.ok(source.includes("serializeSafeReport"));
+  assert.ok(source.includes("type: \"not_found\""));
+});
+
+test("M40 composition es bridge lazy unico y rutas quedan thin", () => {
+  const bridge = read(composition);
+  const reads = read(readsRoute);
+  const status = read(statusRoute);
+
+  for (const marker of [
+    'import("../../../db.ts")',
+    'import("../../../lib/supabase.ts")',
+    'import("../infrastructure/report-query-repository.ts")',
+    'import("./report-command-composition.ts")',
+    "createReportQueryUseCases",
+    "createReportCommandUseCases",
+  ]) {
+    assert.ok(bridge.includes(marker), marker);
+  }
+
+  for (const source of [reads, status]) {
+    for (const forbidden of [
+      "../db.ts",
+      "drizzle-orm",
+      "../lib/supabase.ts",
+      "Promise.all(",
+      "canTransitionReportStatus(",
+      "serializeSafeReport(",
+    ]) {
+      assert.equal(source.includes(forbidden), false, forbidden);
+    }
+  }
+});
+
+test("M40 db.ts conserva solo reexports compatibility de queries", () => {
+  const db = read("server/db.ts");
+  const reportsSection = db.slice(
+    db.indexOf("/* ========================= REPORTS"),
+  );
+
+  for (const name of [
+    "getClinicScopedReportById",
+    "getReportStatusHistory",
+    "getReportsByClinicId",
+    "countReportsByClinicId",
+    "searchReports",
+    "countSearchReports",
+    "getReportStudyTypes",
+    "getStudyTypes",
+  ]) {
+    assert.match(db, new RegExp(`\\b${name}\\b`), name);
+    assert.equal(
+      reportsSection.includes(`function ${name}`),
+      false,
+      name,
+    );
+  }
+
+  assert.equal(reportsSection.includes(".select("), false);
+  assert.equal(reportsSection.includes("count(*)"), false);
+});
+
+test("M40 conserva doble registro /api/reports en orden reads status", () => {
+  const app = read("server/fastify-app.ts");
+  const registrations = Array.from(
+    app.matchAll(
+      /app\.register\(\s*(reportsNativeRoutes|reportsStatusNativeRoutes),\s*\{\s*prefix:\s*"([^"]+)"/g,
+    ),
+    (match) => [match[1], match[2]],
+  );
+
+  assert.deepEqual(registrations, [
+    ["reportsNativeRoutes", "/api/reports"],
+    ["reportsStatusNativeRoutes", "/api/reports"],
+  ]);
+});
+
+test("M40 preserva Options endpoints shims y mantiene M41 ausente", () => {
+  const reads = read(readsRoute);
+  const status = read(statusRoute);
+
+  for (const marker of [
+    "export type ReportsNativeRoutesOptions",
+    'app.options("/", optionsHandler);',
+    'app.options("/search", optionsHandler);',
+    'app.options("/study-types", optionsHandler);',
+    'app.options("/:reportId/history", optionsHandler);',
+    'app.options("/:reportId/preview-url", optionsHandler);',
+    'app.options("/:reportId/download-url", optionsHandler);',
+    '}>("/", async',
+    '}>("/search", async',
+    '}>("/study-types", async',
+    '}>("/:reportId/history", async',
+    '}>("/:reportId/preview-url", async',
+    '}>("/:reportId/download-url", async',
+  ]) {
+    assert.ok(reads.includes(marker), marker);
+  }
+  for (const marker of [
+    "export type ReportsStatusNativeRoutesOptions",
+    'app.options("/:reportId/status", optionsHandler);',
+    '}>("/:reportId/status", async',
+  ]) {
+    assert.ok(status.includes(marker), marker);
+  }
+  for (const shim of [
+    "server/db-report-workflow.ts",
+    "server/lib/report-workflow-communication.ts",
+    "server/lib/report-status.ts",
+    "server/lib/report-study-types.ts",
+    "server/lib/reports.ts",
+  ]) {
+    assert.equal(existsSync(resolve(root, shim)), true, shim);
+  }
+  assert.equal(existsSync(resolve(root, "docs/implementation/m41-reports-closeout.md")), false);
+});

--- a/test/architecture/reports-suite-completeness.test.ts
+++ b/test/architecture/reports-suite-completeness.test.ts
@@ -131,8 +131,8 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "\"/:reportId/status\"",
           "requireReportStatusWritePermission(auth, reply)",
           "parseReportStatus(request.body?.status)",
-          "canTransitionReportStatus",
-          "await deps.updateReportStatus({",
+          "transitionClinicReportStatus",
+          "createClinicReportStatusRouteComposition",
           "AUDIT_EVENTS.REPORT_STATUS_CHANGED",
         ],
       },
@@ -157,7 +157,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "report study types have canonical internal catalog",
           "report study types block free-text",
           "report routes use canonical parser",
-          "DB exposes study types from catalog",
+          "M40 infrastructure exposes study types from catalog",
         ],
       },
     ],
@@ -377,13 +377,13 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "Reports conserva domain M36 y admite inventario M37 autorizado",
           "consumidores externos usan exclusivamente el barrel canonico",
           "domain aplica default-deny",
-          "M39 est\u00e1 materializado",
+          "M40 est\u00e1 materializado",
         ],
       },
       {
         path: "test/architecture/reports-workflow-ports-boundary-guard.test.ts",
         markers: [
-          "M39 conserva inventario exacto de application ports infrastructure y composition",
+          "M40 conserva inventario exacto de application ports infrastructure y composition",
           "application y ports aplican default deny",
           "composition es el unico bridge M37",
           "best effort catch y logging seguro",
@@ -433,9 +433,33 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       {
         path: "test/architecture/reports-command-use-cases-boundary-guard.test.ts",
         markers: [
-          "M39 fija inventario productivo exacto",
+          "M40 fija inventario productivo exacto",
           "application y ports aplican default deny",
-          "M40 ausente",
+          "M36 a M40 permanecen materializados",
+        ],
+      },
+      {
+        path: "test/unit/application/reports/report-query-use-cases.test.ts",
+        markers: [
+          "M40 list coordina query y count",
+          "M40 history ocurre solo despues de ownership",
+          "M40 propaga errores de infraestructura",
+        ],
+      },
+      {
+        path: "test/unit/infrastructure/reports/report-query-repository-contract.test.ts",
+        markers: [
+          "M40 repository es owner unico",
+          "M40 search y count comparten filtros exactos",
+          "M40 counts y catalogo conservan semantica legacy",
+        ],
+      },
+      {
+        path: "test/architecture/reports-query-use-cases-boundary-guard.test.ts",
+        markers: [
+          "M40 materializa inventario productivo exacto",
+          "M40 composition es bridge lazy unico",
+          "M40 conserva doble registro /api/reports",
         ],
       },
       {
@@ -497,7 +521,20 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       },
       {
         path: "server/routes/reports.fastify.ts",
-        markers: ["getAuthorizedReport", "serializeReport"],
+        markers: [
+          "createClinicReportsRouteComposition",
+          "getClinicReportHistory",
+          "getClinicReportPreview",
+          "getClinicReportDownload",
+        ],
+      },
+      {
+        path: "server/features/reports/application/report-query-use-cases.ts",
+        markers: [
+          "listClinicReports",
+          "searchClinicReports",
+          "transitionClinicReportStatus",
+        ],
       },
       {
         path: "server/routes/public-report-access.fastify.ts",
@@ -585,6 +622,9 @@ test("reports suite registers canonical reports guardrail files", () => {
     "report-command-repository-contract.test.ts",
     "report-command-persistence-contract.test.ts",
     "reports-command-use-cases-boundary-guard.test.ts",
+    "report-query-use-cases.test.ts",
+    "report-query-repository-contract.test.ts",
+    "reports-query-use-cases-boundary-guard.test.ts",
   ]) {
     assert.equal(
       registeredFiles.includes(requiredFile),

--- a/test/architecture/reports-workflow-ports-boundary-guard.test.ts
+++ b/test/architecture/reports-workflow-ports-boundary-guard.test.ts
@@ -20,10 +20,12 @@ const expectedApplication = [
   `${application}/README.md`,
   `${application}/index.ts`,
   `${application}/report-command-use-cases.ts`,
+  `${application}/report-query-use-cases.ts`,
   `${application}/report-route-service.ts`,
   `${application}/report-workflow-communication.ts`,
   `${ports}/index.ts`,
   `${ports}/report-command-repository.ts`,
+  `${ports}/report-query-repository.ts`,
   `${ports}/report-workflow-data-port.ts`,
   `${ports}/report-workflow-notification-port.ts`,
 ] as const;
@@ -32,6 +34,7 @@ const expectedInfrastructure = [
   `${infrastructure}/index.ts`,
   `${infrastructure}/db-report-workflow.ts`,
   `${infrastructure}/report-command-repository.ts`,
+  `${infrastructure}/report-query-repository.ts`,
   `${infrastructure}/report-workflow-data-adapter.ts`,
   `${infrastructure}/report-workflow-notification-adapter.ts`,
 ] as const;
@@ -39,6 +42,7 @@ const expectedComposition = [
   `${composition}/README.md`,
   `${composition}/index.ts`,
   `${composition}/report-command-composition.ts`,
+  `${composition}/report-query-composition.ts`,
   `${composition}/report-route-composition.ts`,
   `${composition}/report-workflow-communication-composition.ts`,
 ] as const;
@@ -146,7 +150,7 @@ function target(path: string, specifier: string): string {
     : resolved;
 }
 
-test("M39 conserva inventario exacto de application ports infrastructure y composition", () => {
+test("M40 conserva inventario exacto de application ports infrastructure y composition", () => {
   for (const directory of [application, ports, infrastructure, composition]) {
     assert.equal(existsSync(resolve(root, directory)), true, directory);
   }
@@ -202,7 +206,10 @@ test("application y ports aplican default deny sin DB Drizzle schema ni capas su
       if (
         !resolved.startsWith(`${application}/`) &&
         !(
-          path === `${application}/report-command-use-cases.ts` &&
+          [
+            `${application}/report-command-use-cases.ts`,
+            `${application}/report-query-use-cases.ts`,
+          ].includes(path) &&
           resolved === `${domain}/index.ts`
         )
       ) {
@@ -303,6 +310,7 @@ test("composition es el unico bridge M37 entre application e infrastructure", ()
 
   assert.deepEqual(bridgeFiles, [
     `${composition}/report-command-composition.ts`,
+    `${composition}/report-query-composition.ts`,
     `${composition}/report-route-composition.ts`,
     `${composition}/report-workflow-communication-composition.ts`,
   ]);
@@ -381,7 +389,7 @@ test("fastify app conserva el registro actual sin imports M37", () => {
   );
 });
 
-test("M39 agrega route service y mueve db-report-workflow sin ejecutar M40", () => {
+test("M39 conserva route service y M40 agrega queries sin ejecutar M41", () => {
   assert.equal(existsSync(resolve(root, workflow)), true);
   assert.equal(
     existsSync(resolve(root, `${infrastructure}/db-report-workflow.ts`)),
@@ -399,7 +407,7 @@ test("M39 agrega route service y mueve db-report-workflow sin ejecutar M40", () 
     assert.equal(existsSync(resolve(root, path)), true, path);
   }
   const forbiddenFiles = walk(feature).filter((path) =>
-    /handlers?|controllers?|report-query/i.test(
+    /handlers?|controllers?/i.test(
       path.slice(feature.length + 1),
     ),
   );

--- a/test/architecture/security/security-boundary-suite-completeness.test.ts
+++ b/test/architecture/security/security-boundary-suite-completeness.test.ts
@@ -72,7 +72,17 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
     runtimeAnchors: [
       {
         path: "server/routes/reports-status.fastify.ts",
-        markers: ["getAuthorizedReport", "updateReportStatus"],
+        markers: [
+          "transitionClinicReportStatus",
+          "createClinicReportStatusRouteComposition",
+        ],
+      },
+      {
+        path: "server/features/reports/application/report-query-use-cases.ts",
+        markers: [
+          "findClinicScopedReportById",
+          "transitionClinicReportStatus",
+        ],
       },
       {
         path: "server/features/report-access/application/clinic-report-access-operations.ts",

--- a/test/architecture/security/security-critical-route-surface-registry.test.ts
+++ b/test/architecture/security/security-critical-route-surface-registry.test.ts
@@ -353,7 +353,11 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
     runtimeFiles: [
       {
         path: "server/routes/reports-status.fastify.ts",
-        markers: ["requireReportStatusWritePermission", "deps.updateReportStatus"],
+        markers: [
+          "requireReportStatusWritePermission",
+          "transitionClinicReportStatus",
+          "composition.writeAuditLog",
+        ],
       },
       {
         path: "server/routes/report-access-tokens.fastify.ts",

--- a/test/architecture/security/security-mutation-permission-surface.test.ts
+++ b/test/architecture/security/security-mutation-permission-surface.test.ts
@@ -19,7 +19,10 @@ const SENSITIVE_MUTATION_ROUTES: readonly SensitiveMutationRoute[] = [
     path: "/:reportId/status",
     authGuard: "authenticateClinicUser",
     permissionGuard: "requireReportStatusWritePermission",
-    protectedCalls: ["deps.updateReportStatus", "deps.writeAuditLog"],
+    protectedCalls: [
+      "composition.queries.transitionClinicReportStatus",
+      "composition.writeAuditLog",
+    ],
   },
   {
     file: "server/routes/report-access-tokens.fastify.ts",

--- a/test/architecture/security/security-resource-ownership-boundaries.test.ts
+++ b/test/architecture/security/security-resource-ownership-boundaries.test.ts
@@ -136,6 +136,9 @@ test("resource ownership matrix documents protected owner keys", () => {
 test("clinic-owned resources reject cross-clinic reports tokens and tracking cases", () => {
   const reports = readSource("server/routes/reports.fastify.ts");
   const reportsStatus = readSource("server/routes/reports-status.fastify.ts");
+  const reportQueries = readSource(
+    "server/features/reports/application/report-query-use-cases.ts",
+  );
   const reportAccessApplication = readSource(
     "server/features/report-access/application/clinic-report-access-operations.ts",
   );
@@ -150,11 +153,12 @@ test("clinic-owned resources reject cross-clinic reports tokens and tracking cas
 
   assertContains(reports, "getReadClinicScope", "clinic reports query scope");
   assertContains(reports, "scope.clinicId", "clinic reports query scope");
-  assertContains(reports, "getAuthorizedReport", "clinic reports parameterized scope");
-  assertContains(reports, "getClinicScopedReportById", "clinic reports parameterized scope");
+  assertContains(reports, "getClinicReportHistory", "clinic reports parameterized scope");
+  assertContains(reportQueries, "findClinicScopedReport", "clinic reports parameterized scope");
+  assertContains(reportQueries, "findClinicScopedReportById", "clinic reports parameterized scope");
 
-  assertContains(reportsStatus, "getAuthorizedReport", "clinic report status ownership");
-  assertContains(reportsStatus, "getClinicScopedReportById", "clinic report status ownership");
+  assertContains(reportsStatus, "transitionClinicReportStatus", "clinic report status ownership");
+  assertContains(reportQueries, "findClinicScopedReportById", "clinic report status ownership");
   assertContains(reportsStatus, "auth.clinicId", "clinic report status ownership");
 
   assertContains(reportAccessApplication, "getClinicScopedReportById", "clinic report access token report ownership");

--- a/test/architecture/security/security-response-disclosure-boundaries.test.ts
+++ b/test/architecture/security/security-response-disclosure-boundaries.test.ts
@@ -133,13 +133,16 @@ test("public report access unifies unusable tokens as 404 and preserves 409 and 
 test("clinic report and token surfaces do not disclose cross-scope resources as readable data", () => {
   const reports = readSource("server/routes/reports.fastify.ts");
   const reportsStatus = readSource("server/routes/reports-status.fastify.ts");
+  const reportQueries = readSource(
+    "server/features/reports/application/report-query-use-cases.ts",
+  );
   const reportAccessTokens = readSource("server/routes/report-access-tokens.fastify.ts");
 
-  assertContains(reports, "getClinicScopedReportById", "clinic report ownership check");
-  assertContains(reports, "status: 404", "clinic foreign report response");
+  assertContains(reportQueries, "findClinicScopedReportById", "clinic report ownership check");
+  assertContains(reports, "reply.code(404).send", "clinic foreign report response");
   assertContains(reports, "Informe no encontrado", "clinic report not found body");
 
-  assertContains(reportsStatus, "getClinicScopedReportById", "clinic report status ownership check");
+  assertContains(reportQueries, "findClinicScopedReportById", "clinic report status ownership check");
   assertContains(reportsStatus, "reply.code(404).send", "clinic missing report status response");
   assertContains(reportsStatus, "Informe no encontrado", "clinic report status not found body");
 

--- a/test/architecture/security/security-validation-cutoff-boundaries.test.ts
+++ b/test/architecture/security/security-validation-cutoff-boundaries.test.ts
@@ -210,10 +210,9 @@ test("report status validates route id and requested status before lookup mutati
       "return reply.code(400).send({",
       "if (!nextStatus) {",
       "return reply.code(400).send({",
-      "const reportResult = await getAuthorizedReport(",
-      "const updated = await deps.updateReportStatus({",
-      "await deps.writeAuditLog(createAuditRequestLike(request, auth), {",
-      "report: await serializeReport(updated, deps),",
+      "const result = await composition.queries.transitionClinicReportStatus({",
+      "await composition.writeAuditLog(createAuditRequestLike(request, auth), {",
+      "report: result.report,",
     ],
     "report status validation cut-off",
   );

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -17,6 +17,8 @@ const reportsM38Closeout =
   "docs/implementation/m38-reports-create-edit-transition-use-cases.md";
 const reportsM39Closeout =
   "docs/implementation/m39-reports-admin-thin-routes-workflow.md";
+const reportsM40Closeout =
+  "docs/implementation/m40-reports-query-use-cases-thin-routes.md";
 
 const featureLayers = [
   {
@@ -383,6 +385,7 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
   assert.equal(existsSync(resolve(root, reportsM37Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM38Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM39Closeout)), true);
+  assert.equal(existsSync(resolve(root, reportsM40Closeout)), true);
 
   for (const path of [
     "server/features/reports/application",
@@ -393,7 +396,7 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
   }
 
   const futureCloseouts = walk("docs/implementation").filter((path) =>
-    /\/(?:m(?:40|41)-|reports-phase-i)/i.test(path),
+    /\/(?:m41-|reports-phase-i)/i.test(path),
   );
   assert.deepEqual(futureCloseouts, []);
 });

--- a/test/security/security-audit-logging-phase-boundaries.test.ts
+++ b/test/security/security-audit-logging-phase-boundaries.test.ts
@@ -120,7 +120,10 @@ function assertContainsInOrder(
 }
 
 function assertRouteKeepsInjectedAuditDeps(file: string): void {
-  const source = readSource(file);
+  const source =
+    file === "server/routes/reports-status.fastify.ts"
+      ? `${readSource(file)}\n${readSource("server/features/reports/composition/report-query-composition.ts")}`
+      : readSource(file);
 
   assertContains(source, "writeAuditLog?:", `${file} audit dependency type`);
   assertContains(
@@ -130,7 +133,7 @@ function assertRouteKeepsInjectedAuditDeps(file: string): void {
   );
   assertMatches(
     source,
-    /options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog|writeAuditLog: options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog/,
+    /options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog|writeAuditLog: options\.writeAuditLog \?\? defaultDeps!\.writeAuditLog|options\.writeAuditLog \?\? defaults!\.writeAuditLog/,
     `${file} injected audit dependency selection`,
   );
 }
@@ -252,8 +255,8 @@ test("report mutation audit happens after durable mutation and before success re
     [
       "if (!enforceTrustedOrigin(request, reply, allowedOrigins)) {",
       "const auth = await authenticateClinicUser(",
-      "const updated = await deps.updateReportStatus({",
-      "await deps.writeAuditLog(createAuditRequestLike(request, auth), {",
+      "const result = await composition.queries.transitionClinicReportStatus({",
+      "await composition.writeAuditLog(createAuditRequestLike(request, auth), {",
       "event: AUDIT_EVENTS.REPORT_STATUS_CHANGED",
       "return reply.code(200).send({",
     ],

--- a/test/unit/application/reports/report-query-use-cases.test.ts
+++ b/test/unit/application/reports/report-query-use-cases.test.ts
@@ -1,0 +1,271 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import type {
+  Report,
+  ReportStatusHistory,
+} from "../../../../drizzle/schema.ts";
+import { createReportQueryUseCases } from "../../../../server/features/reports/application/index.ts";
+
+function createReport(overrides: Partial<Report> = {}): Report {
+  return {
+    id: 55,
+    clinicId: 3,
+    patientName: "Luna",
+    studyType: "histopatologia",
+    uploadDate: new Date("2026-07-20T10:00:00.000Z"),
+    fileName: "luna.pdf",
+    storagePath: "reports/3/luna.pdf",
+    previewUrl: null,
+    downloadUrl: null,
+    currentStatus: "ready",
+    statusChangedAt: new Date("2026-07-20T10:00:00.000Z"),
+    statusChangedByClinicUserId: 9,
+    statusChangedByAdminUserId: null,
+    workflowStage: "sample_received",
+    specialStainRequested: false,
+    specialStainAt: null,
+    workflowUpdatedAt: null,
+    createdAt: new Date("2026-07-20T10:00:00.000Z"),
+    updatedAt: new Date("2026-07-20T10:00:00.000Z"),
+    ...overrides,
+  };
+}
+
+function createHarness(input?: {
+  report?: Report | null;
+  reports?: Report[];
+  total?: number;
+  history?: ReportStatusHistory[];
+}) {
+  const calls: string[] = [];
+  const report = input?.report === undefined ? createReport() : input.report;
+  const reports = input?.reports ?? (report ? [report] : []);
+  const repository = {
+    async findClinicScopedReportById(reportId: number, clinicId: number) {
+      calls.push(`lookup:${reportId}:${clinicId}`);
+      return report;
+    },
+    async listReportsByClinicId(
+      clinicId: number,
+      limit: number,
+      offset: number,
+      currentStatus?: string,
+    ) {
+      calls.push(`list:${clinicId}:${limit}:${offset}:${currentStatus}`);
+      return reports;
+    },
+    async countReportsByClinicId(clinicId: number, currentStatus?: string) {
+      calls.push(`count:${clinicId}:${currentStatus}`);
+      return input?.total ?? reports.length;
+    },
+    async searchReports(
+      clinicId: number,
+      filters: {
+        query?: string;
+        studyType?: string;
+        currentStatus?: string;
+      },
+      limit: number,
+      offset: number,
+    ) {
+      calls.push(
+        `search:${clinicId}:${filters.query}:${filters.studyType}:${filters.currentStatus}:${limit}:${offset}`,
+      );
+      return reports;
+    },
+    async countSearchReports(
+      clinicId: number,
+      filters: {
+        query?: string;
+        studyType?: string;
+        currentStatus?: string;
+      },
+    ) {
+      calls.push(
+        `search-count:${clinicId}:${filters.query}:${filters.studyType}:${filters.currentStatus}`,
+      );
+      return input?.total ?? reports.length;
+    },
+    async getReportStatusHistory(reportId: number) {
+      calls.push(`history:${reportId}`);
+      return input?.history ?? [];
+    },
+    async getStudyTypes(clinicId: number) {
+      calls.push(`study-types:${clinicId}`);
+      return ["citologia", "histopatologia", "hemoparasitos"];
+    },
+  };
+  const useCases = createReportQueryUseCases({
+    repository,
+    async createSignedReportUrl(storagePath) {
+      calls.push(`preview:${storagePath}`);
+      return "https://signed.example/preview";
+    },
+    async createSignedReportDownloadUrl(storagePath, fileName) {
+      calls.push(`download:${storagePath}:${fileName}`);
+      return "https://signed.example/download";
+    },
+    async transitionReportStatus(transitionInput) {
+      calls.push(`transition:${transitionInput.reportId}:${transitionInput.toStatus}`);
+      return {
+        type: "persisted" as const,
+        report: createReport({ currentStatus: transitionInput.toStatus }),
+      };
+    },
+  });
+
+  return { calls, useCases };
+}
+
+test("M40 list coordina query y count con paginacion y serializacion segura", async () => {
+  const { calls, useCases } = createHarness({ total: 21 });
+  const result = await useCases.listClinicReports({
+    clinicId: 3,
+    limit: 10,
+    offset: 10,
+    currentStatus: "ready",
+  });
+
+  assert.deepEqual(calls, ["list:3:10:10:ready", "count:3:ready"]);
+  assert.equal(result.count, 1);
+  assert.equal(result.total, 21);
+  assert.equal(result.totalPages, 3);
+  assert.deepEqual(result.filters, { status: "ready" });
+  assert.deepEqual(result.pagination, { limit: 10, offset: 10 });
+  assert.equal("storagePath" in result.reports[0]!, false);
+  assert.equal(result.reports[0]!.hasFile, true);
+});
+
+test("M40 search conserva filtros identicos entre query y count", async () => {
+  const { calls, useCases } = createHarness({ total: 6 });
+  const result = await useCases.searchClinicReports({
+    clinicId: 3,
+    query: "Luna",
+    studyType: "histopatologia",
+    currentStatus: "ready",
+    limit: 5,
+    offset: 5,
+  });
+
+  assert.deepEqual(calls, [
+    "search:3:Luna:histopatologia:ready:5:5",
+    "search-count:3:Luna:histopatologia:ready",
+  ]);
+  assert.equal(result.totalPages, 2);
+  assert.deepEqual(result.filters, {
+    query: "Luna",
+    studyType: "histopatologia",
+    status: "ready",
+  });
+});
+
+test("M40 expone el catalogo vigente sin side effects extra", async () => {
+  const { calls, useCases } = createHarness();
+
+  assert.deepEqual(await useCases.getStudyTypes(3), [
+    "citologia",
+    "histopatologia",
+    "hemoparasitos",
+  ]);
+  assert.deepEqual(calls, ["study-types:3"]);
+});
+
+test("M40 lookup clinic-scoped modela found y not_found", async () => {
+  const found = createHarness();
+  const missing = createHarness({ report: null });
+
+  assert.equal(
+    (await found.useCases.findClinicScopedReport(55, 3)).type,
+    "found",
+  );
+  assert.deepEqual(
+    await missing.useCases.findClinicScopedReport(55, 3),
+    { type: "not_found", reportId: 55 },
+  );
+});
+
+test("M40 history ocurre solo despues de ownership", async () => {
+  const found = createHarness();
+  const missing = createHarness({ report: null });
+
+  await found.useCases.getClinicReportHistory(55, 3);
+  await missing.useCases.getClinicReportHistory(55, 3);
+
+  assert.deepEqual(found.calls, ["lookup:55:3", "history:55"]);
+  assert.deepEqual(missing.calls, ["lookup:55:3"]);
+});
+
+test("M40 preview y download ocurren solo despues de ownership", async () => {
+  const found = createHarness();
+  const missing = createHarness({ report: null });
+
+  await found.useCases.getClinicReportPreview(55, 3);
+  await found.useCases.getClinicReportDownload(55, 3);
+  await missing.useCases.getClinicReportPreview(55, 3);
+  await missing.useCases.getClinicReportDownload(55, 3);
+
+  assert.deepEqual(found.calls, [
+    "lookup:55:3",
+    "preview:reports/3/luna.pdf",
+    "lookup:55:3",
+    "download:reports/3/luna.pdf:luna.pdf",
+  ]);
+  assert.deepEqual(missing.calls, ["lookup:55:3", "lookup:55:3"]);
+});
+
+test("M40 transition ocurre solo despues de ownership y serializa el resultado", async () => {
+  const found = createHarness();
+  const missing = createHarness({ report: null });
+
+  const result = await found.useCases.transitionClinicReportStatus({
+    clinicId: 3,
+    reportId: 55,
+    toStatus: "delivered",
+    note: null,
+    changedByClinicUserId: 9,
+  });
+  await missing.useCases.transitionClinicReportStatus({
+    clinicId: 3,
+    reportId: 55,
+    toStatus: "delivered",
+    note: null,
+  });
+
+  assert.equal(result.type, "persisted");
+  assert.deepEqual(found.calls, ["lookup:55:3", "transition:55:delivered"]);
+  assert.deepEqual(missing.calls, ["lookup:55:3"]);
+  if (result.type === "persisted") {
+    assert.equal("storagePath" in result.report, false);
+  }
+});
+
+test("M40 propaga errores de infraestructura sin catch general", async () => {
+  const { useCases } = createHarness();
+  const failure = new Error("query unavailable");
+  const failing = createReportQueryUseCases({
+    repository: {
+      findClinicScopedReportById: async () => {
+        throw failure;
+      },
+      listReportsByClinicId: async () => {
+        throw failure;
+      },
+      countReportsByClinicId: async () => 0,
+      searchReports: async () => [],
+      countSearchReports: async () => 0,
+      getReportStatusHistory: async () => [],
+      getStudyTypes: async () => [],
+    },
+    createSignedReportUrl: async () => "",
+    createSignedReportDownloadUrl: async () => "",
+    transitionReportStatus: async () => ({ type: "not_found", reportId: 55 }),
+  });
+
+  await assert.rejects(
+    failing.listClinicReports({ clinicId: 3, limit: 50, offset: 0 }),
+    failure,
+  );
+  await assert.rejects(failing.findClinicScopedReport(55, 3), failure);
+  assert.ok(useCases);
+});

--- a/test/unit/contracts/reports/report-command-persistence-contract.test.ts
+++ b/test/unit/contracts/reports/report-command-persistence-contract.test.ts
@@ -114,16 +114,14 @@ test("rutas conservan Options y exports compatibility previos", () => {
   }
   for (const marker of [
     "export type ReportsStatusNativeRoutesOptions",
-    "const db = await import(\"../db.ts\")",
-    "getClinicScopedReportById: db.getClinicScopedReportById",
-    "updateReportStatus: db.updateReportStatus",
-    "const updated = await deps.updateReportStatus({",
+    "createClinicReportStatusRouteComposition",
+    "transitionClinicReportStatus({",
   ]) {
     assert.ok(status.includes(marker), marker);
   }
-  assert.ok(reads.includes("getReportStatusHistory: db.getReportStatusHistory"));
+  assert.ok(reads.includes("createClinicReportsRouteComposition"));
   assert.equal(admin.includes("../db.ts"), false);
-  assert.equal(status.includes("report-command-composition"), false);
+  assert.equal(status.includes("../db.ts"), false);
 });
 
 test("compatibility update atraviesa composition y application sin queries", () => {
@@ -172,6 +170,6 @@ test("compatibility update atraviesa composition y application sin queries", () 
         "server/features/reports/application/report-query-use-cases.ts",
       ),
     ),
-    false,
+    true,
   );
 });

--- a/test/unit/contracts/reports/report-study-types-catalog.test.ts
+++ b/test/unit/contracts/reports/report-study-types-catalog.test.ts
@@ -47,11 +47,11 @@ const CATALOG_CONSUMERS = [
     markers: ["parseReportStudyType(request.query.studyType)"],
   },
   {
-    path: "server/db.ts",
-    specifier: "./features/reports/domain/index.ts",
+    path: "server/features/reports/infrastructure/report-query-repository.ts",
+    specifier: "../domain/index.ts",
     markers: [
-      "REPORT_STUDY_TYPE_LABELS",
       "getReportStudyTypes as getCanonicalReportStudyTypes",
+      "getCanonicalReportStudyTypes()",
     ],
   },
 ] as const;
@@ -234,12 +234,28 @@ test("report routes use canonical parser for upload and filters", () => {
   assertNotContains(dbSource, "selectDistinct({ studyType: reports.studyType })", CATALOG_CONSUMERS[2].path);
 });
 
-test("DB exposes study types from catalog and not persisted free-text values", () => {
+test("M40 infrastructure exposes study types from catalog and DB only reexports", () => {
   const dbSource = readSource("server/db.ts");
+  const repositorySource = readSource(
+    "server/features/reports/infrastructure/report-query-repository.ts",
+  );
 
-  assertContains(dbSource, "./features/reports/domain/index.ts", "server/db.ts");
-  assertContains(dbSource, "REPORT_STUDY_TYPE_LABELS", "server/db.ts");
   assertContains(dbSource, "getReportStudyTypes", "server/db.ts");
+  assertContains(
+    dbSource,
+    "./features/reports/infrastructure/index.ts",
+    "server/db.ts",
+  );
+  assertContains(
+    repositorySource,
+    "../domain/index.ts",
+    "report-query-repository.ts",
+  );
+  assertContains(
+    repositorySource,
+    "getCanonicalReportStudyTypes()",
+    "report-query-repository.ts",
+  );
   assertNotContains(dbSource, "./lib/report-study-types.ts", "server/db.ts");
   assertNotContains(dbSource, "selectDistinct({ studyType: reports.studyType })", "server/db.ts");
 });

--- a/test/unit/infrastructure/reports/report-query-repository-contract.test.ts
+++ b/test/unit/infrastructure/reports/report-query-repository-contract.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const repositoryPath =
+  "server/features/reports/infrastructure/report-query-repository.ts";
+const source = readFileSync(resolve(root, repositoryPath), "utf8").replace(
+  /\r\n/g,
+  "\n",
+);
+
+test("M40 repository es owner unico de las ocho queries", () => {
+  for (const marker of [
+    "findClinicScopedReportById",
+    "getReportStatusHistory",
+    "listReportsByClinicId",
+    "countReportsByClinicId",
+    "searchReports",
+    "countSearchReports",
+    "getReportStudyTypes",
+    "getStudyTypes",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+
+  assert.equal(source.includes("../application/"), false);
+  assert.equal(source.includes("../composition/"), false);
+  assert.ok(source.includes('from "drizzle-orm"'));
+});
+
+test("M40 lookup e history conservan scoping limit y orden", () => {
+  for (const marker of [
+    "eq(reports.id, reportId)",
+    "eq(reports.clinicId, clinicId)",
+    ".limit(1)",
+    "eq(reportStatusHistory.reportId, reportId)",
+    "desc(reportStatusHistory.createdAt)",
+    "desc(reportStatusHistory.id)",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+});
+
+test("M40 list conserva filtros orden limit y offset", () => {
+  for (const marker of [
+    "eq(reports.clinicId, clinicId)",
+    "eq(reports.currentStatus, currentStatus)",
+    ".orderBy(desc(reports.createdAt))",
+    ".limit(limit)",
+    ".offset(offset)",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+});
+
+test("M40 search y count comparten filtros exactos", () => {
+  assert.equal(source.match(/buildSearchFilters\(/g)?.length, 3);
+  for (const marker of [
+    "eq(reports.studyType, studyType)",
+    'ilike(reports.patientName, "%" + query + "%")',
+    'ilike(reports.fileName, "%" + query + "%")',
+    'ilike(reports.studyType, "%" + query + "%")',
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+});
+
+test("M40 counts y catalogo conservan semantica legacy", () => {
+  assert.equal(source.match(/sql<string>`count\(\*\)`/g)?.length, 2);
+  assert.equal(
+    source.match(/Number\(result\[0\]\?\.value \?\? 0\)/g)?.length,
+    2,
+  );
+  assert.ok(source.includes("getCanonicalReportStudyTypes()"));
+  assert.equal(source.includes("selectDistinct"), false);
+});


### PR DESCRIPTION
## Summary

- Change type: backend architecture refactor
- Context / issue: M40 Reports query use cases and clinic thin routes
- What changed:
  - materializes the Reports query repository port, application use cases, Drizzle repository and lazy composition boundary
  - moves the general Reports reads from `server/db.ts` into Reports infrastructure while preserving temporary compatibility reexports
  - converts the clinic Reports read and status routes into thin HTTP adapters
  - routes default status transitions through the M38 application command and compare-and-set repository
  - preserves the ordered double registration of `/api/reports`
  - realigns architecture, security, audit, ownership and catalog guards to the canonical M40 owners

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Tests and documentation changed only as supporting evidence for the single backend-runtime scope.

## HTTP and behavioral compatibility

- preserves every existing `OPTIONS`, `GET` and `PATCH` endpoint under `/api/reports`
- preserves `ReportsNativeRoutesOptions` and `ReportsStatusNativeRoutesOptions`
- preserves clinic authentication, authorization, cookies and session last-access behavior
- preserves CORS, trusted-origin ordering, preflight headers, status codes, payloads and messages
- preserves pagination defaults, search filters, study-type catalog and safe report serialization
- preserves audit event, metadata and write-before-audit ordering for status transitions
- preserves clinic-scoped ownership checks and cross-tenant rejection
- preserves the registration order: `reportsNativeRoutes` before `reportsStatusNativeRoutes`
- leaves `server/fastify-app.ts` unchanged
- leaves M36-M39 behavior intact and keeps all M41 compatibility shims present

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected) - not applicable
- [ ] `pnpm --dir frontend typecheck` (if frontend affected) - not applicable
- [ ] `pnpm --dir frontend build` (if frontend affected) - not applicable
- [x] `pnpm audit --prod` (if dependencies affected)
- [x] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Additional observed validation:

- M40 application, infrastructure and architecture tests: 19/19 passed
- clinic Reports read/status integrations: 29/29 passed
- Reports architecture cohort: 79/79 passed
- focused security/audit contracts: 55/55 passed
- cumulative M36-M40 cohort: 301/301 passed
- `pnpm validate:local`: 3,848 passed, 1 skipped, 0 failed; build completed
- `pnpm security:public-surface`: passed with no public findings
- `git diff --check`: passed
- final scope review: passed with no frontend, schema, migration, dependency, workflow or out-of-scope artifacts

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Scope exclusions

- schema: NOT_RUN
- migrations: NOT_RUN
- DB real: NOT_RUN
- Playwright: NOT_RUN
- frontend: NOT_RUN
- staging: NOT_RUN
- production: NOT_RUN
- M41: NOT_RUN

## Rollback

- Trigger: regression in Reports listing, search, study types, history, signed URL access, status transitions, clinic ownership, authentication, authorization, audit ordering or an existing HTTP contract.
- Steps: revert the M40 commit, restoring the general Reports query implementations in `server/db.ts` and the previous coordination in both clinic Reports routes. Remove the M40 query port, use cases, repository, composition, tests, guards and documentation realignments.
- Data impact: none expected. M40 contains no schema migration, data migration, dependency update or persisted-data transformation.