### PR TITLE
refactor(users-roles): add domain and use cases

### DIFF
--- a/docs/implementation/m42-users-roles-domain-use-cases.md
+++ b/docs/implementation/m42-users-roles-domain-use-cases.md
@@ -1,0 +1,280 @@
+# M42 — Users/Roles domain + application use cases
+
+## 1. Identificación y baseline
+
+- Milestone: **M42 — Users/Roles domain + application use cases**.
+- Rama:
+  `refactor/backend-modularization-m42-users-roles-domain-use-cases`.
+- Baseline y HEAD inicial:
+  `a5d35a2c28bd35305e7607a58d9663bcac7b20b8`.
+- Predecesor: M41 / PR #1580 / squash merge del mismo SHA.
+- Working tree inicial: limpio.
+- PRs abiertos al iniciar: 0 según la identificación de la tarea; no se hizo
+  consulta remota.
+- Riesgo: R2 estructural backend autorizado exclusivamente para M42.
+- Git/GitHub de escritura: `NOT_RUN`.
+
+## 2. Censo inicial
+
+### Persistencia, imports y tipos
+
+`server/db-admin-users-roles.ts` tenía un consumidor productivo:
+`server/routes/admin-users-roles.fastify.ts`, con import type estático y carga
+runtime lazy. Su único consumidor type-only en tests era
+`test/integration/adapters/controllers/admin-users-roles.fastify.test.ts`.
+
+Todos los tipos Users/Roles exportados por el archivo raíz
+(`AdminRoleUserType`, `AdminRoleUserRole`, `AdminRoleUserSummary`,
+`AdminUsersRolesQuery`, `AdminUsersRolesSnapshot`,
+`AdminClinicUserRoleChangeInput`, `AdminClinicUserRoleChangeResult`) se
+consumían únicamente desde esa ruta y ese test. No apareció un consumidor
+inesperado; por eso no se conserva reexport type-only ni compatibilidad.
+
+`getAdminUsersRolesSnapshot` y `changeClinicUserRole` tenían como único
+consumidor productivo la ruta: superficie inyectable en
+`AdminUsersRolesNativeRoutesOptions`, defaults desde la carga lazy del módulo
+raíz y llamadas directas desde los handlers. El test Fastify aportaba stubs
+para ambas operaciones.
+
+### Anchors source-aware
+
+- Path de ruta, 11 archivos:
+  guard de infrastructure Clinics; cinco contratos de auth/security
+  (`global-auth`, suite completeness, critical registry, cross-auth y cookie
+  boundaries); helper de scope Reports; integración Fastify; CSRF mutation
+  coverage; auth de credenciales Clinics; search contract.
+- Path de DB, 5 archivos: helper de scope Reports; integración Fastify; search;
+  heavy-list pagination; global performance/resilience.
+- Funciones inline de parsing de roles: ningún test existente fijaba
+  `parseUserType`, `parseRole` o `parseClinicUserRole`.
+- Llamadas directas `deps.getAdminUsersRolesSnapshot` /
+  `deps.changeClinicUserRole`: ningún test las fijaba; eran implementación
+  directa de la ruta.
+
+### Permissions kernel
+
+Fan-in productivo real de `server/lib/permissions.ts`: **14 archivos**:
+
+- `server/db.ts`;
+- `server/middlewares/auth.ts`;
+- rutas `auth`, `clinic-audit`, `clinic-public-profile`,
+  `logistics-field-visits`, `logistics-route-events`,
+  `logistics-route-plans`, `logistics-sla`, `particular-tokens`,
+  `report-access-tokens`, `reports`, `reports-status` y `study-tracking`.
+
+El fan-in cruza Auth, Clinics, Logistics, Reports y otros contextos. No había
+ningún consumidor Users/Roles.
+
+### Feature, endpoints y tests
+
+`server/features/users-roles` no existía. La ruta registraba, y conserva, este
+orden:
+
+1. `OPTIONS /`;
+2. `OPTIONS /clinic/:clinicUserId/role`;
+3. `OPTIONS /clinic/:clinicUserId/credentials`;
+4. `GET /`;
+5. `PATCH /clinic/:clinicUserId/role`;
+6. `PATCH /clinic/:clinicUserId/credentials`.
+
+El censo de nombres directamente relacionados encontró 5 archivos y 46 tests:
+21 backend (15 integración + 6 search) y 25 frontend (6 density + 6 API + 13
+card). El frontend queda fuera del diff.
+
+## 3. Ownership antes y después
+
+Antes, la ruta poseía parsing de roles y orquestaba directamente las dos
+operaciones de persistencia; el archivo DB era owner conceptual de los DTOs.
+
+Después de M42:
+
+- domain posee realms, roles, catálogos y parsers puros;
+- application posee DTOs, puerto y casos de uso;
+- la ruta posee HTTP, auth, CORS, parsing no-domain, status, auditoría y wiring;
+- `server/db-admin-users-roles.ts` conserva toda la persistencia;
+- Clinics conserva credenciales y hashing;
+- `server/lib/permissions.ts` conserva autorización cross-context.
+
+## 4. Arquitectura M42
+
+```text
+admin-users-roles Fastify route
+  ├─ HTTP / auth / CORS / parsing / status / audit
+  ├─ Users/Roles application use cases
+  │    ├─ Users/Roles domain
+  │    └─ AdminUsersRolesRepository
+  ├─ existing server/db-admin-users-roles.ts
+  └─ existing Clinics credentials command
+```
+
+La composición ruta → persistencia raíz está permitida hasta M43.
+
+## 5. Módulos creados
+
+- Feature y README de capas.
+- Domain: `user-role-policy.ts` + barrel.
+- Application: `admin-users-roles-use-cases.ts`, puerto mínimo y barrels.
+- Tres guards M42.
+- Tests unitarios de domain/application y suite completeness dinámica.
+
+No se creó `infrastructure/`, composition layer ni adapter forwarding.
+
+## 6. Tipos canonicalizados
+
+Domain:
+
+- `AdminRoleUserType`;
+- `AdminRoleUserRole`;
+- `AdminClinicUserRole`.
+
+Application/ports:
+
+- `AdminRoleUserSummary`;
+- `AdminUsersRolesQuery`;
+- `AdminUsersRolesSnapshot`;
+- `AdminClinicUserRoleChangeInput`;
+- `AdminClinicUserRoleChangeResult`.
+
+La ruta y el test de integración apuntan a los owners canónicos. Persistencia
+usa imports exclusivamente type-only. El archivo raíz DB ya no exporta tipos.
+
+## 7. Puerto
+
+`AdminUsersRolesRepository` deriva del seam real de Options y contiene sólo:
+
+- `getAdminUsersRolesSnapshot`;
+- `changeClinicUserRole`.
+
+No incluye Auth, sesiones, CORS, auditoría, hashing, credenciales, clock ni
+operaciones especulativas.
+
+## 8. Casos de uso
+
+`createAdminUsersRolesUseCases(repository)` expone:
+
+- `listAdminUsersRoles(query)`;
+- `changeClinicUserRole(input)`.
+
+Cada operación delega exactamente una vez, conserva identidad de input/output,
+no captura errores, no agrega validaciones, retries ni wrappers, y preserva
+`not_found`, `last_clinic_owner` y `roleChanged: false`.
+
+## 9. Wiring de ruta
+
+Los parsers de user type, role de filtro y role mutable se consumen desde
+`domain/index.ts`. La factory application se compone una vez sobre adapters
+que preservan la resolución lazy de las dependencias existentes. GET y PATCH
+role delegan a application; los handlers no llaman directamente
+`deps.getAdminUsersRolesSnapshot` ni `deps.changeClinicUserRole`.
+
+Se preservan Options, inyección de tests, `defaultDepsPromise`, auth,
+last-access, CORS/preflight/trusted-origin, enteros, search, clamps, mensajes,
+status, payloads, `checkedBy`, `changedBy`, auditoría, metadata y
+`now: new Date(now())`.
+
+## 10. Credenciales Clinics
+
+`PATCH /clinic/:clinicUserId/credentials` sigue delegando en
+`updateAdminClinicUserCredentialsCommand`. Se preserva el orden
+parse → hash → persistence → audit → response. Users/Roles no contiene
+credenciales, hashing ni un puerto alternativo.
+
+## 11. Permissions como shared kernel
+
+`server/lib/permissions.ts` permanece físicamente y byte-idéntico, con su API
+pública intacta. Users/Roles administra identidades, catálogo de roles y
+operaciones administrativas; el kernel resuelve autorización cross-context.
+
+Moverlo dentro de Users/Roles produciría dependencias inversas desde
+Logistics, Clinics, Reports y otros contextos hacia una feature
+administrativa. Una eventual reclasificación pertenece a Fase K, no a M42.
+
+## 12. Clasificación de anchors A/B/C
+
+- A — realineados: imports type-only del test Fastify y owner de
+  `AdminUsersRolesQuery` en el search contract.
+- B — agregados: guards de domain, application y permissions kernel, más suite
+  completeness dinámica.
+- C — preservados sin debilitar: integración Fastify; SQL/search; heavy-list
+  pagination; auth admin; sesión/cookies; trusted origin/CSRF; CORS;
+  auditoría; disclosure/no-secrets; performance; security y audit
+  completeness; route registry.
+
+## 13. Guards
+
+- Domain boundary: auto-descubre los módulos TS, fija inventario/barrel,
+  pureza, imports prohibidos, catálogos exactos, ausencia de enums/permisos
+  duplicados y consumo productivo por barrel.
+- Application boundary: default-deny hacia el propio application y
+  `domain/index.ts`; fija puerto mínimo, factory consumida, delegación de
+  handlers, ownership Clinics de credenciales y ausencia de M43.
+- Permissions kernel: fija path/API canónicos, ausencia de copias/reexports o
+  imports desde Users/Roles y fan-in cross-context de 14.
+- Suite completeness: descubre módulos/tests, detecta huérfanos, verifica
+  barrels/puertos/casos de uso y evita duplicación de credenciales.
+
+## 14. Validación
+
+| Comando | Estado | Exit | Evidencia |
+| --- | --- | ---: | --- |
+| tests M42 aislados, intento 1 | FAILED | 1 | 25 pass, 1 fail |
+| tests M42 aislados, reintento | PASSED | 0 | 26/26 |
+| cohorte dirigida M42 + contratos | PASSED | 0 | 156/156 |
+| `pnpm typecheck` | PASSED | 0 | TypeScript producción |
+| `pnpm typecheck:test` | PASSED | 0 | TypeScript tests |
+| `pnpm test` | PASSED | 0 | 3885 pass, 1 skip, 0 fail |
+| `pnpm build` | PASSED | 0 | esbuild, `dist/index.js` |
+| `pnpm security:public-surface` | PASSED | 0 | cero findings públicos |
+| `pnpm audit --prod` | PASSED | 0 | cero vulnerabilidades conocidas |
+| `pnpm audit` | PASSED | 0 | cero vulnerabilidades conocidas |
+| `pnpm validate:local` | PASSED | 0 | typechecks + 3885/1/0 + build |
+| `git diff --check` | PASSED | 0 | sin whitespace errors |
+
+No se ejecutó DB real ni migraciones. CI con Postgres cubrirá posteriormente
+la integración de persistencia.
+
+## 15. Fail-fast
+
+El primer gate M42 falló porque el guard de permissions interpretaba las
+menciones documentales obligatorias al path canónico como imports
+productivos. Se ajustó el guard para detectar copias por nombre en todo el
+feature y analizar duplicación/imports únicamente en archivos `.ts`. El mismo
+gate se reejecutó completo y pasó 26/26 antes de continuar.
+
+No hubo otros fallos de implementación o validación.
+
+## 16. Riesgos
+
+Riesgo residual: M42 conserva composición hacia la persistencia raíz y la ruta
+todavía coordina HTTP/auditoría. Es deuda explícita y acotada para M43, no una
+regresión. La doble resolución liviana de deps en GET/PATCH role conserva el
+lazy default y no duplica ninguna operación de repository.
+
+## 17. Rollback
+
+Revertir los archivos del feature y sus tests/guards, devolver los tipos a
+`server/db-admin-users-roles.ts`, restaurar los tres parsers inline y las dos
+llamadas directas de handlers, y realinear los dos anchors type/source. No
+requiere schema, migraciones, datos ni compensación de side effects.
+
+## 18. Exclusiones
+
+Sin cambios en Auth, `server/lib/permissions.ts`, command Clinics,
+`server/fastify-app.ts`, schema, migraciones, frontend, dependencias,
+lockfiles, package manifests, scripts, CI/workflows, Supabase, email, audit
+infrastructure, CORS/session helpers, SQL funcional ni transacciones.
+
+No se ejecutaron frontend gates, Playwright, DB real, staging, producción,
+servidores, watchers, Git de escritura ni GitHub. No se crearon shims,
+compat/legacy, nuevos endpoints, repositorio infrastructure, service locator,
+unit of work ni event bus.
+
+## 19. Deuda M43 y estado
+
+M43 queda responsable del move del repository, composition final, retiro del
+path raíz y thin-route closeout. Ninguna parte de ese milestone fue iniciada.
+
+- M42: implementación local completa.
+- Git/GitHub: `NOT_RUN`.
+- Stage / commit / amend / push / PR / merge: `NOT_RUN`.
+- M43: `NOT_RUN`.

--- a/server/db-admin-users-roles.ts
+++ b/server/db-admin-users-roles.ts
@@ -6,78 +6,24 @@ import {
   clinicPublicProfiles,
   clinicUsers,
   clinics,
-  type ClinicUserRole,
 } from "../drizzle/schema.ts";
+import type {
+  AdminClinicUserRole,
+  AdminRoleUserRole,
+} from "./features/users-roles/domain/index.ts";
+import type {
+  AdminClinicUserRoleChangeInput,
+  AdminClinicUserRoleChangeResult,
+  AdminRoleUserSummary,
+  AdminUsersRolesQuery,
+  AdminUsersRolesSnapshot,
+} from "./features/users-roles/application/index.ts";
 import { normalizeListPagination } from "./lib/list-pagination.ts";
-
-export type AdminRoleUserType = "admin" | "clinic";
-export type AdminRoleUserRole = "admin" | ClinicUserRole;
-
-export type AdminRoleUserSummary =
-  | {
-      userType: "admin";
-      userId: number;
-      username: string;
-      role: "admin";
-      clinicId: null;
-      clinicName: null;
-      createdAt: string;
-      updatedAt: string;
-    }
-  | {
-      userType: "clinic";
-      userId: number;
-      username: string;
-      role: ClinicUserRole;
-      clinicId: number;
-      clinicName: string | null;
-      clinicLocality?: string | null;
-      createdAt: string;
-      updatedAt: string;
-    };
-
-export type AdminUsersRolesQuery = {
-  userType?: AdminRoleUserType;
-  role?: AdminRoleUserRole;
-  limit?: number;
-  offset?: number;
-  search?: string;
-};
-
-export type AdminUsersRolesSnapshot = {
-  success: true;
-  users: AdminRoleUserSummary[];
-  total: number;
-  limit: number;
-  offset: number;
-  totals: {
-    adminUsers: number;
-    clinicUsers: number;
-  };
-};
-
-export type AdminClinicUserRoleChangeInput = {
-  clinicUserId: number;
-  role: ClinicUserRole;
-  now?: Date;
-};
-
-export type AdminClinicUserRoleChangeResult =
-  | {
-      ok: true;
-      user: Extract<AdminRoleUserSummary, { userType: "clinic" }>;
-      previousRole: ClinicUserRole;
-      roleChanged: boolean;
-    }
-  | {
-      ok: false;
-      reason: "not_found" | "last_clinic_owner";
-    };
 
 type ClinicUserRoleRow = {
   userId: number;
   username: string;
-  role: ClinicUserRole;
+  role: AdminClinicUserRole;
   clinicId: number;
   clinicName: string | null;
   clinicLocality: string | null;

--- a/server/features/users-roles/README.md
+++ b/server/features/users-roles/README.md
@@ -1,0 +1,27 @@
+# Users/Roles bounded context
+
+M42 abre la Fase J con dominio puro, DTOs y casos de uso de application. La
+topología vigente es:
+
+```text
+admin-users-roles.fastify.ts
+  ├─ HTTP / auth / CORS / parsing / status / audit
+  ├─ application use cases
+  │    ├─ domain
+  │    └─ AdminUsersRolesRepository port
+  ├─ server/db-admin-users-roles.ts
+  └─ Clinics credentials command
+```
+
+Users/Roles administra identidades, catálogo de roles y operaciones
+administrativas. `server/lib/permissions.ts` sigue siendo el kernel compartido
+de autorización cross-context; moverlo aquí invertiría dependencias desde
+Logistics, Clinics, Reports y otros contextos hacia una feature
+administrativa. Su eventual reclasificación corresponde a Fase K.
+
+El cambio de credenciales conserva ownership en Clinics mediante
+`updateAdminClinicUserCredentialsCommand`. Users/Roles no posee hashing ni
+persistencia de credenciales.
+
+La persistencia raíz permanece en `server/db-admin-users-roles.ts`. Su move,
+composition final y thin-route closeout corresponden exclusivamente a M43.

--- a/server/features/users-roles/application/README.md
+++ b/server/features/users-roles/application/README.md
@@ -1,0 +1,16 @@
+# Users/Roles application
+
+Materializa los dos casos de uso propios de M42:
+
+- `listAdminUsersRoles(query)`;
+- `changeClinicUserRole(input)`.
+
+Ambos delegan exactamente una vez en `AdminUsersRolesRepository`, conservan
+identidad de inputs y outputs, y propagan errores y resultados discriminados
+sin traducción. El puerto mínimo deriva del seam
+`AdminUsersRolesNativeRoutesOptions` y contiene únicamente esas dos
+operaciones.
+
+La capa sólo depende del barrel `../domain/index.ts` y de sus propios puertos.
+No contiene Fastify, Drizzle, DB, auth, CORS, sesiones, auditoría, hashing ni
+credenciales.

--- a/server/features/users-roles/application/admin-users-roles-use-cases.ts
+++ b/server/features/users-roles/application/admin-users-roles-use-cases.ts
@@ -1,0 +1,27 @@
+import type {
+  AdminClinicUserRoleChangeInput,
+  AdminClinicUserRoleChangeResult,
+  AdminUsersRolesQuery,
+  AdminUsersRolesRepository,
+  AdminUsersRolesSnapshot,
+} from "./ports/admin-users-roles-repository.ts";
+
+export type AdminUsersRolesUseCases = {
+  listAdminUsersRoles: (
+    query: AdminUsersRolesQuery,
+  ) => Promise<AdminUsersRolesSnapshot>;
+  changeClinicUserRole: (
+    input: AdminClinicUserRoleChangeInput,
+  ) => Promise<AdminClinicUserRoleChangeResult>;
+};
+
+export function createAdminUsersRolesUseCases(
+  repository: AdminUsersRolesRepository,
+): AdminUsersRolesUseCases {
+  return {
+    listAdminUsersRoles: (query) =>
+      repository.getAdminUsersRolesSnapshot(query),
+    changeClinicUserRole: (input) =>
+      repository.changeClinicUserRole(input),
+  };
+}

--- a/server/features/users-roles/application/index.ts
+++ b/server/features/users-roles/application/index.ts
@@ -1,0 +1,12 @@
+export type {
+  AdminClinicUserRoleChangeInput,
+  AdminClinicUserRoleChangeResult,
+  AdminRoleUserSummary,
+  AdminUsersRolesQuery,
+  AdminUsersRolesRepository,
+  AdminUsersRolesSnapshot,
+} from "./ports/index.ts";
+export {
+  createAdminUsersRolesUseCases,
+  type AdminUsersRolesUseCases,
+} from "./admin-users-roles-use-cases.ts";

--- a/server/features/users-roles/application/ports/admin-users-roles-repository.ts
+++ b/server/features/users-roles/application/ports/admin-users-roles-repository.ts
@@ -1,0 +1,75 @@
+import type {
+  AdminClinicUserRole,
+  AdminRoleUserRole,
+  AdminRoleUserType,
+} from "../../domain/index.ts";
+
+export type AdminRoleUserSummary =
+  | {
+      userType: "admin";
+      userId: number;
+      username: string;
+      role: "admin";
+      clinicId: null;
+      clinicName: null;
+      createdAt: string;
+      updatedAt: string;
+    }
+  | {
+      userType: "clinic";
+      userId: number;
+      username: string;
+      role: AdminClinicUserRole;
+      clinicId: number;
+      clinicName: string | null;
+      clinicLocality?: string | null;
+      createdAt: string;
+      updatedAt: string;
+    };
+
+export type AdminUsersRolesQuery = {
+  userType?: AdminRoleUserType;
+  role?: AdminRoleUserRole;
+  limit?: number;
+  offset?: number;
+  search?: string;
+};
+
+export type AdminUsersRolesSnapshot = {
+  success: true;
+  users: AdminRoleUserSummary[];
+  total: number;
+  limit: number;
+  offset: number;
+  totals: {
+    adminUsers: number;
+    clinicUsers: number;
+  };
+};
+
+export type AdminClinicUserRoleChangeInput = {
+  clinicUserId: number;
+  role: AdminClinicUserRole;
+  now?: Date;
+};
+
+export type AdminClinicUserRoleChangeResult =
+  | {
+      ok: true;
+      user: Extract<AdminRoleUserSummary, { userType: "clinic" }>;
+      previousRole: AdminClinicUserRole;
+      roleChanged: boolean;
+    }
+  | {
+      ok: false;
+      reason: "not_found" | "last_clinic_owner";
+    };
+
+export type AdminUsersRolesRepository = {
+  getAdminUsersRolesSnapshot: (
+    query: AdminUsersRolesQuery,
+  ) => Promise<AdminUsersRolesSnapshot>;
+  changeClinicUserRole: (
+    input: AdminClinicUserRoleChangeInput,
+  ) => Promise<AdminClinicUserRoleChangeResult>;
+};

--- a/server/features/users-roles/application/ports/index.ts
+++ b/server/features/users-roles/application/ports/index.ts
@@ -1,0 +1,8 @@
+export type {
+  AdminClinicUserRoleChangeInput,
+  AdminClinicUserRoleChangeResult,
+  AdminRoleUserSummary,
+  AdminUsersRolesQuery,
+  AdminUsersRolesRepository,
+  AdminUsersRolesSnapshot,
+} from "./admin-users-roles-repository.ts";

--- a/server/features/users-roles/domain/README.md
+++ b/server/features/users-roles/domain/README.md
@@ -1,0 +1,15 @@
+# Users/Roles domain
+
+Contiene el catálogo y los parsers puros de realms y roles visibles por la
+superficie administrativa. No conoce Fastify, Drizzle, persistencia, HTTP,
+auditoría, sesiones ni el kernel compartido de permisos.
+
+`index.ts` es el único entrypoint productivo. Expone:
+
+- user types: `admin | clinic`;
+- roles de filtro: `admin | clinic_owner | clinic_staff`;
+- roles mutables de clínica: `clinic_owner | clinic_staff`;
+- predicates y parsers determinísticos, sin normalización implícita.
+
+La matriz cross-context de autorización permanece en
+`server/lib/permissions.ts`; no pertenece a este dominio.

--- a/server/features/users-roles/domain/index.ts
+++ b/server/features/users-roles/domain/index.ts
@@ -1,0 +1,14 @@
+export {
+  ADMIN_CLINIC_USER_ROLES,
+  ADMIN_ROLE_USER_ROLES,
+  ADMIN_ROLE_USER_TYPES,
+  isAdminClinicUserRole,
+  isAdminRoleUserRole,
+  isAdminRoleUserType,
+  parseAdminClinicUserRole,
+  parseAdminRoleUserRole,
+  parseAdminRoleUserType,
+  type AdminClinicUserRole,
+  type AdminRoleUserRole,
+  type AdminRoleUserType,
+} from "./user-role-policy.ts";

--- a/server/features/users-roles/domain/user-role-policy.ts
+++ b/server/features/users-roles/domain/user-role-policy.ts
@@ -1,0 +1,54 @@
+export const ADMIN_ROLE_USER_TYPES = ["admin", "clinic"] as const;
+export const ADMIN_ROLE_USER_ROLES = [
+  "admin",
+  "clinic_owner",
+  "clinic_staff",
+] as const;
+export const ADMIN_CLINIC_USER_ROLES = [
+  "clinic_owner",
+  "clinic_staff",
+] as const;
+
+export type AdminRoleUserType = (typeof ADMIN_ROLE_USER_TYPES)[number];
+export type AdminRoleUserRole = (typeof ADMIN_ROLE_USER_ROLES)[number];
+export type AdminClinicUserRole = (typeof ADMIN_CLINIC_USER_ROLES)[number];
+
+export function isAdminRoleUserType(
+  value: unknown,
+): value is AdminRoleUserType {
+  return value === "admin" || value === "clinic";
+}
+
+export function parseAdminRoleUserType(
+  value: unknown,
+): AdminRoleUserType | null {
+  return isAdminRoleUserType(value) ? value : null;
+}
+
+export function isAdminRoleUserRole(
+  value: unknown,
+): value is AdminRoleUserRole {
+  return (
+    value === "admin" ||
+    value === "clinic_owner" ||
+    value === "clinic_staff"
+  );
+}
+
+export function parseAdminRoleUserRole(
+  value: unknown,
+): AdminRoleUserRole | null {
+  return isAdminRoleUserRole(value) ? value : null;
+}
+
+export function isAdminClinicUserRole(
+  value: unknown,
+): value is AdminClinicUserRole {
+  return value === "clinic_owner" || value === "clinic_staff";
+}
+
+export function parseAdminClinicUserRole(
+  value: unknown,
+): AdminClinicUserRole | null {
+  return isAdminClinicUserRole(value) ? value : null;
+}

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -16,11 +16,16 @@ import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type {
   AdminClinicUserRoleChangeInput,
   AdminClinicUserRoleChangeResult,
-  AdminRoleUserRole,
-  AdminRoleUserType,
   AdminUsersRolesQuery,
   AdminUsersRolesSnapshot,
-} from "../db-admin-users-roles.ts";
+} from "../features/users-roles/application/index.ts";
+import { createAdminUsersRolesUseCases } from "../features/users-roles/application/index.ts";
+import {
+  parseAdminClinicUserRole,
+  parseAdminRoleUserRole,
+  parseAdminRoleUserType,
+  type AdminClinicUserRole,
+} from "../features/users-roles/domain/index.ts";
 import type {
   AdminClinicUserCredentialsUpdateInput,
   AdminClinicUserCredentialsUpdateResult,
@@ -28,8 +33,6 @@ import type {
 import {
   updateAdminClinicUserCredentialsCommand,
 } from "../features/clinics/admin-clinics-command-service.ts";
-
-type AdminClinicUserRole = Exclude<AdminRoleUserRole, "admin">;
 
 type AdminSessionRecord = {
   id: number;
@@ -182,34 +185,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
 }
 
-function parseUserType(value: string | undefined): AdminRoleUserType | undefined | null {
-  if (value === undefined) return undefined;
-  if (value === "admin" || value === "clinic") return value;
-  return null;
-}
-
-function parseRole(value: string | undefined): AdminRoleUserRole | undefined | null {
-  if (value === undefined) return undefined;
-
-  if (
-    value === "admin" ||
-    value === "clinic_owner" ||
-    value === "clinic_staff"
-  ) {
-    return value;
-  }
-
-  return null;
-}
-
-function parseClinicUserRole(value: unknown): AdminClinicUserRole | null {
-  if (value === "clinic_owner" || value === "clinic_staff") {
-    return value;
-  }
-
-  return null;
-}
-
 function parseClinicUserCredentialsBody(
   body: AdminUsersRolesCredentialsChangeBody | undefined,
 ):
@@ -329,8 +304,14 @@ function parsePositiveIntegerParam(value: string | undefined) {
 function parseUsersRolesQuery(
   query: AdminUsersRolesRequestQuery,
 ): AdminUsersRolesQuery | null {
-  const userType = parseUserType(query.userType);
-  const role = parseRole(query.role);
+  const userType =
+    query.userType === undefined
+      ? undefined
+      : parseAdminRoleUserType(query.userType);
+  const role =
+    query.role === undefined
+      ? undefined
+      : parseAdminRoleUserRole(query.role);
   const limit = parseIntegerParam(query.limit, 50, 1, 100);
   const offset = parseIntegerParam(query.offset, 0, 0, 100_000);
   const search = parseSearchParam(query.search);
@@ -412,6 +393,13 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
     };
   }
 
+  const usersRolesUseCases = createAdminUsersRolesUseCases({
+    getAdminUsersRolesSnapshot: async (query) =>
+      (await resolveDeps()).getAdminUsersRolesSnapshot(query),
+    changeClinicUserRole: async (input) =>
+      (await resolveDeps()).changeClinicUserRole(input),
+  });
+
   app.addHook("onRequest", async (request, reply) => {
     applyCorsHeaders(request, reply, allowedOrigins);
   });
@@ -465,7 +453,8 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
         });
       }
 
-      const snapshot = await deps.getAdminUsersRolesSnapshot(params);
+      const snapshot =
+        await usersRolesUseCases.listAdminUsersRoles(params);
 
       return reply.code(200).send({
         ...snapshot,
@@ -501,7 +490,8 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const role = parseClinicUserRole(request.body?.role);
+    const role: AdminClinicUserRole | null =
+      parseAdminClinicUserRole(request.body?.role);
 
     if (!role) {
       return reply.code(400).send({
@@ -510,7 +500,7 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
       });
     }
 
-    const result = await deps.changeClinicUserRole({
+    const result = await usersRolesUseCases.changeClinicUserRole({
       clinicUserId,
       role,
       now: new Date(now()),

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -21,6 +21,8 @@ const reportsM40Closeout =
   "docs/implementation/m40-reports-query-use-cases-thin-routes.md";
 const reportsM41Closeout =
   "docs/implementation/m41-reports-compatibility-shim-retirement.md";
+const usersRolesM42Closeout =
+  "docs/implementation/m42-users-roles-domain-use-cases.md";
 
 const featureLayers = [
   {
@@ -363,7 +365,7 @@ test("M35b mantiene conectados los guards globales de token access", () => {
   }
 });
 
-test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
+test("M35b preserva la secuencia materializada hasta M42 y mantiene M43 no iniciado", () => {
   for (const path of [
     "docs/implementation/public-report-access-error-path-redaction-hotfix.md",
     closeout,
@@ -389,6 +391,16 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
   assert.equal(existsSync(resolve(root, reportsM39Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM40Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM41Closeout)), true);
+  assert.equal(existsSync(resolve(root, usersRolesM42Closeout)), true);
+
+  const usersRolesM42Source = read(usersRolesM42Closeout);
+  for (const marker of [
+    "M42 — Users/Roles domain + application use cases",
+    "M43 queda responsable",
+    "M43: `NOT_RUN`",
+  ]) {
+    assert.equal(usersRolesM42Source.includes(marker), true, marker);
+  }
 
   for (const path of [
     "server/features/reports/application",
@@ -398,8 +410,8 @@ test("M35b documenta cierre de Fase H y preserva fases siguientes", () => {
     assert.equal(existsSync(resolve(root, path)), true, path);
   }
 
-  const futureCloseouts = walk("docs/implementation").filter((path) =>
-    /\/(?:m42-|reports-phase-i)/i.test(path),
+  const m43Closeouts = walk("docs/implementation").filter((path) =>
+    /\/m43-/i.test(path),
   );
-  assert.deepEqual(futureCloseouts, []);
+  assert.deepEqual(m43Closeouts, []);
 });

--- a/test/architecture/users-roles-application-boundary-guard.test.ts
+++ b/test/architecture/users-roles-application-boundary-guard.test.ts
@@ -1,0 +1,135 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, join, relative } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const applicationDir = "server/features/users-roles/application";
+const routeFile = "server/routes/admin-users-roles.fastify.ts";
+
+function read(path: string) {
+  return readFileSync(join(root, path), "utf8").replace(/\r\n/g, "\n");
+}
+
+function walk(path: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(join(root, path), { withFileTypes: true })) {
+    const child = `${path}/${entry.name}`;
+    if (entry.isDirectory()) files.push(...walk(child));
+    if (entry.isFile() && entry.name.endsWith(".ts")) files.push(child);
+  }
+  return files.sort();
+}
+
+function importSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    ),
+    (match) => match[1] ?? match[2],
+  );
+}
+
+function resolveTarget(file: string, specifier: string) {
+  if (!specifier.startsWith(".")) return specifier;
+  return relative(root, join(root, dirname(file), specifier))
+    .replaceAll("\\", "/");
+}
+
+test("Users/Roles application sólo depende de domain/index y de sí misma", () => {
+  const violations: string[] = [];
+
+  for (const file of walk(applicationDir)) {
+    const source = read(file);
+    for (const specifier of importSpecifiers(source)) {
+      const target = resolveTarget(file, specifier);
+      const allowed =
+        target.startsWith(`${applicationDir}/`) ||
+        target === "server/features/users-roles/domain/index.ts";
+      if (!allowed) violations.push(`${file}: ${specifier} -> ${target}`);
+    }
+
+    for (const marker of [
+      "fastify",
+      "drizzle",
+      "server/db",
+      "server/lib",
+      "Audit",
+      "audit",
+      "auth",
+      "Cors",
+      "CORS",
+      "hash",
+      "session",
+      "fetch(",
+      "process.",
+    ]) {
+      if (source.includes(marker)) violations.push(`${file}: ${marker}`);
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("el puerto Users/Roles es mínimo y cada operación tiene caso de uso", () => {
+  const port = read(
+    `${applicationDir}/ports/admin-users-roles-repository.ts`,
+  );
+  const useCases = read(
+    `${applicationDir}/admin-users-roles-use-cases.ts`,
+  );
+
+  assert.equal(
+    (port.match(/getAdminUsersRolesSnapshot:/g) ?? []).length,
+    1,
+  );
+  assert.equal((port.match(/changeClinicUserRole:/g) ?? []).length, 1);
+  assert.equal(
+    (port.match(/Promise</g) ?? []).length,
+    2,
+  );
+  assert.match(useCases, /listAdminUsersRoles:/);
+  assert.match(useCases, /repository\.getAdminUsersRolesSnapshot\(query\)/);
+  assert.match(useCases, /repository\.changeClinicUserRole\(input\)/);
+});
+
+test("la factory pública tiene consumidor productivo y los handlers delegan", () => {
+  const index = read(`${applicationDir}/index.ts`);
+  const route = read(routeFile);
+
+  assert.match(index, /createAdminUsersRolesUseCases/);
+  assert.equal(
+    (route.match(/createAdminUsersRolesUseCases\s*\(/g) ?? []).length,
+    1,
+  );
+  assert.match(
+    route,
+    /usersRolesUseCases\.listAdminUsersRoles\(params\)/,
+  );
+  assert.match(
+    route,
+    /usersRolesUseCases\.changeClinicUserRole\(\{/,
+  );
+  assert.doesNotMatch(route, /deps\.getAdminUsersRolesSnapshot\(/);
+  assert.doesNotMatch(route, /deps\.changeClinicUserRole\(/);
+});
+
+test("credenciales siguen en Clinics y M43 no fue anticipado", () => {
+  const route = read(routeFile);
+  const featureSource = walk("server/features/users-roles")
+    .map(read)
+    .join("\n");
+
+  assert.match(route, /updateAdminClinicUserCredentialsCommand\(/);
+  assert.match(
+    route,
+    /features\/clinics\/admin-clinics-command-service\.ts/,
+  );
+  assert.doesNotMatch(featureSource, /Credentials|password|passwordHash/);
+  assert.equal(
+    existsSync(join(root, "server/features/users-roles/infrastructure")),
+    false,
+  );
+  assert.equal(existsSync(join(root, "server/db-admin-users-roles.ts")), true);
+  assert.doesNotMatch(featureSource, /\b(?:compat|legacy|shim)\b/i);
+});

--- a/test/architecture/users-roles-domain-boundary-guard.test.ts
+++ b/test/architecture/users-roles-domain-boundary-guard.test.ts
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const domainDir = "server/features/users-roles/domain";
+const domainIndex = `${domainDir}/index.ts`;
+
+function read(path: string) {
+  return readFileSync(join(root, path), "utf8").replace(/\r\n/g, "\n");
+}
+
+function domainTsFiles() {
+  return readdirSync(join(root, domainDir), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(".ts"))
+    .map((entry) => `${domainDir}/${entry.name}`)
+    .sort();
+}
+
+function importSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\b(?:from|import)\s*(?:\(\s*)?["']([^"']+)["']\s*\)?/g,
+    ),
+    (match) => match[1],
+  );
+}
+
+test("Users/Roles domain tiene inventario y barrel exactos", () => {
+  assert.deepEqual(domainTsFiles(), [
+    domainIndex,
+    `${domainDir}/user-role-policy.ts`,
+  ]);
+
+  const index = read(domainIndex);
+  assert.equal(
+    importSpecifiers(index).join(","),
+    "./user-role-policy.ts",
+  );
+  for (const symbol of [
+    "ADMIN_ROLE_USER_TYPES",
+    "ADMIN_ROLE_USER_ROLES",
+    "ADMIN_CLINIC_USER_ROLES",
+    "parseAdminRoleUserType",
+    "parseAdminRoleUserRole",
+    "parseAdminClinicUserRole",
+  ]) {
+    assert.match(index, new RegExp(`\\b${symbol}\\b`));
+  }
+});
+
+test("Users/Roles domain permanece puro y determinístico", () => {
+  const violations: string[] = [];
+  const forbidden = [
+    /fastify/i,
+    /drizzle/i,
+    /schema/i,
+    /(?:^|\/)db(?:-|\/|\.|$)/i,
+    /(?:^|\/)(application|infrastructure|routes|lib)(?:\/|$)/i,
+    /node:(?:fs|http|https|net|process)/i,
+  ];
+
+  for (const file of domainTsFiles()) {
+    const source = read(file);
+    for (const specifier of importSpecifiers(source)) {
+      if (forbidden.some((pattern) => pattern.test(specifier))) {
+        violations.push(`${file}: ${specifier}`);
+      }
+    }
+    for (const marker of [
+      "process.",
+      "fetch(",
+      "new Date(",
+      "Date.now(",
+      "getClinicPermissions",
+      "canManageClinicUsers",
+    ]) {
+      if (source.includes(marker)) {
+        violations.push(`${file}: ${marker}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("Users/Roles domain fija catálogos exactos sin enums ni permisos duplicados", () => {
+  const source = read(`${domainDir}/user-role-policy.ts`);
+
+  assert.match(
+    source,
+    /ADMIN_ROLE_USER_TYPES = \["admin", "clinic"\] as const/,
+  );
+  assert.match(
+    source,
+    /ADMIN_ROLE_USER_ROLES = \[\s*"admin",\s*"clinic_owner",\s*"clinic_staff",\s*\] as const/,
+  );
+  assert.match(
+    source,
+    /ADMIN_CLINIC_USER_ROLES = \[\s*"clinic_owner",\s*"clinic_staff",\s*\] as const/,
+  );
+  assert.doesNotMatch(source, /\benum\b/);
+  assert.doesNotMatch(source, /canUploadReports|canManageLogistics/);
+});
+
+test("los consumidores productivos usan domain/index.ts", () => {
+  const route = read("server/routes/admin-users-roles.fastify.ts");
+  const persistence = read("server/db-admin-users-roles.ts");
+
+  assert.match(route, /features\/users-roles\/domain\/index\.ts/);
+  assert.match(persistence, /features\/users-roles\/domain\/index\.ts/);
+  assert.doesNotMatch(
+    `${route}\n${persistence}`,
+    /features\/users-roles\/domain\/user-role-policy\.ts/,
+  );
+});

--- a/test/architecture/users-roles-permissions-kernel-guard.test.ts
+++ b/test/architecture/users-roles-permissions-kernel-guard.test.ts
@@ -1,0 +1,73 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const kernelFile = "server/lib/permissions.ts";
+const featureDir = "server/features/users-roles";
+
+function read(path: string) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+function walk(path: string): string[] {
+  const files: string[] = [];
+  for (const entry of readdirSync(join(root, path), { withFileTypes: true })) {
+    const child = `${path}/${entry.name}`;
+    if (entry.isDirectory()) files.push(...walk(child));
+    if (entry.isFile()) files.push(child);
+  }
+  return files;
+}
+
+function walkTs(path: string): string[] {
+  return walk(path).filter((file) => file.endsWith(".ts"));
+}
+
+test("permissions.ts permanece como kernel compartido en su path canónico", () => {
+  assert.equal(existsSync(join(root, kernelFile)), true);
+  const source = read(kernelFile);
+  assert.match(source, /export function getClinicPermissions/);
+  assert.match(source, /export type ClinicPermissions/);
+});
+
+test("Users/Roles no copia, reexporta ni importa el kernel de permisos", () => {
+  const violations: string[] = [];
+
+  for (const file of walk(featureDir)) {
+    const normalized = file.replaceAll("\\", "/");
+    if (/permissions\.ts$/i.test(normalized)) {
+      violations.push(`${normalized}: copia de permissions.ts`);
+    }
+    if (!normalized.endsWith(".ts")) {
+      continue;
+    }
+
+    const source = read(normalized);
+    if (/getClinicPermissions|ClinicPermissions/.test(source)) {
+      violations.push(`${normalized}: API del kernel duplicada o reexportada`);
+    }
+    if (/lib\/permissions\.ts/.test(source)) {
+      violations.push(`${normalized}: import del kernel`);
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("el fan-in productivo del kernel sigue siendo cross-context", () => {
+  const consumers = walkTs("server")
+    .filter((file) => file !== kernelFile)
+    .filter((file) => read(file).includes("permissions.ts"))
+    .sort();
+
+  assert.equal(consumers.length, 14);
+  assert.ok(consumers.some((file) => file.includes("logistics-")));
+  assert.ok(consumers.some((file) => file.includes("reports")));
+  assert.ok(consumers.some((file) => file.includes("clinic")));
+  assert.equal(
+    consumers.some((file) => file.startsWith(`${featureDir}/`)),
+    false,
+  );
+});

--- a/test/integration/adapters/controllers/admin-users-roles.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-users-roles.fastify.test.ts
@@ -20,16 +20,16 @@ type AdminUsersRolesNativeRoutesOptions = import(
   "../../../../server/routes/admin-users-roles.fastify.ts"
 ).AdminUsersRolesNativeRoutesOptions;
 type AdminUsersRolesQuery = import(
-  "../../../../server/db-admin-users-roles.ts"
+  "../../../../server/features/users-roles/application/index.ts"
 ).AdminUsersRolesQuery;
 type AdminUsersRolesSnapshot = import(
-  "../../../../server/db-admin-users-roles.ts"
+  "../../../../server/features/users-roles/application/index.ts"
 ).AdminUsersRolesSnapshot;
 type AdminRoleUserSummary = import(
-  "../../../../server/db-admin-users-roles.ts"
+  "../../../../server/features/users-roles/application/index.ts"
 ).AdminRoleUserSummary;
 type AdminClinicUserRoleChangeResult = import(
-  "../../../../server/db-admin-users-roles.ts"
+  "../../../../server/features/users-roles/application/index.ts"
 ).AdminClinicUserRoleChangeResult;
 type AdminClinicUserCredentialsUpdateResult = import(
   "../../../../server/features/clinics/admin-clinics-command-service.ts"

--- a/test/unit/application/users-roles/admin-users-roles-use-cases.test.ts
+++ b/test/unit/application/users-roles/admin-users-roles-use-cases.test.ts
@@ -1,0 +1,165 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  createAdminUsersRolesUseCases,
+  type AdminClinicUserRoleChangeInput,
+  type AdminClinicUserRoleChangeResult,
+  type AdminUsersRolesQuery,
+  type AdminUsersRolesRepository,
+  type AdminUsersRolesSnapshot,
+} from "../../../../server/features/users-roles/application/index.ts";
+
+const snapshot: AdminUsersRolesSnapshot = {
+  success: true,
+  users: [],
+  total: 0,
+  limit: 50,
+  offset: 0,
+  totals: {
+    adminUsers: 0,
+    clinicUsers: 0,
+  },
+};
+
+const roleChangedResult: AdminClinicUserRoleChangeResult = {
+  ok: true,
+  user: {
+    userType: "clinic",
+    userId: 7,
+    username: "clinic-user",
+    role: "clinic_owner",
+    clinicId: 3,
+    clinicName: "Clínica",
+    createdAt: "2026-07-27T00:00:00.000Z",
+    updatedAt: "2026-07-27T00:00:00.000Z",
+  },
+  previousRole: "clinic_staff",
+  roleChanged: true,
+};
+
+function createRepository(
+  overrides: Partial<AdminUsersRolesRepository> = {},
+): AdminUsersRolesRepository {
+  return {
+    getAdminUsersRolesSnapshot: async () => snapshot,
+    changeClinicUserRole: async () => roleChangedResult,
+    ...overrides,
+  };
+}
+
+test("listAdminUsersRoles delega una vez y preserva input/output por identidad", async () => {
+  const query: AdminUsersRolesQuery = {
+    userType: "clinic",
+    role: "clinic_owner",
+    search: "demo",
+    limit: 10,
+    offset: 5,
+  };
+  let calls = 0;
+  let received: AdminUsersRolesQuery | undefined;
+  let commandCalls = 0;
+  const useCases = createAdminUsersRolesUseCases(
+    createRepository({
+      getAdminUsersRolesSnapshot: async (input) => {
+        calls += 1;
+        received = input;
+        return snapshot;
+      },
+      changeClinicUserRole: async () => {
+        commandCalls += 1;
+        return roleChangedResult;
+      },
+    }),
+  );
+
+  const result = await useCases.listAdminUsersRoles(query);
+
+  assert.equal(calls, 1);
+  assert.equal(commandCalls, 0);
+  assert.strictEqual(received, query);
+  assert.strictEqual(result, snapshot);
+});
+
+test("changeClinicUserRole delega una vez y preserva input/output por identidad", async () => {
+  const input: AdminClinicUserRoleChangeInput = {
+    clinicUserId: 7,
+    role: "clinic_owner",
+    now: new Date("2026-07-27T00:00:00.000Z"),
+  };
+  let calls = 0;
+  let received: AdminClinicUserRoleChangeInput | undefined;
+  let readCalls = 0;
+  const useCases = createAdminUsersRolesUseCases(
+    createRepository({
+      getAdminUsersRolesSnapshot: async () => {
+        readCalls += 1;
+        return snapshot;
+      },
+      changeClinicUserRole: async (value) => {
+        calls += 1;
+        received = value;
+        return roleChangedResult;
+      },
+    }),
+  );
+
+  const result = await useCases.changeClinicUserRole(input);
+
+  assert.equal(calls, 1);
+  assert.equal(readCalls, 0);
+  assert.strictEqual(received, input);
+  assert.strictEqual(result, roleChangedResult);
+});
+
+for (const preservedResult of [
+  { ok: false, reason: "not_found" },
+  { ok: false, reason: "last_clinic_owner" },
+  {
+    ...roleChangedResult,
+    roleChanged: false,
+  },
+] satisfies AdminClinicUserRoleChangeResult[]) {
+  test(`changeClinicUserRole preserva ${preservedResult.ok ? "roleChanged false" : preservedResult.reason}`, async () => {
+    const useCases = createAdminUsersRolesUseCases(
+      createRepository({
+        changeClinicUserRole: async () => preservedResult,
+      }),
+    );
+
+    assert.strictEqual(
+      await useCases.changeClinicUserRole({
+        clinicUserId: 7,
+        role: "clinic_staff",
+      }),
+      preservedResult,
+    );
+  });
+}
+
+test("los errores del repository pasan sin envolver", async () => {
+  const readError = new Error("read failed");
+  const commandError = new Error("command failed");
+  const useCases = createAdminUsersRolesUseCases(
+    createRepository({
+      getAdminUsersRolesSnapshot: async () => {
+        throw readError;
+      },
+      changeClinicUserRole: async () => {
+        throw commandError;
+      },
+    }),
+  );
+
+  await assert.rejects(
+    useCases.listAdminUsersRoles({}),
+    (error) => error === readError,
+  );
+  await assert.rejects(
+    useCases.changeClinicUserRole({
+      clinicUserId: 7,
+      role: "clinic_staff",
+    }),
+    (error) => error === commandError,
+  );
+});

--- a/test/unit/application/users-roles/users-roles-suite-completeness.test.ts
+++ b/test/unit/application/users-roles/users-roles-suite-completeness.test.ts
@@ -1,0 +1,97 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const domainDir = "server/features/users-roles/domain";
+const applicationDir = "server/features/users-roles/application";
+const domainTestDir = "test/unit/domain/users-roles";
+const applicationTestDir = "test/unit/application/users-roles";
+const self = "users-roles-suite-completeness.test.ts";
+
+function read(path: string) {
+  return readFileSync(join(root, path), "utf8");
+}
+
+function names(path: string, suffix: string) {
+  return readdirSync(join(root, path), { withFileTypes: true })
+    .filter((entry) => entry.isFile() && entry.name.endsWith(suffix))
+    .map((entry) => entry.name.slice(0, -suffix.length))
+    .sort();
+}
+
+test("cada módulo productivo de domain y application tiene test correlativo", () => {
+  const domainModules = names(domainDir, ".ts").filter(
+    (name) => name !== "index",
+  );
+  const domainTests = names(domainTestDir, ".test.ts");
+  const applicationModules = names(applicationDir, ".ts").filter(
+    (name) => name !== "index",
+  );
+  const applicationTests = names(applicationTestDir, ".test.ts").filter(
+    (name) => `${name}.test.ts` !== self,
+  );
+
+  assert.deepEqual(domainTests, domainModules);
+  assert.deepEqual(applicationTests, applicationModules);
+});
+
+test("los barrels cubren todos los módulos y puertos", () => {
+  const domainIndex = read(`${domainDir}/index.ts`);
+  const applicationIndex = read(`${applicationDir}/index.ts`);
+  const portsIndex = read(`${applicationDir}/ports/index.ts`);
+
+  for (const module of names(domainDir, ".ts").filter(
+    (name) => name !== "index",
+  )) {
+    assert.match(domainIndex, new RegExp(`\\./${module}\\.ts`));
+  }
+  for (const module of names(applicationDir, ".ts").filter(
+    (name) => name !== "index",
+  )) {
+    assert.match(applicationIndex, new RegExp(`\\./${module}\\.ts`));
+  }
+  for (const port of names(`${applicationDir}/ports`, ".ts").filter(
+    (name) => name !== "index",
+  )) {
+    assert.match(portsIndex, new RegExp(`\\./${port}\\.ts`));
+  }
+});
+
+test("cada puerto tiene consumidor y los casos de uso públicos tienen test", () => {
+  const useCaseFile =
+    `${applicationDir}/admin-users-roles-use-cases.ts`;
+  const useCaseSource = read(useCaseFile);
+  const testSource = read(
+    `${applicationTestDir}/admin-users-roles-use-cases.test.ts`,
+  );
+
+  assert.match(
+    useCaseSource,
+    /ports\/admin-users-roles-repository\.ts/,
+  );
+  for (const operation of [
+    "listAdminUsersRoles",
+    "changeClinicUserRole",
+  ]) {
+    assert.match(useCaseSource, new RegExp(`\\b${operation}\\b`));
+    assert.match(testSource, new RegExp(`\\b${operation}\\b`));
+  }
+});
+
+test("Users/Roles no duplica el endpoint de credenciales", () => {
+  const productionSources = [
+    ...names(domainDir, ".ts")
+      .map((name) => `${domainDir}/${name}.ts`),
+    ...names(applicationDir, ".ts")
+      .map((name) => `${applicationDir}/${name}.ts`),
+    ...names(`${applicationDir}/ports`, ".ts")
+      .map((name) => `${applicationDir}/ports/${name}.ts`),
+  ].map(read).join("\n");
+
+  assert.doesNotMatch(
+    productionSources,
+    /credentials|password|hashPassword|updateAdminClinicUserCredentials/i,
+  );
+});

--- a/test/unit/contracts/admin/admin-users-roles-search-contract.test.ts
+++ b/test/unit/contracts/admin/admin-users-roles-search-contract.test.ts
@@ -113,7 +113,9 @@ test("search se aplica tanto al conteo (total/totalPages) como al listado pagina
 });
 
 test("AdminUsersRolesQuery expone search opcional sin romper el shape existente", () => {
-  const source = read("server/db-admin-users-roles.ts");
+  const source = read(
+    "server/features/users-roles/application/ports/admin-users-roles-repository.ts",
+  );
 
   const typeStart = source.indexOf("export type AdminUsersRolesQuery = {");
   const typeEnd = source.indexOf("};", typeStart) + 2;

--- a/test/unit/domain/users-roles/user-role-policy.test.ts
+++ b/test/unit/domain/users-roles/user-role-policy.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  ADMIN_CLINIC_USER_ROLES,
+  ADMIN_ROLE_USER_ROLES,
+  ADMIN_ROLE_USER_TYPES,
+  parseAdminClinicUserRole,
+  parseAdminRoleUserRole,
+  parseAdminRoleUserType,
+} from "../../../../server/features/users-roles/domain/index.ts";
+
+test("Users/Roles conserva los catálogos canónicos exactos", () => {
+  assert.deepEqual(ADMIN_ROLE_USER_TYPES, ["admin", "clinic"]);
+  assert.deepEqual(ADMIN_ROLE_USER_ROLES, [
+    "admin",
+    "clinic_owner",
+    "clinic_staff",
+  ]);
+  assert.deepEqual(ADMIN_CLINIC_USER_ROLES, [
+    "clinic_owner",
+    "clinic_staff",
+  ]);
+});
+
+test("parseAdminRoleUserType acepta admin y clinic", () => {
+  assert.equal(parseAdminRoleUserType("admin"), "admin");
+  assert.equal(parseAdminRoleUserType("clinic"), "clinic");
+});
+
+test("parseAdminRoleUserRole acepta el catálogo completo de filtros", () => {
+  assert.equal(parseAdminRoleUserRole("admin"), "admin");
+  assert.equal(parseAdminRoleUserRole("clinic_owner"), "clinic_owner");
+  assert.equal(parseAdminRoleUserRole("clinic_staff"), "clinic_staff");
+});
+
+test("parseAdminClinicUserRole acepta sólo roles mutables de clínica", () => {
+  assert.equal(parseAdminClinicUserRole("clinic_owner"), "clinic_owner");
+  assert.equal(parseAdminClinicUserRole("clinic_staff"), "clinic_staff");
+  assert.equal(parseAdminClinicUserRole("admin"), null);
+});
+
+test("los parsers rechazan tipos y strings desconocidos sin normalizar", () => {
+  const rejectedValues = [
+    null,
+    undefined,
+    {},
+    1,
+    "owner",
+    " clinic_owner ",
+    "CLINIC_STAFF",
+  ];
+
+  for (const value of rejectedValues) {
+    assert.equal(parseAdminRoleUserType(value), null);
+    assert.equal(parseAdminRoleUserRole(value), null);
+    assert.equal(parseAdminClinicUserRole(value), null);
+  }
+});


### PR DESCRIPTION
## Summary

- Change type: backend architecture refactor
- Context / issue: M42 Users/Roles domain and application use cases
- What changed:
  - establishes the canonical Users/Roles bounded-context domain
  - canonicalizes the administrative user and role types
  - adds a minimal repository port for snapshot reads and clinic-role changes
  - adds application use cases for listing users/roles and changing clinic-user roles
  - delegates the corresponding GET and PATCH role handlers through application
  - keeps clinic credential updates owned by the existing Clinics command
  - documents `server/lib/permissions.ts` as the shared authorization kernel
  - adds architecture guards, unit coverage and suite completeness

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Tests and documentation changed only as supporting evidence for the single backend-runtime scope.

## Mixed-Scope Justification

Not applicable.

## Other Scope Detail

M42 creates the Users/Roles domain and application boundaries without moving the root persistence module or completing the final thin-route closeout. Repository relocation, canonical infrastructure composition and phase closeout remain deferred to M43.

## Ownership decisions

- `server/lib/permissions.ts` remains byte-identical as the shared cross-context authorization kernel.
- Users/Roles owns administrative user/role semantics, DTOs and use cases.
- `PATCH /clinic/:clinicUserId/credentials` remains owned by Clinics through `updateAdminClinicUserCredentialsCommand`.
- Authentication, sessions, hashing, cookies and all three authentication realms remain outside M42.
- `server/db-admin-users-roles.ts` remains at its root path until M43.

## HTTP and behavioral compatibility

- preserves all six endpoint methods, paths and registration order
- preserves admin authentication and session last-access behavior
- preserves CORS, preflight and trusted-origin enforcement
- preserves query parsing, search trim behavior, pagination defaults and clamps
- preserves status codes, Spanish messages and response payloads
- preserves `checkedBy` and `changedBy`
- preserves audit events, metadata and persistence ÔåÆ audit ÔåÆ response ordering
- preserves the `last_clinic_owner` policy in persistence
- preserves credential hashing and update behavior under Clinics ownership
- preserves secret and password non-disclosure
- leaves `server/fastify-app.ts` unchanged

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected) - not applicable
- [ ] `pnpm --dir frontend typecheck` (if frontend affected) - not applicable
- [ ] `pnpm --dir frontend build` (if frontend affected) - not applicable
- [x] `pnpm audit --prod`
- [x] `pnpm audit`
- [x] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Additional observed validation:

- isolated M42 cohort: 26/26 passed after correcting one guard-only false positive
- directed M42/security/audit cohort: 156/156 passed
- `pnpm test`: 3,885 passed, 1 skipped, 0 failed
- `pnpm validate:local`: passed with typechecks, full test suite and build
- `pnpm security:public-surface`: passed with zero public findings
- `git diff --check`: passed
- final inventory: 21 files, 1,237 additions, 113 deletions
- 16 new files, 5 modified files and zero deletions
- zero direct handler calls to the two Users/Roles persistence dependencies
- zero copies or reexports of the permissions kernel

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Scope exclusions

- final repository move and infrastructure composition: M43 / NOT_RUN
- final thin-route closeout: M43 / NOT_RUN
- Auth realms and authentication helpers: NOT_RUN
- frontend: NOT_RUN
- Playwright: NOT_RUN
- schema: NOT_RUN
- migrations: NOT_RUN
- DB real manual validation: NOT_RUN
- staging: NOT_RUN
- production: NOT_RUN
- dependencies: NOT_RUN
- workflows/CI modifications: NOT_RUN
- subsequent milestones: NOT_RUN

## Rollback

- Trigger: regression in administrative user listing, filters, role changes, audit sequencing, authorization ownership or an existing HTTP contract.
- Steps: revert the M42 commit, restoring the route-local role parsers, root persistence-owned DTO declarations and direct handler dependency calls.
- Data impact: none expected. M42 contains no schema migration, data migration, SQL rewrite, dependency change or persisted-data transformation.