### PR TITLE
refactor(reports): retire compatibility shims

### DIFF
--- a/docs/implementation/m41-reports-compatibility-shim-retirement.md
+++ b/docs/implementation/m41-reports-compatibility-shim-retirement.md
@@ -1,0 +1,219 @@
+# M41 — Reports compatibility shim retirement
+
+## Identificación
+
+- Milestone: M41, cierre de Fase I Reports.
+- Rama:
+  `refactor/backend-modularization-m41-reports-compatibility-shim-retirement`.
+- Baseline exacto:
+  `791b526b10e66b2d48265b10f83ca2c06815822e`.
+- Predecesor: M40 / PR #1579 / squash merge
+  `791b526b10e66b2d48265b10f83ca2c06815822e`.
+- Riesgo: R2 estructural backend autorizado específicamente para M41.
+- Git/GitHub: stage, commit, amend, push, PR y merge reservados a Nico.
+
+## Objetivo y scope
+
+M41 retira la capa temporal de compatibilidad acumulada en M36–M40. La
+arquitectura runtime queda:
+
+```text
+HTTP routes
+  → Reports composition
+    → Reports application
+      → Reports ports
+        → Reports infrastructure
+```
+
+El cambio elimina cinco forwarding modules, quita todos los reexports Reports
+de `server/db.ts`, migra los consumidores residuales al owner canónico y
+endurece los guards M36–M40. No modifica endpoints, Options, payloads, status
+codes, mensajes, CORS, trusted origin, cookies, auth, permisos, aislamiento,
+session last-access, timing, logging, serialización, auditoría, storage,
+transiciones ni compare-and-set.
+
+## Censo inicial
+
+Paths de compatibilidad presentes al inicio:
+
+1. `server/db-report-workflow.ts`;
+2. `server/lib/report-workflow-communication.ts`;
+3. `server/lib/report-status.ts`;
+4. `server/lib/report-study-types.ts`;
+5. `server/lib/reports.ts`.
+
+`server/db.ts` reexportaba once nombres Reports: ocho operaciones query M40,
+dos operaciones command M38 y `updateReportStatus` desde composition.
+
+Consumidores runtime que todavía obtenían Reports como propiedades de
+`server/db.ts`: seis archivos, con siete edges:
+
+- `server/routes/admin-report-access-tokens.fastify.ts`:
+  `getReportById`;
+- `server/routes/admin-study-tracking.fastify.ts`: `getReportById`;
+- `server/routes/particular-auth.fastify.ts`:
+  `getClinicScopedReportById`;
+- `server/routes/report-access-tokens.fastify.ts`:
+  `getClinicScopedReportById`;
+- `server/routes/study-tracking.fastify.ts`:
+  `getClinicScopedReportById`;
+- `server/features/particular-access/particular-access-route-composition.ts`:
+  `getReportById` y `getClinicScopedReportById`.
+
+Un test de integración importaba el tipo `AdminReportWorkflowItem` desde el
+shim raíz. Los demás matches de paths legacy eran anchors source-aware o
+documentación histórica, no consumidores runtime.
+
+## Consumidores migrados y owners finales
+
+Los seis consumidores runtime resuelven ahora
+`server/features/reports/composition/index.ts`:
+
+- reads sin scope administrativo → `report-command-composition.ts` →
+  `findReportById` application → command port → command repository;
+- reads clinic-scoped cross-context → `report-command-composition.ts` →
+  `findClinicScopedReportById` application → command port → command repository.
+
+La inyección por Options permanece intacta. El test de workflow importa su
+tipo desde `server/features/reports/infrastructure/index.ts`.
+
+## Compatibilidad retirada
+
+Eliminados:
+
+- `server/db-report-workflow.ts`;
+- `server/lib/report-workflow-communication.ts`;
+- `server/lib/report-status.ts`;
+- `server/lib/report-study-types.ts`;
+- `server/lib/reports.ts`.
+
+Retirado de `server/db.ts`:
+
+- `countReportsByClinicId`;
+- `countSearchReports`;
+- `getClinicScopedReportById`;
+- `getReportsByClinicId`;
+- `getReportStatusHistory`;
+- `getReportById`;
+- `getReportStudyTypes`;
+- `getStudyTypes`;
+- `searchReports`;
+- `upsertReport`;
+- `updateReportStatus`.
+
+También se retiraron adapters públicos cuyo único propósito era sostener esos
+forwarders: `updateReportStatus` de command composition, los wrappers
+`getReportById`/`upsertReport` de command infrastructure y las cuatro
+operaciones standalone de workflow route composition. Los owners factories y
+casos de uso permanecen.
+
+## Arquitectura antes y después
+
+Antes:
+
+```text
+consumer → server/db.ts → Reports infrastructure/composition
+consumer → shim → Reports barrel canónico
+```
+
+Después:
+
+```text
+consumer/route → Reports composition → application → port → infrastructure
+```
+
+`server/db.ts` vuelve a ser exclusivamente el kernel compartido de conexión y
+operaciones de otros bounded contexts; no importa, exporta ni cataloga Reports.
+
+## Clasificación A/B/C
+
+- A — anchors source-aware realineados: guards M36, M37, M38, M39 y M40;
+  catálogo de study types; persistencia command; workflow communication;
+  registry de suite; import type del workflow.
+- B — guard específico nuevo:
+  `test/architecture/reports-compatibility-shim-retirement.test.ts`.
+- C — contratos de comportamiento preservados: domain, command/query use
+  cases, route service, workflow communication, repositories, adapters,
+  integraciones admin/clínica, auth/autorización, CORS, sesión, timing/logging,
+  auditoría, CAS, ownership/IDOR, disclosure, catálogo y closeouts M34/M35b.
+
+No se eliminaron assertions conductuales ni se redujeron conteos. Los cambios
+de A invierten únicamente la expectativa temporal de compatibilidad.
+
+## Guard M41
+
+El guard exige:
+
+- ausencia física de los cinco shims;
+- ausencia de Reports en `server/db.ts`;
+- cero imports estáticos, dinámicos o `require` a paths retirados;
+- consumidores residuales apuntando a composition;
+- barrels exactos por capa;
+- application default-deny;
+- Drizzle en infrastructure y cero imports runtime ascendentes;
+- composition como único bridge application/infrastructure;
+- rutas Reports thin;
+- doble registro `/api/reports` en orden;
+- inventarios M36–M40 completos;
+- cero reemplazos `compat`, `legacy`, `shim` o forwarding modules.
+
+## Contratos preservados
+
+Se preservan los cuatro módulos de rutas Reports, su orden de registro y todos
+los contratos HTTP. Los reads cross-context mantienen las mismas funciones y
+valores `null`/`undefined` observables mediante el wiring default; las Options
+inyectadas no cambian. Persistencia, SQL, transacciones, historial, CAS, orden
+de auditoría/notificación y signed URLs no se reescriben.
+
+## Validación
+
+| Gate | Estado | Evidencia |
+| --- | --- | --- |
+| guard M41 aislado | PASSED | exit 0; 9/9 |
+| guards M36–M41, suite Reports y security completeness | PASSED | exit 0; 68/68 |
+| cohorte dirigida Reports | PASSED | exit 0; 200/200 |
+| contratos de seguridad y auditoría | PASSED | exit 0; 241/241 |
+| `pnpm typecheck` | PASSED | exit 0 |
+| `pnpm typecheck:test` | PASSED | exit 0 |
+| `pnpm validate:local` | PASSED | exit 0; 3859 pass, 1 skip, 0 fail; build exitoso |
+| `pnpm security:public-surface` | PASSED | exit 0; cero findings públicos |
+| `pnpm audit --prod` | PASSED | exit 0; cero vulnerabilidades conocidas |
+| `pnpm audit` | PASSED | exit 0; cero vulnerabilidades conocidas |
+| `git diff --check` | PASSED | exit 0 |
+
+Fail-fast detectó y corrigió tres grupos de contratos:
+
+1. dos anchors M39/M40 todavía exigían wrappers retirados por M41;
+2. el primer lookup clinic-scoped devolvía una proyección M40 incompleta para
+   consumidores cross-context; se movió a command application/composition
+   sobre el agregado completo;
+3. guards históricos M32–M35b y su registry conservaban hashes/nombres/cutoff
+   anteriores a la migración autorizada M41.
+
+Cada gate fallido se corrigió y reintentó antes de continuar. El tercer intento
+de `validate:local` pasó completo.
+
+## Exclusiones
+
+Frontend, Playwright, schema, migraciones, DB real, dependencias, lockfiles,
+CI, workflows, staging, producción, dev servers, watchers y
+`server/fastify-app.ts` quedan fuera del diff. No se inicia otro milestone.
+
+## Riesgos y rollback
+
+Riesgo residual esperado: anchors source-aware externos a la cohorte Reports o
+un consumidor default omitido por el censo inicial. El guard M41 resuelve
+imports y la suite global cubre ambos riesgos.
+
+Rollback estructural: restaurar los cinco shims y los reexports de
+`server/db.ts`, devolver los siete edges runtime a `db`, restaurar los adapters
+compatibility retirados y revertir los anchors M41. No requiere schema,
+migraciones, datos ni compensación de side effects.
+
+## Estado
+
+- M41: implementación local completa.
+- Fase I Reports: compatibilidad temporal retirada; gates funcionales,
+  arquitectónicos, seguridad, auditoría, compilación y build en PASSED.
+- Siguiente milestone: `NOT_RUN`.
+- Commit, amend, push, PR y merge: `NOT_RUN`.

--- a/server/db-report-workflow.ts
+++ b/server/db-report-workflow.ts
@@ -1,8 +1,0 @@
-// Shim temporal de compatibilidad. Retiro previsto para M41.
-export type { AdminReportWorkflowItem } from "./features/reports/infrastructure/index.ts";
-export {
-  getAdminReportWorkflowItem,
-  listAdminReportWorkflowItems,
-  updateAdminReportSpecialStain,
-  updateAdminReportWorkflowStage,
-} from "./features/reports/composition/index.ts";

--- a/server/db.ts
+++ b/server/db.ts
@@ -15,21 +15,6 @@ import {
 } from "../drizzle/schema.ts";
 import { ENV } from "./lib/env.ts";
 import { normalizeClinicUserRole } from "./lib/permissions.ts";
-export {
-  countReportsByClinicId,
-  countSearchReports,
-  getClinicScopedReportById,
-  getReportsByClinicId,
-  getReportStatusHistory,
-  getReportById,
-  getReportStudyTypes,
-  getStudyTypes,
-  searchReports,
-  upsertReport,
-} from "./features/reports/infrastructure/index.ts";
-export {
-  updateReportStatus,
-} from "./features/reports/composition/index.ts";
 
 const client = postgres(ENV.databaseUrl, {
   prepare: false,

--- a/server/features/particular-access/particular-access-route-composition.ts
+++ b/server/features/particular-access/particular-access-route-composition.ts
@@ -7,12 +7,14 @@ export async function loadAdminParticularAccessRouteDeps() {
     repository,
     email,
     studyTracking,
+    reportCommands,
   ] = await Promise.all([
     import("../../db.ts"),
     import("../../lib/auth-security.ts"),
     import("./infrastructure/index.ts"),
     import("../../lib/email.ts"),
     loadParticularAccessStudyTrackingPersistence(),
+    import("../reports/composition/index.ts"),
   ]);
 
   return {
@@ -23,7 +25,7 @@ export async function loadAdminParticularAccessRouteDeps() {
     generateSessionToken: authSecurity.generateSessionToken,
     hashSessionToken: authSecurity.hashSessionToken,
     getClinicById: db.getClinicById,
-    getReportById: db.getReportById,
+    getReportById: reportCommands.getReportById,
     createParticularToken: repository.createParticularToken,
     getParticularTokenById: repository.getParticularTokenById,
     listParticularTokens: repository.listParticularTokens,
@@ -42,12 +44,14 @@ export async function loadClinicParticularAccessRouteDeps() {
     repository,
     email,
     studyTracking,
+    reportCommands,
   ] = await Promise.all([
     import("../../db.ts"),
     import("../../lib/auth-security.ts"),
     import("./infrastructure/index.ts"),
     import("../../lib/email.ts"),
     loadParticularAccessStudyTrackingPersistence(),
+    import("../reports/composition/index.ts"),
   ]);
 
   return {
@@ -57,7 +61,7 @@ export async function loadClinicParticularAccessRouteDeps() {
     updateSessionLastAccess: db.updateSessionLastAccess,
     generateSessionToken: authSecurity.generateSessionToken,
     hashSessionToken: authSecurity.hashSessionToken,
-    getClinicScopedReportById: db.getClinicScopedReportById,
+    getClinicScopedReportById: reportCommands.getClinicScopedReportById,
     createParticularToken: repository.createParticularToken,
     getClinicScopedParticularToken:
       repository.getClinicScopedParticularToken,

--- a/server/features/reports/README.md
+++ b/server/features/reports/README.md
@@ -3,7 +3,8 @@
 M36 estableció la frontera de dominio, M37 desacopló la comunicación interna
 del workflow, M38 agregó los comandos de creación/edición y transición de
 estado, M39 adelgazó las rutas administrativas y M40 materializa queries y
-adelgaza las rutas clínicas.
+adelgazó las rutas clínicas. M41 retiró la compatibilidad temporal: los cinco
+shims legacy ya no existen y `server/db.ts` dejó de exportar Reports.
 
 ## Superficie disponible
 
@@ -28,13 +29,10 @@ los puertos y concentra DB, Drizzle, tablas Reports, transacciones, SQL de
 historial y persistencia del workflow. Composition es el único bridge
 application → infrastructure y carga defaults concretos de forma lazy.
 
-`server/lib/report-workflow-communication.ts` y
-`server/db-report-workflow.ts` permanecen como shims temporales hasta M41.
-`server/db.ts` reexporta temporalmente commands y las ocho queries M40 desde
-infrastructure. `updateReportStatus` atraviesa composition y application, que
-agrega `expectedFromStatus`, antes del UPDATE compare-and-set. Las rutas
-administrativas y clínicas conservan Options y contratos HTTP; las clínicas
-delegan listado, búsqueda, catálogo, ownership, historial, signed URLs y
-transición a `report-query-use-cases.ts`.
+Los consumidores runtime resuelven Reports mediante `composition/index.ts`.
+`server/db.ts` conserva únicamente infraestructura compartida ajena a Reports.
+Las rutas administrativas y clínicas mantienen Options y contratos HTTP; las
+clínicas delegan listado, búsqueda, catálogo, ownership, historial, signed URLs
+y transición a `report-query-use-cases.ts`.
 
-M41 realizará el closeout y retiro final de compatibilidad.
+La compatibilidad temporal de M36–M40 quedó cerrada en M41.

--- a/server/features/reports/application/README.md
+++ b/server/features/reports/application/README.md
@@ -17,6 +17,11 @@ garantiza que history, preview, download y transición sólo ocurran después de
 lookup tenant-scoped. La transición reutiliza el resultado M38 y no captura
 errores de infraestructura.
 
+M41 expone los lookups cross-context canónicos a través de command composition:
+`getReportById` delega al caso de uso y `getClinicScopedReportById` aplica
+ownership en application antes de devolver el agregado completo. Ningún
+consumidor obtiene estas operaciones desde `server/db.ts`.
+
 El puerto `report-command-repository.ts` contiene sólo `findReportById`,
 `createOrEditReport` y `persistReportStatusTransition`. La transición consume
 `canTransitionReportStatus` desde domain y construye `expectedFromStatus` desde

--- a/server/features/reports/application/report-command-use-cases.ts
+++ b/server/features/reports/application/report-command-use-cases.ts
@@ -29,10 +29,25 @@ export type TransitionReportStatusResult<
   | { type: "concurrent_not_found"; reportId: number }
   | { type: "persisted"; report: TReport };
 
+export async function findClinicScopedReportById<
+  TReport extends ReportCommandRecord & { clinicId: number },
+>(
+  repository: Pick<ReportCommandRepository<TReport>, "findReportById">,
+  reportId: number,
+  clinicId: number,
+): Promise<TReport | null> {
+  const report = await repository.findReportById(reportId);
+  return report?.clinicId === clinicId ? report : null;
+}
+
 export function createReportCommandUseCases<
   TReport extends ReportCommandRecord,
 >(repository: ReportCommandRepository<TReport>) {
   return {
+    findReportById(reportId: number): Promise<TReport | null | undefined> {
+      return repository.findReportById(reportId);
+    },
+
     createOrEditReport(input: CreateOrEditReportInput): Promise<TReport> {
       return repository.createOrEditReport(input);
     },

--- a/server/features/reports/composition/README.md
+++ b/server/features/reports/composition/README.md
@@ -6,9 +6,8 @@ reloj runtime. `index.ts` exporta la operación pública
 
 M38 agrega `report-command-composition.ts`: instancia el repository de comandos
 con `() => new Date()`, construye los casos de uso y exporta
-`createOrEditReport` y `transitionReportStatus` para M39/M40. También expone el
-adapter compatible `updateReportStatus`, que traduce `persisted` a la fila y
-los resultados rechazados o concurrentes a `undefined`.
+`getReportById`, `getClinicScopedReportById`, `createOrEditReport` y
+`transitionReportStatus` para los consumidores runtime.
 
 M39 agrega `report-route-composition.ts`, único bridge entre las rutas
 administrativas y los defaults concretos. Resuelve auth, audit, storage,
@@ -22,4 +21,7 @@ clínicas. Adapta sus Options históricas a los puertos M40, conserva el fallbac
 inyección completa no carga DB, storage, audit ni auth concretos.
 
 La composición construye sus dependencias de forma lazy, no consulta DB durante
-el import, no mantiene estado mutable y no importa Fastify ni rutas.
+el import, no mantiene estado mutable y no importa Fastify ni rutas. Desde M41
+command composition también publica el lookup clinic-scoped canónico para
+consumidores de otros contextos; ningún runtime depende de `server/db.ts` para
+Reports.

--- a/server/features/reports/composition/report-command-composition.ts
+++ b/server/features/reports/composition/report-command-composition.ts
@@ -1,5 +1,6 @@
 import {
   createReportCommandUseCases,
+  findClinicScopedReportById as findClinicScopedReportByIdUseCase,
   type CreateOrEditReportInput,
   type TransitionReportStatusInput,
 } from "../application/index.ts";
@@ -13,6 +14,24 @@ function createRuntimeReportCommandUseCases() {
   );
 }
 
+export async function getReportById(reportId: number) {
+  return (await createRuntimeReportCommandUseCases().findReportById(reportId)) ??
+    null;
+}
+
+export function getClinicScopedReportById(
+  reportId: number,
+  clinicId: number,
+) {
+  return findClinicScopedReportByIdUseCase(
+    createReportCommandRepository({
+      now: () => new Date(),
+    }),
+    reportId,
+    clinicId,
+  );
+}
+
 export function createOrEditReport(input: CreateOrEditReportInput) {
   return createRuntimeReportCommandUseCases().createOrEditReport(input);
 }
@@ -21,11 +40,4 @@ export function transitionReportStatus(
   input: TransitionReportStatusInput,
 ) {
   return createRuntimeReportCommandUseCases().transitionReportStatus(input);
-}
-
-export async function updateReportStatus(
-  input: TransitionReportStatusInput,
-) {
-  const result = await transitionReportStatus(input);
-  return result.type === "persisted" ? result.report : undefined;
 }

--- a/server/features/reports/composition/report-route-composition.ts
+++ b/server/features/reports/composition/report-route-composition.ts
@@ -207,7 +207,6 @@ async function loadDefaultAdminReportsDependencies() {
         particular,
         studyTracking,
         reportCommands,
-        reportCommandRepository,
       ] = await Promise.all([
         import("../../../db.ts"),
         import("../../../lib/auth-security.ts"),
@@ -216,7 +215,6 @@ async function loadDefaultAdminReportsDependencies() {
         import("../../particular-access/infrastructure/index.ts"),
         import("../../study-tracking/infrastructure/index.ts"),
         import("./report-command-composition.ts"),
-        import("../infrastructure/report-command-repository.ts"),
       ]);
 
       return {
@@ -226,7 +224,7 @@ async function loadDefaultAdminReportsDependencies() {
         updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
         hashSessionToken: authSecurity.hashSessionToken,
         getClinicById: db.getClinicById,
-        getReportById: reportCommandRepository.getReportById,
+        getReportById: reportCommands.getReportById,
         uploadReport: storage.uploadReport,
         upsertReport: reportCommands.createOrEditReport,
         getParticularTokenById: particular.getParticularTokenById,
@@ -497,38 +495,4 @@ export async function createAdminReportWorkflowRouteComposition(
     },
     service,
   };
-}
-
-export async function listAdminReportWorkflowItems(input: {
-  limit?: number;
-  offset?: number;
-} = {}) {
-  const dependencies = await loadDefaultWorkflowDependencies();
-  return dependencies.listAdminReportWorkflowItems({
-    limit: input.limit ?? 20,
-    offset: input.offset ?? 0,
-  });
-}
-
-export async function getAdminReportWorkflowItem(id: number) {
-  const dependencies = await loadDefaultWorkflowDependencies();
-  return dependencies.getAdminReportWorkflowItem(id);
-}
-
-export async function updateAdminReportWorkflowStage(
-  id: number,
-  stage: ReportWorkflowStage,
-  now: Date,
-) {
-  const dependencies = await loadDefaultWorkflowDependencies();
-  return dependencies.updateAdminReportWorkflowStage(id, stage, now);
-}
-
-export async function updateAdminReportSpecialStain(
-  id: number,
-  requested: boolean,
-  now: Date,
-) {
-  const dependencies = await loadDefaultWorkflowDependencies();
-  return dependencies.updateAdminReportSpecialStain(id, requested, now);
 }

--- a/server/features/reports/domain/README.md
+++ b/server/features/reports/domain/README.md
@@ -14,5 +14,5 @@ Inventario canónico:
 - `reports.ts`
 - `index.ts`
 
-Los paths legacy bajo `server/lib` son shims temporales de compatibilidad. Su
-retiro pertenece al censo final de Fase I, no a M36.
+M41 retiró los tres paths legacy bajo `server/lib`. El barrel canónico de esta
+capa es la única superficie de dominio Reports para consumidores externos.

--- a/server/features/reports/infrastructure/README.md
+++ b/server/features/reports/infrastructure/README.md
@@ -25,5 +25,6 @@ catálogo delega al domain canónico y no consulta DB.
 
 Esta capa es la única superficie de Reports que importa DB, Drizzle, schema y
 tablas para comandos, queries y workflow. No importa composition ni contiene
-auditoría, auth, storage o transporte HTTP. `server/db.ts` y
-`server/db-report-workflow.ts` sólo preservan compatibilidad temporal.
+auditoría, auth, storage o transporte HTTP. M41 retiró los reexports Reports de
+`server/db.ts` y eliminó `server/db-report-workflow.ts`; no queda un owner
+alternativo de persistencia.

--- a/server/features/reports/infrastructure/report-command-repository.ts
+++ b/server/features/reports/infrastructure/report-command-repository.ts
@@ -4,7 +4,6 @@ import { db } from "../../../db.ts";
 import {
   reports,
   reportStatusHistory,
-  type Report,
   type ReportStatus,
 } from "../../../../drizzle/schema.ts";
 type ReportCommandDatabase = typeof db;
@@ -246,14 +245,4 @@ export function createReportCommandRepository(dependencies?: {
       });
     },
   };
-}
-
-export function getReportById(id: number): Promise<Report> {
-  return createReportCommandRepository().findReportById(
-    id,
-  ) as Promise<Report>;
-}
-
-export function upsertReport(input: CreateOrEditReportPersistenceInput) {
-  return createReportCommandRepository().createOrEditReport(input);
 }

--- a/server/lib/report-status.ts
+++ b/server/lib/report-status.ts
@@ -1,1 +1,0 @@
-export * from "../features/reports/domain/index.ts";

--- a/server/lib/report-study-types.ts
+++ b/server/lib/report-study-types.ts
@@ -1,1 +1,0 @@
-export * from "../features/reports/domain/index.ts";

--- a/server/lib/report-workflow-communication.ts
+++ b/server/lib/report-workflow-communication.ts
@@ -1,1 +1,0 @@
-export * from "../features/reports/composition/index.ts";

--- a/server/lib/reports.ts
+++ b/server/lib/reports.ts
@@ -1,1 +1,0 @@
-export * from "../features/reports/domain/index.ts";

--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -154,6 +154,9 @@ async function loadDefaultDeps(): Promise<NativeAdminReportAccessTokensDeps> {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
+      const reportCommands = await import(
+        "../features/reports/composition/index.ts"
+      );
       const reportAccessRepository = await loadReportAccessRepository();
       const audit = await import("../lib/audit.ts");
 
@@ -165,7 +168,7 @@ async function loadDefaultDeps(): Promise<NativeAdminReportAccessTokensDeps> {
         generateSessionToken: authSecurity.generateSessionToken,
         hashSessionToken: authSecurity.hashSessionToken,
         getClinicById: db.getClinicById,
-        getReportById: db.getReportById,
+        getReportById: reportCommands.getReportById,
         createReportAccessToken:
           reportAccessRepository.createReportAccessToken,
         getReportAccessTokenById:

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -196,6 +196,9 @@ type NativeAdminStudyTrackingDeps = Required<
 async function loadDefaultDeps(): Promise<NativeAdminStudyTrackingDeps> {
   const db = await import("../db.ts");
   const authSecurity = await import("../lib/auth-security.ts");
+  const reportCommands = await import(
+    "../features/reports/composition/index.ts"
+  );
   const dbParticular = await import("../db-particular.ts");
   const email = await import("../lib/email.ts");
   const audit = await import("../lib/audit.ts");
@@ -211,7 +214,7 @@ async function loadDefaultDeps(): Promise<NativeAdminStudyTrackingDeps> {
     updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
     hashSessionToken: authSecurity.hashSessionToken,
     getClinicById: db.getClinicById,
-    getReportById: db.getReportById,
+    getReportById: reportCommands.getReportById,
     getParticularTokenById: dbParticular.getParticularTokenById,
     updateParticularTokenReport: dbParticular.updateParticularTokenReport,
     createStudyTrackingCase: persistence.createStudyTrackingCase,

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -153,6 +153,9 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDefaultDeps> {
       const dbParticular = await import("../db-particular.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const supabase = await import("../lib/supabase.ts");
+      const reportCommands = await import(
+        "../features/reports/composition/index.ts"
+      );
 
       return {
         createParticularSession: dbParticular.createParticularSession,
@@ -165,7 +168,8 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDefaultDeps> {
           dbParticular.updateParticularSessionLastAccess,
         updateParticularTokenLastLogin:
           dbParticular.updateParticularTokenLastLogin,
-        getClinicScopedReportById: db.getClinicScopedReportById,
+        getClinicScopedReportById:
+          reportCommands.getClinicScopedReportById,
         createSignedReportUrl: supabase.createSignedReportUrl,
         createSignedReportDownloadUrl:
           supabase.createSignedReportDownloadUrl,

--- a/server/routes/report-access-tokens.fastify.ts
+++ b/server/routes/report-access-tokens.fastify.ts
@@ -184,6 +184,9 @@ async function loadDefaultDeps(): Promise<NativeReportAccessTokensDeps> {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
       const authSecurity = await import("../lib/auth-security.ts");
+      const reportCommands = await import(
+        "../features/reports/composition/index.ts"
+      );
       const reportAccessRepository = await loadReportAccessRepository();
       const audit = await import("../lib/audit.ts");
 
@@ -197,7 +200,8 @@ async function loadDefaultDeps(): Promise<NativeReportAccessTokensDeps> {
         hashPassword: authSecurity.hashPassword,
         hashSessionToken: authSecurity.hashSessionToken,
         verifyPassword: authSecurity.verifyPassword,
-        getClinicScopedReportById: db.getClinicScopedReportById,
+        getClinicScopedReportById:
+          reportCommands.getClinicScopedReportById,
         createReportAccessToken:
           reportAccessRepository.createReportAccessToken,
         getClinicScopedReportAccessToken:

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -216,6 +216,9 @@ type NativeStudyTrackingDeps = Required<
 async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
   const db = await import("../db.ts");
   const authSecurity = await import("../lib/auth-security.ts");
+  const reportCommands = await import(
+    "../features/reports/composition/index.ts"
+  );
   const dbParticular = await import("../db-particular.ts");
   const email = await import("../lib/email.ts");
   const audit = await import("../lib/audit.ts");
@@ -231,7 +234,7 @@ async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
     updateSessionLastAccess: db.updateSessionLastAccess,
     hashSessionToken: authSecurity.hashSessionToken,
     getClinicById: db.getClinicById,
-    getClinicScopedReportById: db.getClinicScopedReportById,
+    getClinicScopedReportById: reportCommands.getClinicScopedReportById,
     getParticularTokenById: dbParticular.getParticularTokenById,
     updateParticularTokenReport: dbParticular.updateParticularTokenReport,
     ...persistence,

--- a/test/architecture/particular-access-m33-closeout.test.ts
+++ b/test/architecture/particular-access-m33-closeout.test.ts
@@ -349,10 +349,10 @@ test("shims conservan una línea y allowlists residuales exactas", () => {
   );
 });
 
-test("Auth permanece byte-identical y Reports usa composition M39", () => {
+test("Auth preserva contrato y Reports usa composition M41", () => {
   assert.equal(
     digest("server/routes/particular-auth.fastify.ts"),
-    "ae2847fd9c6dd68a13f88ad1d9672d0863741c2839c0343696dd67133e21078a",
+    "5ed5bf6f6ec6edb72983cdcfca84b283b89a3db4ff3b408349b557aa9a0d1561",
   );
   assert.equal(
     digest("server/middlewares/particular-auth.ts"),

--- a/test/architecture/reports-admin-thin-routes.test.ts
+++ b/test/architecture/reports-admin-thin-routes.test.ts
@@ -14,7 +14,7 @@ const infrastructure =
   "server/features/reports/infrastructure/db-report-workflow.ts";
 const reportsRoute = "server/routes/admin-reports.fastify.ts";
 const workflowRoute = "server/routes/admin-report-workflow.fastify.ts";
-const shim = "server/db-report-workflow.ts";
+const retiredShim = "server/db-report-workflow.ts";
 
 const m39ProductionInventory = [
   reportsRoute,
@@ -29,7 +29,6 @@ const m39ProductionInventory = [
   "server/features/reports/composition/index.ts",
   "server/features/reports/composition/README.md",
   "server/features/reports/README.md",
-  shim,
 ] as const;
 
 test("M39 materializa exactamente el inventario productivo contratado", () => {
@@ -46,7 +45,6 @@ test("M39 materializa exactamente el inventario productivo contratado", () => {
     "server/features/reports/composition/index.ts",
     "server/features/reports/composition/README.md",
     "server/features/reports/README.md",
-    shim,
   ]);
   for (const path of m39ProductionInventory) {
     assert.equal(existsSync(resolve(root, path)), true, path);
@@ -193,7 +191,7 @@ test("composition es el único bridge lazy y la inyección completa evita defaul
     "await loadDefaultAdminReportsDependencies()",
     "await loadDefaultWorkflowDependencies()",
     "reportCommands.createOrEditReport",
-    "reportCommandRepository.getReportById",
+    "reportCommands.getReportById",
     "createDbReportWorkflowRepository",
     "createReportWorkflowNotification",
   ]) {
@@ -202,28 +200,16 @@ test("composition es el único bridge lazy y la inyección completa evita defaul
   assert.equal(source.includes(" from \"../../../db.ts\""), false);
 });
 
-test("shim M41 no contiene implementación ni tiene consumidores runtime M39", () => {
-  const source = read(shim);
+test("M39 permanece canónico después del retiro del shim M41", () => {
   const reports = read(reportsRoute);
   const workflow = read(workflowRoute);
 
-  assert.ok(source.includes("Shim temporal de compatibilidad"));
-  assert.ok(source.includes("Retiro previsto para M41"));
-  for (const forbidden of [
-    "drizzle-orm",
-    "./db.ts",
-    ".select(",
-    ".update(",
-    "normalizeListPagination",
-    "console.",
-  ]) {
-    assert.equal(source.includes(forbidden), false, forbidden);
-  }
+  assert.equal(existsSync(resolve(root, retiredShim)), false);
   assert.equal(reports.includes("db-report-workflow"), false);
   assert.equal(workflow.includes("db-report-workflow"), false);
 });
 
-test("M40 queda materializado y los shims M41 siguen presentes", () => {
+test("M40 queda materializado y los cinco shims M41 siguen retirados", () => {
   assert.equal(
     existsSync(
       resolve(
@@ -240,6 +226,6 @@ test("M40 queda materializado y los shims M41 siguen presentes", () => {
     "server/lib/report-study-types.ts",
     "server/lib/reports.ts",
   ]) {
-    assert.equal(existsSync(resolve(root, path)), true, path);
+    assert.equal(existsSync(resolve(root, path)), false, path);
   }
 });

--- a/test/architecture/reports-command-use-cases-boundary-guard.test.ts
+++ b/test/architecture/reports-command-use-cases-boundary-guard.test.ts
@@ -260,7 +260,7 @@ test("infrastructure es owner único de DB transacciones tablas y SQL M38", () =
   assert.equal(repository.includes("../composition/"), false);
 });
 
-test("compatibilidad db y rutas M40 quedan conectadas por composition", () => {
+test("M38 queda canónico, db.ts se desacopla y rutas usan composition", () => {
   const database = read("server/db.ts");
   const admin = read("server/routes/admin-reports.fastify.ts");
   const status = read("server/routes/reports-status.fastify.ts");
@@ -268,35 +268,23 @@ test("compatibilidad db y rutas M40 quedan conectadas por composition", () => {
   const workflow = read("server/routes/admin-report-workflow.fastify.ts");
   const app = read("server/fastify-app.ts");
 
-  assert.ok(
-    database.includes(
-      'from "./features/reports/infrastructure/index.ts";',
-    ),
-  );
-  assert.ok(
-    database.includes(
-      'from "./features/reports/composition/index.ts";',
-    ),
-  );
-  for (const name of ["getReportById", "upsertReport"]) {
-    assert.match(
-      database,
-      new RegExp(`export \\{[\\s\\S]*?\\b${name}\\b[\\s\\S]*?\\} from`),
-    );
+  assert.equal(database.includes("features/reports"), false);
+  for (const name of [
+    "getReportById",
+    "upsertReport",
+    "updateReportStatus",
+  ]) {
+    assert.doesNotMatch(database, new RegExp(`\\b${name}\\b`), name);
   }
-  assert.match(
-    database,
-    /export \{\s*updateReportStatus,\s*\} from "\.\/features\/reports\/composition\/index\.ts";/,
-  );
   const bridge = read(`${composition}/report-command-composition.ts`);
   for (const marker of [
+    "export async function getReportById",
+    ".findReportById(reportId)",
     "export function transitionReportStatus",
-    "export async function updateReportStatus",
-    "const result = await transitionReportStatus(input)",
-    'result.type === "persisted" ? result.report : undefined',
   ]) {
     assert.ok(bridge.includes(marker), marker);
   }
+  assert.equal(bridge.includes("export async function updateReportStatus"), false);
   for (const [source, markers] of [
     [admin, ["export type AdminReportsNativeRoutesOptions", "createAdminReportsRouteComposition"]],
     [status, ["export type ReportsStatusNativeRoutesOptions", "createClinicReportStatusRouteComposition"]],

--- a/test/architecture/reports-compatibility-shim-retirement.test.ts
+++ b/test/architecture/reports-compatibility-shim-retirement.test.ts
@@ -1,0 +1,374 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const root = process.cwd();
+const feature = "server/features/reports";
+const domain = `${feature}/domain`;
+const application = `${feature}/application`;
+const infrastructure = `${feature}/infrastructure`;
+const composition = `${feature}/composition`;
+
+const retiredPaths = [
+  "server/db-report-workflow.ts",
+  "server/lib/report-workflow-communication.ts",
+  "server/lib/report-status.ts",
+  "server/lib/report-study-types.ts",
+  "server/lib/reports.ts",
+] as const;
+
+const reportDbExports = [
+  "countReportsByClinicId",
+  "countSearchReports",
+  "getClinicScopedReportById",
+  "getReportsByClinicId",
+  "getReportStatusHistory",
+  "getReportById",
+  "getReportStudyTypes",
+  "getStudyTypes",
+  "searchReports",
+  "upsertReport",
+  "updateReportStatus",
+] as const;
+
+type ImportReference = {
+  specifier: string;
+  typeOnly: boolean;
+};
+
+function read(path: string): string {
+  return readFileSync(resolve(root, path), "utf8")
+    .replace(/^\uFEFF/, "")
+    .replace(/\r\n/g, "\n");
+}
+
+function repoPath(path: string): string {
+  return path.replaceAll("\\", "/");
+}
+
+function walk(directory: string): string[] {
+  const absolute = resolve(root, directory);
+  if (!existsSync(absolute)) {
+    return [];
+  }
+
+  return readdirSync(absolute, { withFileTypes: true }).flatMap((entry) => {
+    const path = `${directory}/${entry.name}`;
+    return entry.isDirectory() ? walk(path) : [path];
+  });
+}
+
+function imports(path: string): ImportReference[] {
+  const source = ts.createSourceFile(
+    path,
+    read(path),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const result: ImportReference[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      (ts.isImportDeclaration(node) || ts.isExportDeclaration(node)) &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      result.push({
+        specifier: node.moduleSpecifier.text,
+        typeOnly:
+          ts.isImportDeclaration(node) &&
+          !!node.importClause?.isTypeOnly,
+      });
+    }
+
+    if (
+      ts.isCallExpression(node) &&
+      (node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) &&
+          node.expression.text === "require"))
+    ) {
+      const argument = node.arguments[0];
+      if (argument && ts.isStringLiteral(argument)) {
+        result.push({ specifier: argument.text, typeOnly: false });
+      }
+    }
+
+    node.forEachChild(visit);
+  }
+
+  visit(source);
+  return result;
+}
+
+function target(path: string, specifier: string): string {
+  if (!specifier.startsWith(".")) {
+    return specifier;
+  }
+
+  const normalized = repoPath(
+    relative(root, resolve(root, dirname(path), specifier)),
+  );
+
+  if (normalized.endsWith(".ts")) {
+    return normalized;
+  }
+  if (existsSync(resolve(root, `${normalized}.ts`))) {
+    return `${normalized}.ts`;
+  }
+  return existsSync(resolve(root, `${normalized}/index.ts`))
+    ? `${normalized}/index.ts`
+    : normalized;
+}
+
+test("M41 retira físicamente los cinco shims sin reemplazos forwarding", () => {
+  for (const path of retiredPaths) {
+    assert.equal(existsSync(resolve(root, path)), false, path);
+  }
+
+  const reportFiles = walk(feature).filter((path) => path.endsWith(".ts"));
+  for (const path of reportFiles) {
+    assert.doesNotMatch(path, /(?:compat|legacy|shim)/i, path);
+    if (!path.endsWith("/index.ts")) {
+      assert.doesNotMatch(
+        read(path).trim(),
+        /^export \* from ["'][^"']+["'];?$/,
+        path,
+      );
+    }
+  }
+});
+
+test("M41 elimina todos los exports y ownership Reports de server/db.ts", () => {
+  const source = read("server/db.ts");
+
+  assert.equal(source.includes("features/reports"), false);
+  assert.equal(source.includes("/* ========================= REPORTS"), false);
+  assert.equal(source.includes("report-status"), false);
+  assert.equal(source.includes("report-study-types"), false);
+  assert.equal(source.includes("report-workflow"), false);
+
+  for (const name of reportDbExports) {
+    assert.doesNotMatch(source, new RegExp(`\\b${name}\\b`), name);
+  }
+});
+
+test("M41 deja cero imports estáticos dinámicos o require a paths retirados", () => {
+  const violations: string[] = [];
+
+  for (const base of ["server", "test", "scripts"]) {
+    for (const path of walk(base).filter((file) => file.endsWith(".ts"))) {
+      for (const reference of imports(path)) {
+        const resolved = target(path, reference.specifier);
+        if (retiredPaths.includes(resolved as (typeof retiredPaths)[number])) {
+          violations.push(`${path}: ${reference.specifier} -> ${resolved}`);
+        }
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("consumidores runtime migrados resuelven Reports por composition", () => {
+  const consumers = [
+    "server/routes/admin-report-access-tokens.fastify.ts",
+    "server/routes/admin-study-tracking.fastify.ts",
+    "server/routes/particular-auth.fastify.ts",
+    "server/routes/report-access-tokens.fastify.ts",
+    "server/routes/study-tracking.fastify.ts",
+    "server/features/particular-access/particular-access-route-composition.ts",
+  ] as const;
+
+  for (const path of consumers) {
+    const source = read(path);
+    const targets = imports(path).map((reference) =>
+      target(path, reference.specifier)
+    );
+
+    assert.ok(targets.includes(`${composition}/index.ts`), path);
+    assert.doesNotMatch(
+      source,
+      /\bdb\.(?:getReportById|getClinicScopedReportById)\b/,
+      path,
+    );
+  }
+
+  const commandBridge = read(`${composition}/report-command-composition.ts`);
+  assert.ok(commandBridge.includes("export async function getReportById"));
+  assert.ok(commandBridge.includes(".findReportById(reportId)"));
+  assert.ok(
+    commandBridge.includes("export function getClinicScopedReportById"),
+  );
+  assert.ok(commandBridge.includes("findClinicScopedReportByIdUseCase("));
+});
+
+test("barrels Reports exportan sólo módulos canónicos de sus capas", () => {
+  const expected = new Map<string, readonly string[]>([
+    [
+      `${domain}/index.ts`,
+      [
+        'export * from "./report-status.ts";',
+        'export * from "./report-study-types.ts";',
+        'export * from "./reports.ts";',
+      ],
+    ],
+    [
+      `${application}/index.ts`,
+      [
+        'export * from "./ports/index.ts";',
+        'export * from "./report-command-use-cases.ts";',
+        'export * from "./report-query-use-cases.ts";',
+        'export * from "./report-route-service.ts";',
+        'export * from "./report-workflow-communication.ts";',
+      ],
+    ],
+    [
+      `${infrastructure}/index.ts`,
+      [
+        'export * from "./db-report-workflow.ts";',
+        'export * from "./report-command-repository.ts";',
+        'export * from "./report-query-repository.ts";',
+        'export * from "./report-workflow-data-adapter.ts";',
+        'export * from "./report-workflow-notification-adapter.ts";',
+      ],
+    ],
+    [
+      `${composition}/index.ts`,
+      [
+        'export * from "./report-command-composition.ts";',
+        'export * from "./report-query-composition.ts";',
+        'export * from "./report-route-composition.ts";',
+        'export * from "./report-workflow-communication-composition.ts";',
+      ],
+    ],
+  ]);
+
+  for (const [path, lines] of expected) {
+    assert.deepEqual(
+      read(path).trim().split("\n"),
+      lines,
+      path,
+    );
+  }
+});
+
+test("application mantiene default deny e infrastructure conserva Drizzle", () => {
+  const applicationViolations: string[] = [];
+  for (const path of walk(application).filter((file) => file.endsWith(".ts"))) {
+    for (const reference of imports(path)) {
+      const resolved = target(path, reference.specifier);
+      if (
+        !resolved.startsWith(`${application}/`) &&
+        resolved !== `${domain}/index.ts`
+      ) {
+        applicationViolations.push(`${path}: ${reference.specifier}`);
+      }
+    }
+  }
+  assert.deepEqual(applicationViolations, []);
+
+  const infrastructureFiles = walk(infrastructure).filter((path) =>
+    path.endsWith(".ts")
+  );
+  assert.ok(
+    infrastructureFiles.some((path) =>
+      imports(path).some((reference) => reference.specifier === "drizzle-orm")
+    ),
+  );
+
+  const runtimeUpwardImports = infrastructureFiles.flatMap((path) =>
+    imports(path)
+      .filter((reference) => !reference.typeOnly)
+      .map((reference) => target(path, reference.specifier))
+      .filter((resolved) =>
+        resolved.startsWith(`${application}/`) ||
+        resolved.startsWith(`${composition}/`)
+      )
+      .map((resolved) => `${path}: ${resolved}`)
+  );
+  assert.deepEqual(runtimeUpwardImports, []);
+});
+
+test("composition sigue siendo el único bridge Reports entre application e infrastructure", () => {
+  const bridges = walk(feature)
+    .filter((path) => path.endsWith(".ts"))
+    .filter((path) => {
+      const targets = imports(path).map((reference) =>
+        target(path, reference.specifier)
+      );
+      return (
+        targets.some((resolved) => resolved.startsWith(`${application}/`)) &&
+        targets.some((resolved) => resolved.startsWith(`${infrastructure}/`))
+      );
+    })
+    .sort();
+
+  assert.deepEqual(bridges, [
+    `${composition}/report-command-composition.ts`,
+    `${composition}/report-query-composition.ts`,
+    `${composition}/report-route-composition.ts`,
+    `${composition}/report-workflow-communication-composition.ts`,
+  ]);
+});
+
+test("rutas Reports siguen thin y preservan el doble registro ordenado", () => {
+  for (const path of [
+    "server/routes/admin-reports.fastify.ts",
+    "server/routes/admin-report-workflow.fastify.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/reports-status.fastify.ts",
+  ]) {
+    const source = read(path);
+    const runtimeTargets = imports(path)
+      .filter((reference) => !reference.typeOnly)
+      .map((reference) => target(path, reference.specifier));
+
+    assert.ok(runtimeTargets.includes(`${composition}/index.ts`), path);
+    assert.equal(source.includes("drizzle-orm"), false, path);
+    assert.equal(source.includes(".select("), false, path);
+    assert.equal(source.includes(".insert("), false, path);
+    assert.equal(source.includes(".update("), false, path);
+  }
+
+  const app = read("server/fastify-app.ts");
+  const registrations = Array.from(
+    app.matchAll(
+      /app\.register\(\s*(reportsNativeRoutes|reportsStatusNativeRoutes),\s*\{\s*prefix:\s*"([^"]+)"/g,
+    ),
+    (match) => [match[1], match[2]],
+  );
+  assert.deepEqual(registrations, [
+    ["reportsNativeRoutes", "/api/reports"],
+    ["reportsStatusNativeRoutes", "/api/reports"],
+  ]);
+});
+
+test("M36 a M40 permanecen materializados sin reducir inventarios", () => {
+  const expectedCounts = new Map<string, number>([
+    [domain, 4],
+    [application, 10],
+    [infrastructure, 6],
+    [composition, 5],
+  ]);
+
+  for (const [directory, count] of expectedCounts) {
+    assert.equal(
+      walk(directory).filter((path) => path.endsWith(".ts")).length,
+      count,
+      directory,
+    );
+  }
+
+  for (const path of [
+    "docs/implementation/m36-reports-domain-moves-catalog-census.md",
+    "docs/implementation/m37-reports-workflow-data-notification-ports.md",
+    "docs/implementation/m38-reports-create-edit-transition-use-cases.md",
+    "docs/implementation/m39-reports-admin-thin-routes-workflow.md",
+    "docs/implementation/m40-reports-query-use-cases-thin-routes.md",
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
+});

--- a/test/architecture/reports-domain-boundary-guard.test.ts
+++ b/test/architecture/reports-domain-boundary-guard.test.ts
@@ -18,7 +18,7 @@ const domainFiles = [
   reportsFile,
 ] as const;
 
-const legacyShimFiles = [
+const retiredShimFiles = [
   "server/lib/report-status.ts",
   "server/lib/report-study-types.ts",
   "server/lib/reports.ts",
@@ -212,31 +212,21 @@ test("los tres módulos canónicos contienen implementación real y exports pres
   assert.equal(readText(reportsFile).includes("storagePath:"), false);
 });
 
-test("los tres shims legacy existen y son reexports exactos de una línea", () => {
-  for (const file of legacyShimFiles) {
-    assert.equal(existsSync(join(repoRoot, file)), true, `${file} must exist in M36`);
-    assert.equal(
-      readText(file).trim(),
-      'export * from "../features/reports/domain/index.ts";',
-      file,
-    );
-    assert.equal(readText(file).trim().split("\n").length, 1, file);
+test("los tres shims legacy de dominio permanecen retirados por M41", () => {
+  for (const file of retiredShimFiles) {
+    assert.equal(existsSync(join(repoRoot, file)), false, file);
   }
 });
 
-test("ningún consumidor runtime ni test de comportamiento importa los shims", () => {
+test("ningún consumidor runtime ni test de comportamiento importa paths retirados", () => {
   const violations: string[] = [];
 
   for (const root of ["server", "test"] as const) {
     for (const file of walkTsFiles(root)) {
-      if (legacyShimFiles.includes(file as (typeof legacyShimFiles)[number])) {
-        continue;
-      }
-
       for (const { specifier } of listImportReferences(readText(file))) {
         const target = resolveSpecifier(file, specifier);
 
-        if (legacyShimFiles.includes(target as (typeof legacyShimFiles)[number])) {
+        if (retiredShimFiles.includes(target as (typeof retiredShimFiles)[number])) {
           violations.push(`${file}: import legacy "${specifier}" -> ${target}`);
         }
       }
@@ -343,7 +333,7 @@ test("domain no contiene transporte infraestructura I/O ni side effects", () => 
   assert.deepEqual(violations, []);
 });
 
-test("M37 a M40 quedan fuera del dominio y M40 está materializado", () => {
+test("M37 a M40 quedan fuera del dominio y M41 retira sus shims", () => {
   for (const path of [
     `${featureDir}/application`,
     `${featureDir}/infrastructure`,
@@ -356,7 +346,7 @@ test("M37 a M40 quedan fuera del dominio y M40 está materializado", () => {
     "server/lib/report-workflow-communication.ts",
     "server/db-report-workflow.ts",
   ]) {
-    assert.equal(existsSync(join(repoRoot, path)), true, `${path} must remain outside domain`);
+    assert.equal(existsSync(join(repoRoot, path)), false, path);
   }
 
   for (const file of walkTsFiles(domainDir)) {
@@ -513,7 +503,7 @@ test("fastify app conserva el registro Reports M36 sin consumir capas M37", () =
   assert.deepEqual(forbiddenImports, []);
 });
 
-test("censo path-aware apunta al catálogo canónico y conserva los shims M36", () => {
+test("censo path-aware apunta al catálogo canónico y fija ausencia M41", () => {
   const source = readText(
     "test/unit/contracts/reports/report-study-types-catalog.test.ts",
   );
@@ -526,7 +516,7 @@ test("censo path-aware apunta al catálogo canónico y conserva los shims M36", 
   assert.ok(source.includes('"server/features/reports/domain/index.ts"'));
   assert.ok(source.includes('"server/lib/report-study-types.ts"'));
 
-  for (const shim of legacyShimFiles) {
-    assert.equal(existsSync(join(repoRoot, shim)), true, shim);
+  for (const shim of retiredShimFiles) {
+    assert.equal(existsSync(join(repoRoot, shim)), false, shim);
   }
 });

--- a/test/architecture/reports-query-use-cases-boundary-guard.test.ts
+++ b/test/architecture/reports-query-use-cases-boundary-guard.test.ts
@@ -107,11 +107,9 @@ test("M40 composition es bridge lazy unico y rutas quedan thin", () => {
   }
 });
 
-test("M40 db.ts conserva solo reexports compatibility de queries", () => {
+test("M40 conserva queries canónicas y M41 retira sus reexports de db.ts", () => {
   const db = read("server/db.ts");
-  const reportsSection = db.slice(
-    db.indexOf("/* ========================= REPORTS"),
-  );
+  const repositorySource = read(repository);
 
   for (const name of [
     "getClinicScopedReportById",
@@ -123,16 +121,12 @@ test("M40 db.ts conserva solo reexports compatibility de queries", () => {
     "getReportStudyTypes",
     "getStudyTypes",
   ]) {
-    assert.match(db, new RegExp(`\\b${name}\\b`), name);
-    assert.equal(
-      reportsSection.includes(`function ${name}`),
-      false,
-      name,
-    );
+    assert.match(repositorySource, new RegExp(`\\b${name}\\b`), name);
+    assert.doesNotMatch(db, new RegExp(`\\b${name}\\b`), name);
   }
 
-  assert.equal(reportsSection.includes(".select("), false);
-  assert.equal(reportsSection.includes("count(*)"), false);
+  assert.equal(db.includes("features/reports"), false);
+  assert.equal(db.includes("/* ========================= REPORTS"), false);
 });
 
 test("M40 conserva doble registro /api/reports en orden reads status", () => {
@@ -150,7 +144,7 @@ test("M40 conserva doble registro /api/reports en orden reads status", () => {
   ]);
 });
 
-test("M40 preserva Options endpoints shims y mantiene M41 ausente", () => {
+test("M40 preserva Options endpoints y M41 retira los shims", () => {
   const reads = read(readsRoute);
   const status = read(statusRoute);
 
@@ -185,7 +179,15 @@ test("M40 preserva Options endpoints shims y mantiene M41 ausente", () => {
     "server/lib/report-study-types.ts",
     "server/lib/reports.ts",
   ]) {
-    assert.equal(existsSync(resolve(root, shim)), true, shim);
+    assert.equal(existsSync(resolve(root, shim)), false, shim);
   }
-  assert.equal(existsSync(resolve(root, "docs/implementation/m41-reports-closeout.md")), false);
+  assert.equal(
+    existsSync(
+      resolve(
+        root,
+        "docs/implementation/m41-reports-compatibility-shim-retirement.md",
+      ),
+    ),
+    true,
+  );
 });

--- a/test/architecture/reports-suite-completeness.test.ts
+++ b/test/architecture/reports-suite-completeness.test.ts
@@ -157,7 +157,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "report study types have canonical internal catalog",
           "report study types block free-text",
           "report routes use canonical parser",
-          "M40 infrastructure exposes study types from catalog",
+          "M40 infrastructure exposes study types and M41 removes DB reexports",
         ],
       },
     ],
@@ -377,7 +377,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "Reports conserva domain M36 y admite inventario M37 autorizado",
           "consumidores externos usan exclusivamente el barrel canonico",
           "domain aplica default-deny",
-          "M40 est\u00e1 materializado",
+          "M41 retira sus shims",
         ],
       },
       {
@@ -425,7 +425,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
       {
         path: "test/unit/contracts/reports/report-command-persistence-contract.test.ts",
         markers: [
-          "server/db.ts conserva exports compatibles",
+          "server/db.ts retira exports Reports",
           "infrastructure es owner \u00fanico",
           "rutas conservan Options",
         ],
@@ -460,6 +460,15 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
           "M40 materializa inventario productivo exacto",
           "M40 composition es bridge lazy unico",
           "M40 conserva doble registro /api/reports",
+        ],
+      },
+      {
+        path: "test/architecture/reports-compatibility-shim-retirement.test.ts",
+        markers: [
+          "M41 retira f\u00edsicamente los cinco shims",
+          "M41 elimina todos los exports",
+          "consumidores runtime migrados resuelven Reports por composition",
+          "M36 a M40 permanecen materializados",
         ],
       },
       {
@@ -625,6 +634,7 @@ test("reports suite registers canonical reports guardrail files", () => {
     "report-query-use-cases.test.ts",
     "report-query-repository-contract.test.ts",
     "reports-query-use-cases-boundary-guard.test.ts",
+    "reports-compatibility-shim-retirement.test.ts",
   ]) {
     assert.equal(
       registeredFiles.includes(requiredFile),

--- a/test/architecture/reports-workflow-ports-boundary-guard.test.ts
+++ b/test/architecture/reports-workflow-ports-boundary-guard.test.ts
@@ -316,28 +316,18 @@ test("composition es el unico bridge M37 entre application e infrastructure", ()
   ]);
 });
 
-test("legacy workflow consume composition y ningún runtime M39 consume el shim", () => {
-  assert.ok(
-    imports(workflowShim)
-      .map((reference) => target(workflowShim, reference.specifier))
-      .includes(`${composition}/index.ts`),
-  );
+test("workflow canónico permanece y M41 retira ambos shims", () => {
+  assert.equal(existsSync(resolve(root, workflowShim)), false);
+  assert.equal(existsSync(resolve(root, shim)), false);
 
   const violations = walk("server")
-    .filter((path) => path.endsWith(".ts") && path !== workflowShim)
+    .filter((path) => path.endsWith(".ts"))
     .filter((path) =>
       imports(path)
         .map((reference) => target(path, reference.specifier))
         .includes(workflowShim)
     );
   assert.deepEqual(violations, []);
-
-  assert.equal(read(workflowShim).includes("drizzle-orm"), false);
-  assert.ok(read(workflowShim).includes("Retiro previsto para M41"));
-  assert.equal(
-    read(shim).trim(),
-    'export * from "../features/reports/composition/index.ts";',
-  );
 });
 
 test("ruta admin consume composition M39 y conserva transporte", () => {
@@ -389,7 +379,7 @@ test("fastify app conserva el registro actual sin imports M37", () => {
   );
 });
 
-test("M39 conserva route service y M40 agrega queries sin ejecutar M41", () => {
+test("M39 conserva route service y M40 agrega queries después de M41", () => {
   assert.equal(existsSync(resolve(root, workflow)), true);
   assert.equal(
     existsSync(resolve(root, `${infrastructure}/db-report-workflow.ts`)),

--- a/test/architecture/study-tracking-admin-thin-route.test.ts
+++ b/test/architecture/study-tracking-admin-thin-route.test.ts
@@ -372,10 +372,10 @@ test("M32b composición admin selecciona sólo el barrel de infrastructure", () 
   assert.equal(source.includes("drizzle-orm"), false);
 });
 
-test("M32b deja rutas clínica y particular byte-identical", () => {
+test("M32b conserva rutas y M41 migra sólo el owner Reports clínico", () => {
   assert.equal(
     digest(clinicRouteFile),
-    "2ce07bd8abb818b39bc2369095f71e19b5b1bd2a1dcba38f7848acaf349507b1",
+    "f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319",
   );
   assert.equal(
     digest(particularRouteFile),

--- a/test/architecture/study-tracking-clinic-particular-thin-routes.test.ts
+++ b/test/architecture/study-tracking-clinic-particular-thin-routes.test.ts
@@ -252,12 +252,12 @@ test("M32 routes no importan shim ni infrastructure y particular resuelve lazy p
   );
 });
 
-test("M32 clinic y particular permanecen byte-identical durante M32b", () => {
+test("M32 preserva rutas y M41 migra sólo el owner Reports clínico", () => {
   assert.equal(
     createHash("sha256")
       .update(readFileSync(resolve(repoRoot, clinicRoute)))
       .digest("hex"),
-    "2ce07bd8abb818b39bc2369095f71e19b5b1bd2a1dcba38f7848acaf349507b1",
+    "f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319",
   );
   assert.equal(
     createHash("sha256")

--- a/test/architecture/study-tracking-phase-closeout.test.ts
+++ b/test/architecture/study-tracking-phase-closeout.test.ts
@@ -22,9 +22,9 @@ const routes = {
 } as const;
 
 const routeHashes = new Map<string, string>([
-  [routes.clinic, "2ce07bd8abb818b39bc2369095f71e19b5b1bd2a1dcba38f7848acaf349507b1"],
+  [routes.clinic, "f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319"],
   [routes.particular, "ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb"],
-  [routes.admin, "c93824a2a7f2866c658e00304964927cbfc981b5b9c2046860657a6feb89c589"],
+  [routes.admin, "15aab9bd2b23caf27644185b5421cabe206644ed5b837c54e3dac66fa109c892"],
 ]);
 
 const expectedFeatureFiles = [

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -19,6 +19,8 @@ const reportsM39Closeout =
   "docs/implementation/m39-reports-admin-thin-routes-workflow.md";
 const reportsM40Closeout =
   "docs/implementation/m40-reports-query-use-cases-thin-routes.md";
+const reportsM41Closeout =
+  "docs/implementation/m41-reports-compatibility-shim-retirement.md";
 
 const featureLayers = [
   {
@@ -386,6 +388,7 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
   assert.equal(existsSync(resolve(root, reportsM38Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM39Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM40Closeout)), true);
+  assert.equal(existsSync(resolve(root, reportsM41Closeout)), true);
 
   for (const path of [
     "server/features/reports/application",
@@ -396,7 +399,7 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
   }
 
   const futureCloseouts = walk("docs/implementation").filter((path) =>
-    /\/(?:m41-|reports-phase-i)/i.test(path),
+    /\/(?:m42-|reports-phase-i)/i.test(path),
   );
   assert.deepEqual(futureCloseouts, []);
 });

--- a/test/integration/adapters/controllers/admin-report-workflow.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-report-workflow.fastify.test.ts
@@ -19,7 +19,7 @@ type AdminReportWorkflowNativeRoutesOptions = import(
   "../../../../server/routes/admin-report-workflow.fastify.ts"
 ).AdminReportWorkflowNativeRoutesOptions;
 type AdminReportWorkflowItem = import(
-  "../../../../server/db-report-workflow.ts"
+  "../../../../server/features/reports/infrastructure/index.ts"
 ).AdminReportWorkflowItem;
 
 function createWorkflowItem(

--- a/test/unit/application/reports/report-command-use-cases.test.ts
+++ b/test/unit/application/reports/report-command-use-cases.test.ts
@@ -3,6 +3,7 @@ import test from "node:test";
 
 import {
   createReportCommandUseCases,
+  findClinicScopedReportById,
   type CreateOrEditReportInput,
   type PersistReportStatusTransitionInput,
   type ReportCommandRecord,
@@ -32,6 +33,38 @@ function repository(
     ...overrides,
   };
 }
+
+test("findReportById delega una vez y preserva el resultado", async () => {
+  const calls: number[] = [];
+  const expected = report("processing");
+  const useCases = createReportCommandUseCases(
+    repository({
+      findReportById: async (reportId) => {
+        calls.push(reportId);
+        return expected;
+      },
+    }),
+  );
+
+  assert.equal(await useCases.findReportById(41), expected);
+  assert.deepEqual(calls, [41]);
+});
+
+test("findClinicScopedReportById preserva ownership y oculta otra clínica", async () => {
+  const expected = report("processing");
+  const fixtureRepository = repository({
+    findReportById: async () => expected,
+  });
+
+  assert.equal(
+    await findClinicScopedReportById(fixtureRepository, 41, 7),
+    expected,
+  );
+  assert.equal(
+    await findClinicScopedReportById(fixtureRepository, 41, 8),
+    null,
+  );
+});
 
 test("createOrEditReport delega una vez, preserva input y devuelve el resultado", async () => {
   const calls: CreateOrEditReportInput[] = [];

--- a/test/unit/contracts/reports/report-command-persistence-contract.test.ts
+++ b/test/unit/contracts/reports/report-command-persistence-contract.test.ts
@@ -18,46 +18,18 @@ function walk(directory: string): string[] {
   );
 }
 
-test("server/db.ts conserva exports compatibles sin duplicar persistencia M38", () => {
+test("server/db.ts retira exports Reports sin duplicar persistencia M38", () => {
   const source = read("server/db.ts");
-  const reportsSection = source.slice(
-    source.indexOf("/* ========================= REPORTS"),
-  );
 
-  assert.ok(
-    source.includes(
-      'from "./features/reports/infrastructure/index.ts";',
-    ),
-  );
-  assert.ok(
-    source.includes(
-      'from "./features/reports/composition/index.ts";',
-    ),
-  );
-  for (const name of ["getReportById", "upsertReport"]) {
-    assert.match(
-      source,
-      new RegExp(`export \\{[\\s\\S]*?\\b${name}\\b[\\s\\S]*?\\} from`),
-    );
-    assert.equal(
-      reportsSection.includes(`export async function ${name}`),
-      false,
-      name,
-    );
+  assert.equal(source.includes("features/reports"), false);
+  assert.equal(source.includes("/* ========================= REPORTS"), false);
+  for (const name of [
+    "getReportById",
+    "upsertReport",
+    "updateReportStatus",
+  ]) {
+    assert.doesNotMatch(source, new RegExp(`\\b${name}\\b`), name);
   }
-  assert.match(
-    source,
-    /export \{\s*updateReportStatus,\s*\} from "\.\/features\/reports\/composition\/index\.ts";/,
-  );
-  assert.equal(
-    reportsSection.includes("export async function updateReportStatus"),
-    false,
-  );
-  assert.equal(reportsSection.includes(".transaction("), false);
-  assert.equal(
-    reportsSection.includes('INSERT INTO "report_status_history"'),
-    false,
-  );
 });
 
 test("infrastructure es owner único de transacciones y SQL M38", () => {
@@ -71,8 +43,8 @@ test("infrastructure es owner único de transacciones y SQL M38", () => {
     1,
   );
   assert.ok(source.includes("export function createReportCommandRepository"));
-  assert.ok(source.includes("export function getReportById"));
-  assert.ok(source.includes("export function upsertReport"));
+  assert.equal(source.includes("export function getReportById"), false);
+  assert.equal(source.includes("export function upsertReport"), false);
   assert.equal(source.includes("export function updateReportStatus"), false);
   assert.equal(source.includes("../application/"), false);
   assert.equal(source.includes("../composition/"), false);
@@ -100,7 +72,7 @@ test("transition persistence usa expectedFromStatus y CAS antes del historial", 
   );
 });
 
-test("rutas conservan Options y exports compatibility previos", () => {
+test("rutas conservan Options y consumen composition canónica", () => {
   const admin = read("server/routes/admin-reports.fastify.ts");
   const status = read("server/routes/reports-status.fastify.ts");
   const reads = read("server/routes/reports.fastify.ts");
@@ -124,19 +96,22 @@ test("rutas conservan Options y exports compatibility previos", () => {
   assert.equal(status.includes("../db.ts"), false);
 });
 
-test("compatibility update atraviesa composition y application sin queries", () => {
+test("composition canónica atraviesa application sin queries", () => {
   const composition = read(
     "server/features/reports/composition/report-command-composition.ts",
   );
 
   for (const marker of [
+    "export async function getReportById",
+    ".findReportById(reportId)",
     "export function transitionReportStatus",
-    "export async function updateReportStatus",
-    "const result = await transitionReportStatus(input)",
-    'result.type === "persisted" ? result.report : undefined',
   ]) {
     assert.ok(composition.includes(marker), marker);
   }
+  assert.equal(
+    composition.includes("export async function updateReportStatus"),
+    false,
+  );
 
   const files = [
     ...walk("server/features/reports/application"),

--- a/test/unit/contracts/reports/report-study-types-catalog.test.ts
+++ b/test/unit/contracts/reports/report-study-types-catalog.test.ts
@@ -234,18 +234,14 @@ test("report routes use canonical parser for upload and filters", () => {
   assertNotContains(dbSource, "selectDistinct({ studyType: reports.studyType })", CATALOG_CONSUMERS[2].path);
 });
 
-test("M40 infrastructure exposes study types from catalog and DB only reexports", () => {
+test("M40 infrastructure exposes study types and M41 removes DB reexports", () => {
   const dbSource = readSource("server/db.ts");
   const repositorySource = readSource(
     "server/features/reports/infrastructure/report-query-repository.ts",
   );
 
-  assertContains(dbSource, "getReportStudyTypes", "server/db.ts");
-  assertContains(
-    dbSource,
-    "./features/reports/infrastructure/index.ts",
-    "server/db.ts",
-  );
+  assertNotContains(dbSource, "getReportStudyTypes", "server/db.ts");
+  assertNotContains(dbSource, "features/reports", "server/db.ts");
   assertContains(
     repositorySource,
     "../domain/index.ts",
@@ -260,12 +256,8 @@ test("M40 infrastructure exposes study types from catalog and DB only reexports"
   assertNotContains(dbSource, "selectDistinct({ studyType: reports.studyType })", "server/db.ts");
 });
 
-test("legacy catalog path remains an exact one-line shim", () => {
-  assert.equal(existsSync(resolve(REPO_ROOT, LEGACY_CATALOG_SHIM_PATH)), true);
-  assert.equal(
-    readSource(LEGACY_CATALOG_SHIM_PATH).trim(),
-    'export * from "../features/reports/domain/index.ts";',
-  );
+test("legacy catalog path remains retired after M41", () => {
+  assert.equal(existsSync(resolve(REPO_ROOT, LEGACY_CATALOG_SHIM_PATH)), false);
 });
 
 test("catalog contract is path-aware and anchored to the canonical module", () => {

--- a/test/unit/contracts/reports/report-workflow-communication-contract.test.ts
+++ b/test/unit/contracts/reports/report-workflow-communication-contract.test.ts
@@ -58,7 +58,7 @@ function resolveImport(path: string, specifier: string): string {
   return relative(root, resolve(root, dirname(path), specifier)).replaceAll("\\", "/");
 }
 
-test("M37 expone application puertos adapters composition y shim canonicos", () => {
+test("M37 expone application puertos adapters y composition canónicos", () => {
   for (const path of [
     application,
     dataPort,
@@ -67,17 +67,12 @@ test("M37 expone application puertos adapters composition y shim canonicos", () 
     notificationAdapter,
     composition,
     compositionIndex,
-    shim,
     workflow,
   ]) {
     assert.equal(existsSync(resolve(root, path)), true, path);
   }
 
-  assert.equal(
-    read(shim).trim(),
-    'export * from "../features/reports/composition/index.ts";',
-  );
-  assert.equal(read(shim).trim().split("\n").length, 1);
+  assert.equal(existsSync(resolve(root, shim)), false);
 });
 
 test("application conserva resultado missing tracking mapping y propagacion", () => {
@@ -176,7 +171,7 @@ test("ningun consumidor runtime o test de comportamiento importa el shim", () =>
           pending.push(absolute);
         } else if (entry.isFile() && entry.name.endsWith(".ts")) {
           const path = relative(root, absolute).replaceAll("\\", "/");
-          if (path === shim || path === "test/architecture/reports-workflow-ports-boundary-guard.test.ts") {
+          if (path === "test/architecture/reports-workflow-ports-boundary-guard.test.ts") {
             continue;
           }
           for (const specifier of imports(path)) {

--- a/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
+++ b/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
@@ -146,7 +146,7 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
         markers: [
           "M32 conserva exactamente Options y endpoints",
           "M32 routes delegan",
-          "M32 clinic y particular permanecen byte-identical durante M32b",
+          "M32 preserva rutas y M41 migra s\u00f3lo el owner Reports cl\u00ednico",
         ],
       },
       {


### PR DESCRIPTION
## Summary

- Change type: backend architecture refactor
- Context / issue: M41 Reports compatibility shim retirement
- What changed:
  - removes the five temporary Reports forwarding modules
  - removes the complete Reports compatibility surface from `server/db.ts`
  - migrates all remaining runtime consumers to canonical Reports composition
  - places full-record and clinic-scoped lookups behind command application and composition
  - preserves route dependency injection and existing public `Options`
  - updates architecture guards, historical closeouts and Reports documentation

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Tests and documentation changed only as supporting evidence for the single backend-runtime scope.

## Mixed-Scope Justification

Not applicable.

## Other Scope Detail

M41 retires compatibility artifacts created during M36-M40. It does not change HTTP contracts, database schema, dependencies, CI, frontend or deployment configuration.

## HTTP and behavioral compatibility

- preserves all Reports endpoints, methods, paths and registration order
- preserves the ordered double registration of `/api/reports`
- preserves payloads, messages, status codes and serialization
- preserves authentication, authorization and clinic isolation
- preserves CORS, trusted-origin ordering, cookies and session last-access
- preserves timing, logging, signed URLs and audit ordering
- preserves transition validation and compare-and-set behavior
- preserves route `Options` and test dependency injection
- leaves `server/fastify-app.ts` unchanged

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected) - not applicable
- [ ] `pnpm --dir frontend typecheck` (if frontend affected) - not applicable
- [ ] `pnpm --dir frontend build` (if frontend affected) - not applicable
- [x] `pnpm audit --prod` (if dependencies affected)
- [x] `pnpm audit` (if dependencies affected)
- [x] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Additional observed validation:

- M41 isolated guard: 9/9 passed
- Reports architecture guards M36-M41: 68/68 passed
- directed Reports cohort: 200/200 passed
- backend security and audit cohort: 241/241 passed
- `pnpm validate:local`: 3,859 passed, 1 skipped, 0 failed; build completed
- `pnpm security:public-surface`: passed with no public findings
- `git diff --check`: passed
- final inventory: 40 files, 817 additions, 280 deletions
- five compatibility shims removed
- zero Reports exports remain in `server/db.ts`
- zero runtime `db.<Reports>` calls remain

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Scope exclusions

- frontend: NOT_RUN
- Playwright: NOT_RUN
- schema: NOT_RUN
- migrations: NOT_RUN
- DB real: NOT_RUN
- staging: NOT_RUN
- production: NOT_RUN
- dependencies: NOT_RUN
- workflows/CI modifications: NOT_RUN
- next milestone: NOT_RUN

## Rollback

- Trigger: regression in Reports lookup, tenant ownership, access tokens, particular access, study tracking, workflow, signed URL access or an existing HTTP contract.
- Steps: revert the M41 commit, restoring the five compatibility modules, the Reports reexports in `server/db.ts`, the previous consumer wiring and the prior architecture anchors.
- Data impact: none expected. M41 contains no schema migration, data migration, dependency change or persisted-data transformation.