### PR TITLE
refactor(users-roles): move repository and thin route

### DIFF
--- a/docs/implementation/m43-users-roles-repository-thin-route-closeout.md
+++ b/docs/implementation/m43-users-roles-repository-thin-route-closeout.md
@@ -1,0 +1,198 @@
+# M43 — Users/Roles repository + thin-route closeout
+
+## 1. Identificación y baseline
+
+- Milestone: M43 — repository, composición final y thin-route closeout.
+- Rama:
+  `refactor/backend-modularization-m43-users-roles-repository-thin-closeout`.
+- Baseline y HEAD inicial:
+  `da73eb1291bc89b4ec505d22e337b173dd01219e`.
+- Working tree inicial: limpio.
+- Riesgo: R2 estructural backend autorizado exclusivamente para M43.
+- Terminal: una única Terminal 1; sin servidor, watcher ni proceso persistente.
+
+## 2. Censo inicial
+
+`server/db-admin-users-roles.ts` tenía un único consumidor productivo:
+`server/routes/admin-users-roles.fastify.ts`, mediante carga runtime lazy.
+Los anchors activos al path raíz estaban en el helper de scope Reports, los
+contratos de search y paginación, el contrato global de performance y los
+guards Users/Roles. Las menciones históricas en auditorías, propuestas y
+documentación de milestones anteriores se preservan.
+
+La ruta registraba seis endpoints, en este orden:
+
+1. `OPTIONS /`;
+2. `OPTIONS /clinic/:clinicUserId/role`;
+3. `OPTIONS /clinic/:clinicUserId/credentials`;
+4. `GET /`;
+5. `PATCH /clinic/:clinicUserId/role`;
+6. `PATCH /clinic/:clinicUserId/credentials`.
+
+No apareció ningún consumidor productivo adicional que exigiera ampliar la
+allowlist o conservar un shim.
+
+## 3. Ownership antes y después
+
+Antes, la ruta poseía el wiring lazy, resolvía defaults, componía los casos de
+uso y conocía el repository raíz concreto. La persistencia vivía fuera del
+bounded context.
+
+Después:
+
+- domain posee catálogos y parsers puros;
+- application posee DTOs, el puerto mínimo y los dos casos de uso;
+- infrastructure posee las consultas Drizzle y el mapping;
+- composition resuelve defaults lazy, combina overrides y compone los casos de
+  uso;
+- la ruta conserva HTTP, auth administrativa, sesión/last-access, CORS,
+  trusted origin, parsing, mensajes, status, payloads y auditoría;
+- Clinics conserva el command y la persistencia de credenciales;
+- `server/lib/permissions.ts` permanece como shared kernel.
+
+## 4. Arquitectura final
+
+```text
+admin-users-roles.fastify.ts
+  ├─ HTTP / auth / session / CORS / parsing / status / audit
+  └─ admin-users-roles-route-composition.ts
+       ├─ application/admin-users-roles-use-cases.ts
+       │    ├─ domain/index.ts
+       │    └─ AdminUsersRolesRepository
+       ├─ infrastructure/index.ts
+       │    └─ admin-users-roles-repository.ts
+       ├─ Auth/security dependencies existentes
+       ├─ audit writer existente
+       └─ Clinics credentials command existente
+```
+
+## 5. Repository move
+
+El contenido funcional de `server/db-admin-users-roles.ts` se movió completo a
+`server/features/users-roles/infrastructure/admin-users-roles-repository.ts`.
+Sólo cambiaron los imports por la nueva profundidad. Se conservaron consultas,
+joins, filtros, `ilike`, counts, paginación, offsets, ordenamiento, ISO,
+timestamps, motivos `not_found` / `last_clinic_owner`, `roleChanged` y `now`.
+
+El baseline no contenía un `db.transaction()` en
+`changeClinicUserRole`; M43 preserva ese límite transaccional existente —cero
+wrappers explícitos— para no reescribir semántica bajo un move. El test del
+repository fija expresamente esta realidad.
+
+El path raíz fue eliminado sin compat layer, shim ni reexport.
+
+## 6. Composition layer
+
+`admin-users-roles-route-composition.ts` mantiene un único
+`defaultDepsPromise` module-level. Los módulos DB, Auth/security, audit e
+infrastructure se importan sólo al resolver defaults. Una inyección completa
+evita esa carga; una parcial combina overrides con defaults.
+
+`createAdminUsersRolesUseCases` se invoca exactamente una vez por composición.
+La composición expone `resolveDeps`, los casos de uso, el clock y el command
+Clinics cableado, sin SQL, Drizzle, Fastify, reglas HTTP ni permissions.
+
+## 7. Thin route
+
+La ruta dejó de contener `defaultDepsPromise`, `loadDefaultDeps`, imports al
+repository raíz/concreto y composición inline de los casos de uso. Continúa
+registrando los seis endpoints en el mismo orden y delega GET/PATCH role a
+application mediante la composición.
+
+## 8. Contratos HTTP preservados
+
+Se preservan la firma pública `AdminUsersRolesNativeRoutesOptions`, inyección
+parcial/completa, autenticación administrativa, cookie/sesión, last-access,
+CORS, preflight, trusted origin, parsing de query/params/body, precedencia de
+errores, status codes, mensajes, payloads, `checkedBy`, `changedBy`, metadata,
+eventos de auditoría y `now: new Date(now())`.
+
+## 9. Credenciales permanecen en Clinics
+
+`PATCH /clinic/:clinicUserId/credentials` sigue ejecutando parse → hash →
+persistencia → audit → response mediante
+`updateAdminClinicUserCredentialsCommand`. La composición sólo cablea el
+command externo y sus dependencias existentes. Domain, application e
+infrastructure Users/Roles no contienen password, credenciales, hashing,
+repository ni caso de uso de credenciales.
+
+## 10. Permissions permanece shared kernel
+
+`server/lib/permissions.ts` no fue modificado, movido, copiado, envuelto ni
+reexportado. Ninguna capa Users/Roles ni su composición lo importa. Auth,
+sesiones, cookies, tokens y el authorization kernel quedaron fuera de M43.
+
+## 11. Anchors A/B/C
+
+- A — realineados: helper de scope Reports; domain/application guards; search;
+  heavy-list pagination; performance/resilience; Clinics infrastructure y
+  secuencia M35b.
+- B — agregados: infrastructure boundary guard, M43 closeout guard, test
+  source-aware del repository y discovery de infrastructure en suite
+  completeness.
+- C — preservados: integración Fastify, contratos admin auth/security/CSRF,
+  permisos, endpoints, mensajes, auditoría y opciones de inyección.
+
+## 12. Guards
+
+Los guards fijan: infrastructure y barrel reales; dos operaciones exactas del
+puerto; imports canónicos; ausencia de Fastify/HTTP/Auth/Clinics/credenciales
+en infrastructure; ruta sin repository concreto; composition conectada a
+application e infrastructure; path raíz ausente; ausencia de shim; permissions
+sin duplicación; discovery de tests de infrastructure y closeout M43.
+
+## 13. Validación
+
+| Comando | Estado | Exit | Evidencia |
+| --- | --- | ---: | --- |
+| `pnpm typecheck` (gate temprano) | PASSED | 0 | `tsc --noEmit` |
+| cohorte preliminar M43 | PASSED | 0 | 77 pass, 0 fail |
+| cohorte dirigida M43 | PASSED | 0 | 151 pass, 0 fail |
+| `pnpm typecheck` (gate final) | PASSED | 0 | `tsc --noEmit` |
+| `pnpm typecheck:test` | PASSED | 0 | `tsc -p ./test/tsconfig.json --noEmit` |
+| `pnpm test` | PASSED | 0 | 3903 tests; 3902 pass, 1 skip, 0 fail |
+| `pnpm build` | PASSED | 0 | esbuild generó `dist/index.js` |
+| `pnpm security:public-surface` | PASSED | 0 | cero exposición pública |
+| `pnpm audit --prod` | PASSED | 0 | sin vulnerabilidades conocidas |
+| `pnpm audit` | PASSED | 0 | sin vulnerabilidades conocidas |
+| `pnpm validate:local` | PASSED | 0 | typechecks + 3903/3902/1/0 + build |
+| guards de closeout reejecutados | PASSED | 0 | 13 pass, 0 fail |
+| `git diff --check` | PASSED | 0 | sin whitespace errors |
+| `git diff --cached --check` | PASSED | 0 | índice vacío, sin errores |
+
+No se ejecuta DB real ni migraciones. La integración con Postgres corresponde
+a CI; el test local del adapter es source-aware y no simula Drizzle.
+
+## 14. Fail-fast y reintentos
+
+No hubo fallos de implementación ni validación. Todos los comandos ejecutados
+terminaron con exit code 0; no se requirieron reintentos.
+
+## 15. Riesgos
+
+Riesgo principal: regresión contractual al mover persistencia y wiring.
+Mitigación: move 1:1, composición lazy, options intactas, guards source-aware,
+integración Fastify y suites amplias. Riesgo residual: la semántica preexistente
+del cambio de rol no usa una transacción explícita; M43 no la altera.
+
+## 16. Rollback
+
+Revertir M43 restaura `server/db-admin-users-roles.ts`, devuelve el wiring lazy
+y la factory de casos de uso a la ruta, elimina composition/infrastructure y
+reapunta los anchors al path raíz. No requiere rollback de schema, migraciones,
+datos, credenciales, Auth ni permissions.
+
+## 17. Exclusiones
+
+Sin cambios en frontend, schema, migraciones, seed, Supabase, manifests,
+lockfile, dependencias, scripts, CI/workflows, Docker, email, infraestructura
+global de auditoría, helpers CORS/session, API pública, `server/fastify-app.ts`,
+Auth ni worktrees/ramas ajenos.
+
+## 18. Git/GitHub y estado de Fase J
+
+Stage, commit, amend, push, PR y merge: `NOT_RUN`; son operaciones manuales de
+Nico. No se ejecutó ningún comando Git/GitHub de escritura.
+
+M43: cerrado. La Fase J queda cerrada localmente con repository canónico,
+composition final, ruta thin, anchors realineados y gates amplios aprobados.

--- a/server/features/users-roles/README.md
+++ b/server/features/users-roles/README.md
@@ -1,16 +1,17 @@
 # Users/Roles bounded context
 
-M42 abre la Fase J con dominio puro, DTOs y casos de uso de application. La
-topología vigente es:
+M43 cierra la Fase J con dominio puro, casos de uso, persistencia canónica y
+composición lazy. La topología vigente es:
 
 ```text
 admin-users-roles.fastify.ts
   ├─ HTTP / auth / CORS / parsing / status / audit
-  ├─ application use cases
-  │    ├─ domain
-  │    └─ AdminUsersRolesRepository port
-  ├─ server/db-admin-users-roles.ts
-  └─ Clinics credentials command
+  └─ admin-users-roles-route-composition.ts
+       ├─ application use cases
+       │    ├─ domain
+       │    └─ AdminUsersRolesRepository port
+       ├─ infrastructure/admin-users-roles-repository.ts
+       └─ Clinics credentials command
 ```
 
 Users/Roles administra identidades, catálogo de roles y operaciones
@@ -23,5 +24,8 @@ El cambio de credenciales conserva ownership en Clinics mediante
 `updateAdminClinicUserCredentialsCommand`. Users/Roles no posee hashing ni
 persistencia de credenciales.
 
-La persistencia raíz permanece en `server/db-admin-users-roles.ts`. Su move,
-composition final y thin-route closeout corresponden exclusivamente a M43.
+La persistencia vive en
+`server/features/users-roles/infrastructure/admin-users-roles-repository.ts`;
+el path raíz fue retirado sin shim. La ruta consume únicamente la composición,
+que resuelve defaults de forma lazy y preserva los overrides de
+`AdminUsersRolesNativeRoutesOptions`.

--- a/server/features/users-roles/admin-users-roles-route-composition.ts
+++ b/server/features/users-roles/admin-users-roles-route-composition.ts
@@ -1,0 +1,180 @@
+import type { AuditWriteInput } from "../../lib/audit.ts";
+import type {
+  AdminClinicUserCredentialsCommandInput,
+  AdminClinicUserCredentialsUpdateInput,
+  AdminClinicUserCredentialsUpdateResult,
+} from "../clinics/admin-clinics-command-service.ts";
+import {
+  createAdminUsersRolesUseCases,
+  type AdminClinicUserRoleChangeInput,
+  type AdminClinicUserRoleChangeResult,
+  type AdminUsersRolesQuery,
+  type AdminUsersRolesSnapshot,
+} from "./application/index.ts";
+
+type AdminSessionRecord = {
+  id: number;
+  adminUserId: number;
+  expiresAt: Date | null;
+  lastAccess?: Date | null;
+};
+
+type SessionAdminUserRecord = {
+  id: number;
+  username: string;
+};
+
+type AdminSessionWithUserRecord = {
+  session: AdminSessionRecord;
+  adminUser: SessionAdminUserRecord | null;
+};
+
+export type AdminUsersRolesRouteCompositionOptions = {
+  deleteAdminSession?: (tokenHash: string) => Promise<void>;
+  getAdminSessionWithUser?: (
+    tokenHash: string,
+  ) => Promise<AdminSessionWithUserRecord | null>;
+  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
+  hashSessionToken?: (token: string) => string;
+  getAdminUsersRolesSnapshot?: (
+    params: AdminUsersRolesQuery,
+  ) => Promise<AdminUsersRolesSnapshot>;
+  changeClinicUserRole?: (
+    input: AdminClinicUserRoleChangeInput,
+  ) => Promise<AdminClinicUserRoleChangeResult>;
+  updateAdminClinicUserCredentials?: (
+    input: AdminClinicUserCredentialsUpdateInput,
+  ) => Promise<AdminClinicUserCredentialsUpdateResult>;
+  hashPassword?: (password: string) => Promise<string>;
+  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
+  now?: () => number;
+};
+
+type AdminUsersRolesDefaultDeps = Required<
+  Pick<
+    AdminUsersRolesRouteCompositionOptions,
+    | "deleteAdminSession"
+    | "getAdminSessionWithUser"
+    | "updateAdminSessionLastAccess"
+    | "hashSessionToken"
+    | "getAdminUsersRolesSnapshot"
+    | "changeClinicUserRole"
+    | "hashPassword"
+    | "writeAuditLog"
+  >
+>;
+
+export type AdminUsersRolesResolvedRouteDeps =
+  AdminUsersRolesDefaultDeps &
+    Pick<
+      AdminUsersRolesRouteCompositionOptions,
+      "updateAdminClinicUserCredentials"
+    >;
+
+let defaultDepsPromise:
+  | Promise<AdminUsersRolesDefaultDeps>
+  | undefined;
+
+async function loadDefaultDeps(): Promise<AdminUsersRolesDefaultDeps> {
+  if (!defaultDepsPromise) {
+    defaultDepsPromise = (async () => {
+      const [db, authSecurity, audit, repository] = await Promise.all([
+        import("../../db.ts"),
+        import("../../lib/auth-security.ts"),
+        import("../../lib/audit.ts"),
+        import("./infrastructure/index.ts"),
+      ]);
+
+      return {
+        deleteAdminSession: db.deleteAdminSession,
+        getAdminSessionWithUser: db.getAdminSessionWithUser,
+        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
+        hashSessionToken: authSecurity.hashSessionToken,
+        getAdminUsersRolesSnapshot:
+          repository.getAdminUsersRolesSnapshot,
+        changeClinicUserRole: repository.changeClinicUserRole,
+        hashPassword: authSecurity.hashPassword,
+        writeAuditLog: audit.writeAuditLog as (
+          req: unknown,
+          input: AuditWriteInput,
+        ) => Promise<void>,
+      };
+    })();
+  }
+
+  return defaultDepsPromise;
+}
+
+export function createAdminUsersRolesRouteComposition(
+  options: AdminUsersRolesRouteCompositionOptions,
+) {
+  const now = options.now ?? (() => Date.now());
+
+  async function resolveDeps(): Promise<AdminUsersRolesResolvedRouteDeps> {
+    const hasAllInjectedDeps =
+      !!options.deleteAdminSession &&
+      !!options.getAdminSessionWithUser &&
+      !!options.updateAdminSessionLastAccess &&
+      !!options.hashSessionToken &&
+      !!options.getAdminUsersRolesSnapshot &&
+      !!options.changeClinicUserRole &&
+      !!options.hashPassword &&
+      !!options.writeAuditLog;
+
+    const defaultDeps = hasAllInjectedDeps
+      ? undefined
+      : await loadDefaultDeps();
+
+    return {
+      deleteAdminSession:
+        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
+      getAdminSessionWithUser:
+        options.getAdminSessionWithUser ??
+        defaultDeps!.getAdminSessionWithUser,
+      updateAdminSessionLastAccess:
+        options.updateAdminSessionLastAccess ??
+        defaultDeps!.updateAdminSessionLastAccess,
+      hashSessionToken:
+        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
+      getAdminUsersRolesSnapshot:
+        options.getAdminUsersRolesSnapshot ??
+        defaultDeps!.getAdminUsersRolesSnapshot,
+      changeClinicUserRole:
+        options.changeClinicUserRole ??
+        defaultDeps!.changeClinicUserRole,
+      updateAdminClinicUserCredentials:
+        options.updateAdminClinicUserCredentials,
+      hashPassword: options.hashPassword ?? defaultDeps!.hashPassword,
+      writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
+    };
+  }
+
+  const usersRolesUseCases = createAdminUsersRolesUseCases({
+    getAdminUsersRolesSnapshot: async (query) =>
+      (await resolveDeps()).getAdminUsersRolesSnapshot(query),
+    changeClinicUserRole: async (input) =>
+      (await resolveDeps()).changeClinicUserRole(input),
+  });
+
+  async function updateAdminClinicUserCredentials(
+    input: AdminClinicUserCredentialsCommandInput,
+    deps: AdminUsersRolesResolvedRouteDeps,
+  ): Promise<AdminClinicUserCredentialsUpdateResult> {
+    const { updateAdminClinicUserCredentialsCommand } = await import(
+      "../clinics/admin-clinics-command-service.ts"
+    );
+
+    return updateAdminClinicUserCredentialsCommand(input, {
+      hashPassword: deps.hashPassword,
+      updateAdminClinicUserCredentials:
+        deps.updateAdminClinicUserCredentials,
+    });
+  }
+
+  return {
+    now,
+    resolveDeps,
+    usersRolesUseCases,
+    updateAdminClinicUserCredentials,
+  };
+}

--- a/server/features/users-roles/infrastructure/README.md
+++ b/server/features/users-roles/infrastructure/README.md
@@ -1,0 +1,13 @@
+# Users/Roles infrastructure
+
+Esta capa implementa el puerto `AdminUsersRolesRepository` con Drizzle y la
+persistencia compartida existente.
+
+`admin-users-roles-repository.ts` conserva las consultas, joins, filtros,
+búsqueda `ilike`, conteos, paginación, ordenamiento, serialización ISO y
+reglas de cambio de rol del repository raíz retirado en M43. El barrel
+`index.ts` es la entrada canónica para la composición productiva.
+
+Infrastructure no posee HTTP, Fastify, Auth, sesiones, CORS, auditoría,
+credenciales, hashing ni reglas de Clinics. Tampoco importa el kernel
+compartido `server/lib/permissions.ts`.

--- a/server/features/users-roles/infrastructure/admin-users-roles-repository.ts
+++ b/server/features/users-roles/infrastructure/admin-users-roles-repository.ts
@@ -1,24 +1,24 @@
 import { and, asc, eq, ilike, ne, or, sql } from "drizzle-orm";
 
-import { db } from "./db.ts";
+import { db } from "../../../db.ts";
 import {
   adminUsers,
   clinicPublicProfiles,
   clinicUsers,
   clinics,
-} from "../drizzle/schema.ts";
+} from "../../../../drizzle/schema.ts";
 import type {
   AdminClinicUserRole,
   AdminRoleUserRole,
-} from "./features/users-roles/domain/index.ts";
+} from "../domain/index.ts";
 import type {
   AdminClinicUserRoleChangeInput,
   AdminClinicUserRoleChangeResult,
   AdminRoleUserSummary,
   AdminUsersRolesQuery,
   AdminUsersRolesSnapshot,
-} from "./features/users-roles/application/index.ts";
-import { normalizeListPagination } from "./lib/list-pagination.ts";
+} from "../application/index.ts";
+import { normalizeListPagination } from "../../../lib/list-pagination.ts";
 
 type ClinicUserRoleRow = {
   userId: number;

--- a/server/features/users-roles/infrastructure/index.ts
+++ b/server/features/users-roles/infrastructure/index.ts
@@ -1,0 +1,1 @@
+export * from "./admin-users-roles-repository.ts";

--- a/server/routes/admin-users-roles.fastify.ts
+++ b/server/routes/admin-users-roles.fastify.ts
@@ -11,46 +11,22 @@ import {
   getRequestOrigin,
   enforceTrustedOrigin,
 } from "../lib/cors-headers.ts";
-import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
+import { AUDIT_EVENTS } from "../lib/audit.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
 import type {
-  AdminClinicUserRoleChangeInput,
-  AdminClinicUserRoleChangeResult,
   AdminUsersRolesQuery,
-  AdminUsersRolesSnapshot,
 } from "../features/users-roles/application/index.ts";
-import { createAdminUsersRolesUseCases } from "../features/users-roles/application/index.ts";
+import {
+  createAdminUsersRolesRouteComposition,
+  type AdminUsersRolesResolvedRouteDeps,
+  type AdminUsersRolesRouteCompositionOptions,
+} from "../features/users-roles/admin-users-roles-route-composition.ts";
 import {
   parseAdminClinicUserRole,
   parseAdminRoleUserRole,
   parseAdminRoleUserType,
   type AdminClinicUserRole,
 } from "../features/users-roles/domain/index.ts";
-import type {
-  AdminClinicUserCredentialsUpdateInput,
-  AdminClinicUserCredentialsUpdateResult,
-} from "../features/clinics/admin-clinics-command-service.ts";
-import {
-  updateAdminClinicUserCredentialsCommand,
-} from "../features/clinics/admin-clinics-command-service.ts";
-
-type AdminSessionRecord = {
-  id: number;
-  adminUserId: number;
-  expiresAt: Date | null;
-  lastAccess?: Date | null;
-};
-
-type SessionAdminUserRecord = {
-  id: number;
-  username: string;
-};
-
-type AdminSessionWithUserRecord = {
-  session: AdminSessionRecord;
-  adminUser: SessionAdminUserRecord | null;
-};
-
 type AuthenticatedAdminUser = {
   id: number;
   username: string;
@@ -81,83 +57,13 @@ type AdminUsersRolesCredentialsChangeBody = {
   password?: unknown;
 };
 
-export type AdminUsersRolesNativeRoutesOptions = {
-  deleteAdminSession?: (tokenHash: string) => Promise<void>;
-  getAdminSessionWithUser?: (
-    tokenHash: string,
-  ) => Promise<AdminSessionWithUserRecord | null>;
-  updateAdminSessionLastAccess?: (tokenHash: string) => Promise<void>;
-  hashSessionToken?: (token: string) => string;
-  getAdminUsersRolesSnapshot?: (
-    params: AdminUsersRolesQuery,
-  ) => Promise<AdminUsersRolesSnapshot>;
-  changeClinicUserRole?: (
-    input: AdminClinicUserRoleChangeInput,
-  ) => Promise<AdminClinicUserRoleChangeResult>;
-  updateAdminClinicUserCredentials?: (
-    input: AdminClinicUserCredentialsUpdateInput,
-  ) => Promise<AdminClinicUserCredentialsUpdateResult>;
-  hashPassword?: (password: string) => Promise<string>;
-  writeAuditLog?: (req: unknown, input: AuditWriteInput) => Promise<void>;
-  now?: () => number;
-};
-
-type NativeAdminUsersRolesCoreDeps = Required<
-  Pick<
-    AdminUsersRolesNativeRoutesOptions,
-    | "deleteAdminSession"
-    | "getAdminSessionWithUser"
-    | "updateAdminSessionLastAccess"
-    | "hashSessionToken"
-    | "getAdminUsersRolesSnapshot"
-    | "changeClinicUserRole"
-    | "hashPassword"
-    | "writeAuditLog"
-  >
->;
-
-type NativeAdminUsersRolesDeps =
-  NativeAdminUsersRolesCoreDeps &
-    Pick<
-      AdminUsersRolesNativeRoutesOptions,
-      "updateAdminClinicUserCredentials"
-    >;
-
-let defaultDepsPromise:
-  | Promise<NativeAdminUsersRolesCoreDeps>
-  | undefined;
-
-async function loadDefaultDeps(): Promise<NativeAdminUsersRolesCoreDeps> {
-  if (!defaultDepsPromise) {
-    defaultDepsPromise = (async () => {
-      const db = await import("../db.ts");
-      const authSecurity = await import("../lib/auth-security.ts");
-      const audit = await import("../lib/audit.ts");
-      const usersRoles = await import("../db-admin-users-roles.ts");
-
-      return {
-        deleteAdminSession: db.deleteAdminSession,
-        getAdminSessionWithUser: db.getAdminSessionWithUser,
-        updateAdminSessionLastAccess: db.updateAdminSessionLastAccess,
-        hashSessionToken: authSecurity.hashSessionToken,
-        getAdminUsersRolesSnapshot: usersRoles.getAdminUsersRolesSnapshot,
-        changeClinicUserRole: usersRoles.changeClinicUserRole,
-        hashPassword: authSecurity.hashPassword,
-        writeAuditLog: audit.writeAuditLog as (
-          req: unknown,
-          input: AuditWriteInput,
-        ) => Promise<void>,
-      };
-    })();
-  }
-
-  return defaultDepsPromise!;
-}
+export type AdminUsersRolesNativeRoutesOptions =
+  AdminUsersRolesRouteCompositionOptions;
 
 async function authenticateAdminUser(
   request: FastifyRequest,
   reply: FastifyReply,
-  deps: NativeAdminUsersRolesDeps,
+  deps: AdminUsersRolesResolvedRouteDeps,
   now: () => number,
 ): Promise<AuthenticatedAdminUser | null> {
   return authenticateFastifyAdmin(request, reply, {
@@ -354,51 +260,13 @@ function createAuditRequestLike(
 export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
   AdminUsersRolesNativeRoutesOptions
 > = async (app, options) => {
-  const now = options.now ?? (() => Date.now());
+  const {
+    now,
+    resolveDeps,
+    usersRolesUseCases,
+    updateAdminClinicUserCredentials,
+  } = createAdminUsersRolesRouteComposition(options);
   const allowedOrigins = new Set(getAllowedOrigins());
-
-  async function resolveDeps(): Promise<NativeAdminUsersRolesDeps> {
-    const hasAllInjectedDeps =
-      !!options.deleteAdminSession &&
-      !!options.getAdminSessionWithUser &&
-      !!options.updateAdminSessionLastAccess &&
-      !!options.hashSessionToken &&
-      !!options.getAdminUsersRolesSnapshot &&
-      !!options.changeClinicUserRole &&
-      !!options.hashPassword &&
-      !!options.writeAuditLog;
-
-    const defaultDeps = hasAllInjectedDeps ? undefined : await loadDefaultDeps();
-
-    return {
-      deleteAdminSession:
-        options.deleteAdminSession ?? defaultDeps!.deleteAdminSession,
-      getAdminSessionWithUser:
-        options.getAdminSessionWithUser ??
-        defaultDeps!.getAdminSessionWithUser,
-      updateAdminSessionLastAccess:
-        options.updateAdminSessionLastAccess ??
-        defaultDeps!.updateAdminSessionLastAccess,
-      hashSessionToken:
-        options.hashSessionToken ?? defaultDeps!.hashSessionToken,
-      getAdminUsersRolesSnapshot:
-        options.getAdminUsersRolesSnapshot ??
-        defaultDeps!.getAdminUsersRolesSnapshot,
-      changeClinicUserRole:
-        options.changeClinicUserRole ?? defaultDeps!.changeClinicUserRole,
-      updateAdminClinicUserCredentials:
-        options.updateAdminClinicUserCredentials,
-      hashPassword: options.hashPassword ?? defaultDeps!.hashPassword,
-      writeAuditLog: options.writeAuditLog ?? defaultDeps!.writeAuditLog,
-    };
-  }
-
-  const usersRolesUseCases = createAdminUsersRolesUseCases({
-    getAdminUsersRolesSnapshot: async (query) =>
-      (await resolveDeps()).getAdminUsersRolesSnapshot(query),
-    changeClinicUserRole: async (input) =>
-      (await resolveDeps()).changeClinicUserRole(input),
-  });
 
   app.addHook("onRequest", async (request, reply) => {
     applyCorsHeaders(request, reply, allowedOrigins);
@@ -585,18 +453,14 @@ export const adminUsersRolesNativeRoutes: FastifyPluginAsync<
     }
 
     const result =
-      await updateAdminClinicUserCredentialsCommand(
+      await updateAdminClinicUserCredentials(
         {
           clinicUserId,
           username: parsed.data.username,
           password: parsed.data.password,
           now: new Date(now()),
         },
-        {
-          hashPassword: deps.hashPassword,
-          updateAdminClinicUserCredentials:
-            deps.updateAdminClinicUserCredentials,
-        },
+        deps,
       );
 
     if (!result.ok && result.reason === "not_found") {

--- a/test/architecture/clinics-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/clinics-infrastructure-boundary-guard.test.ts
@@ -18,6 +18,8 @@ const queryServiceFile =
   featureDir + "/admin-clinics-query-service.ts";
 const commandServiceFile =
   featureDir + "/admin-clinics-command-service.ts";
+const usersRolesCompositionFile =
+  "server/features/users-roles/admin-users-roles-route-composition.ts";
 const publicProfileQueryServiceFile =
   featureDir + "/clinic-public-profile-query-service.ts";
 const publicProfileCommandServiceFile =
@@ -467,7 +469,7 @@ test(
       ],
       [
         "server/routes/admin-users-roles.fastify.ts",
-        [commandServiceFile],
+        [usersRolesCompositionFile],
       ],
     ]);
 
@@ -509,17 +511,29 @@ test(
 );
 
 test(
-  "admin-users-roles delega sólo el comando Clinics de credenciales",
+  "composition Users/Roles delega sólo el comando Clinics de credenciales",
   () => {
-    const source = readText(
+    const routeSource = readText(
       "server/routes/admin-users-roles.fastify.ts",
     );
+    const source = readText(usersRolesCompositionFile);
 
     assert.equal(
       source.match(
         /\bupdateAdminClinicUserCredentialsCommand\s*\(/g,
       )?.length ?? 0,
       1,
+    );
+    assert.equal(
+      routeSource.includes("updateAdminClinicUserCredentialsCommand"),
+      false,
+    );
+    assert.ok(
+      listImportSpecifiers(source)
+        .map((specifier) =>
+          resolveSpecifier(usersRolesCompositionFile, specifier),
+        )
+        .includes(commandServiceFile),
     );
 
     for (const unrelatedCommand of [

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -23,6 +23,8 @@ const reportsM41Closeout =
   "docs/implementation/m41-reports-compatibility-shim-retirement.md";
 const usersRolesM42Closeout =
   "docs/implementation/m42-users-roles-domain-use-cases.md";
+const usersRolesM43Closeout =
+  "docs/implementation/m43-users-roles-repository-thin-route-closeout.md";
 
 const featureLayers = [
   {
@@ -365,7 +367,7 @@ test("M35b mantiene conectados los guards globales de token access", () => {
   }
 });
 
-test("M35b preserva la secuencia materializada hasta M42 y mantiene M43 no iniciado", () => {
+test("M35b preserva la secuencia materializada hasta el cierre M43", () => {
   for (const path of [
     "docs/implementation/public-report-access-error-path-redaction-hotfix.md",
     closeout,
@@ -392,15 +394,24 @@ test("M35b preserva la secuencia materializada hasta M42 y mantiene M43 no inici
   assert.equal(existsSync(resolve(root, reportsM40Closeout)), true);
   assert.equal(existsSync(resolve(root, reportsM41Closeout)), true);
   assert.equal(existsSync(resolve(root, usersRolesM42Closeout)), true);
+  assert.equal(existsSync(resolve(root, usersRolesM43Closeout)), true);
 
   const usersRolesM42Source = read(usersRolesM42Closeout);
   for (const marker of [
     "M42 — Users/Roles domain + application use cases",
     "M43 queda responsable",
-    "M43: `NOT_RUN`",
   ]) {
     assert.equal(usersRolesM42Source.includes(marker), true, marker);
   }
+  const usersRolesM43Source = read(usersRolesM43Closeout);
+  for (const marker of [
+    "M43 — Users/Roles repository + thin-route closeout",
+    "Fase J",
+    "M43: cerrado",
+  ]) {
+    assert.equal(usersRolesM43Source.includes(marker), true, marker);
+  }
+  assert.doesNotMatch(usersRolesM43Source, /M43:\s*`?NOT_RUN`?/);
 
   for (const path of [
     "server/features/reports/application",
@@ -413,5 +424,5 @@ test("M35b preserva la secuencia materializada hasta M42 y mantiene M43 no inici
   const m43Closeouts = walk("docs/implementation").filter((path) =>
     /\/m43-/i.test(path),
   );
-  assert.deepEqual(m43Closeouts, []);
+  assert.deepEqual(m43Closeouts, [usersRolesM43Closeout]);
 });

--- a/test/architecture/users-roles-application-boundary-guard.test.ts
+++ b/test/architecture/users-roles-application-boundary-guard.test.ts
@@ -6,6 +6,10 @@ import test from "node:test";
 const root = process.cwd();
 const applicationDir = "server/features/users-roles/application";
 const routeFile = "server/routes/admin-users-roles.fastify.ts";
+const compositionFile =
+  "server/features/users-roles/admin-users-roles-route-composition.ts";
+const infrastructureDir =
+  "server/features/users-roles/infrastructure";
 
 function read(path: string) {
   return readFileSync(join(root, path), "utf8").replace(/\r\n/g, "\n");
@@ -96,12 +100,15 @@ test("el puerto Users/Roles es mínimo y cada operación tiene caso de uso", () 
 test("la factory pública tiene consumidor productivo y los handlers delegan", () => {
   const index = read(`${applicationDir}/index.ts`);
   const route = read(routeFile);
+  const composition = read(compositionFile);
 
   assert.match(index, /createAdminUsersRolesUseCases/);
   assert.equal(
-    (route.match(/createAdminUsersRolesUseCases\s*\(/g) ?? []).length,
+    (composition.match(/createAdminUsersRolesUseCases\s*\(/g) ?? []).length,
     1,
   );
+  assert.doesNotMatch(route, /createAdminUsersRolesUseCases\s*\(/);
+  assert.match(route, /createAdminUsersRolesRouteComposition\(options\)/);
   assert.match(
     route,
     /usersRolesUseCases\.listAdminUsersRoles\(params\)/,
@@ -114,22 +121,37 @@ test("la factory pública tiene consumidor productivo y los handlers delegan", (
   assert.doesNotMatch(route, /deps\.changeClinicUserRole\(/);
 });
 
-test("credenciales siguen en Clinics y M43 no fue anticipado", () => {
+test("credenciales siguen en Clinics y M43 queda compuesto", () => {
   const route = read(routeFile);
-  const featureSource = walk("server/features/users-roles")
+  const composition = read(compositionFile);
+  const ownedLayerSource = [
+    ...walk("server/features/users-roles/domain"),
+    ...walk(applicationDir),
+    ...walk(infrastructureDir),
+  ]
     .map(read)
     .join("\n");
 
-  assert.match(route, /updateAdminClinicUserCredentialsCommand\(/);
+  assert.doesNotMatch(route, /updateAdminClinicUserCredentialsCommand\(/);
   assert.match(
-    route,
-    /features\/clinics\/admin-clinics-command-service\.ts/,
+    composition,
+    /\.\.\/clinics\/admin-clinics-command-service\.ts/,
   );
-  assert.doesNotMatch(featureSource, /Credentials|password|passwordHash/);
+  assert.match(composition, /updateAdminClinicUserCredentialsCommand/);
+  assert.doesNotMatch(
+    ownedLayerSource,
+    /Credentials|password|passwordHash/,
+  );
   assert.equal(
-    existsSync(join(root, "server/features/users-roles/infrastructure")),
+    existsSync(join(root, infrastructureDir)),
+    true,
+  );
+  assert.equal(
+    existsSync(join(root, "server/db-admin-users-roles.ts")),
     false,
   );
-  assert.equal(existsSync(join(root, "server/db-admin-users-roles.ts")), true);
-  assert.doesNotMatch(featureSource, /\b(?:compat|legacy|shim)\b/i);
+  assert.doesNotMatch(
+    `${route}\n${composition}\n${ownedLayerSource}`,
+    /\b(?:compat|legacy|shim)\b/i,
+  );
 });

--- a/test/architecture/users-roles-domain-boundary-guard.test.ts
+++ b/test/architecture/users-roles-domain-boundary-guard.test.ts
@@ -106,10 +106,12 @@ test("Users/Roles domain fija catálogos exactos sin enums ni permisos duplicado
 
 test("los consumidores productivos usan domain/index.ts", () => {
   const route = read("server/routes/admin-users-roles.fastify.ts");
-  const persistence = read("server/db-admin-users-roles.ts");
+  const persistence = read(
+    "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
+  );
 
   assert.match(route, /features\/users-roles\/domain\/index\.ts/);
-  assert.match(persistence, /features\/users-roles\/domain\/index\.ts/);
+  assert.match(persistence, /\.\.\/domain\/index\.ts/);
   assert.doesNotMatch(
     `${route}\n${persistence}`,
     /features\/users-roles\/domain\/user-role-policy\.ts/,

--- a/test/architecture/users-roles-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/users-roles-infrastructure-boundary-guard.test.ts
@@ -1,0 +1,177 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const featureDir = "server/features/users-roles";
+const infrastructureDir = `${featureDir}/infrastructure`;
+const repositoryFile =
+  `${infrastructureDir}/admin-users-roles-repository.ts`;
+const barrelFile = `${infrastructureDir}/index.ts`;
+const compositionFile =
+  `${featureDir}/admin-users-roles-route-composition.ts`;
+const routeFile = "server/routes/admin-users-roles.fastify.ts";
+const legacyFile = "server/db-admin-users-roles.ts";
+const portFile =
+  `${featureDir}/application/ports/admin-users-roles-repository.ts`;
+
+function read(path: string) {
+  return readFileSync(resolve(root, path), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function walk(path: string): string[] {
+  return readdirSync(resolve(root, path), { withFileTypes: true })
+    .flatMap((entry) => {
+      const child = `${path}/${entry.name}`;
+      return entry.isDirectory() ? walk(child) : [child];
+    })
+    .sort();
+}
+
+function importSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    ),
+    (match) => match[1] ?? match[2],
+  );
+}
+
+function resolveTarget(file: string, specifier: string) {
+  if (!specifier.startsWith(".")) return specifier;
+  return relative(root, resolve(root, dirname(file), specifier))
+    .replaceAll("\\", "/");
+}
+
+test("Users/Roles infrastructure contiene repository, barrel y README canónicos", () => {
+  for (const path of [
+    infrastructureDir,
+    repositoryFile,
+    barrelFile,
+    `${infrastructureDir}/README.md`,
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
+
+  assert.equal(
+    read(barrelFile).trim(),
+    'export * from "./admin-users-roles-repository.ts";',
+  );
+  assert.equal(existsSync(resolve(root, legacyFile)), false);
+});
+
+test("repository implementa exactamente las dos operaciones del puerto", () => {
+  const repository = read(repositoryFile);
+  const port = read(portFile);
+  const repositoryOperations = Array.from(
+    repository.matchAll(/export async function (\w+)\s*\(/g),
+    (match) => match[1],
+  );
+
+  assert.deepEqual(repositoryOperations, [
+    "getAdminUsersRolesSnapshot",
+    "changeClinicUserRole",
+  ]);
+  assert.equal(
+    (port.match(/getAdminUsersRolesSnapshot:/g) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (port.match(/changeClinicUserRole:/g) ?? []).length,
+    1,
+  );
+});
+
+test("infrastructure sólo importa persistencia y barrels Users/Roles autorizados", () => {
+  const allowed = new Set([
+    "drizzle-orm",
+    "server/db.ts",
+    "drizzle/schema.ts",
+    `${featureDir}/domain/index.ts`,
+    `${featureDir}/application/index.ts`,
+    "server/lib/list-pagination.ts",
+  ]);
+  const violations: string[] = [];
+
+  for (const file of walk(infrastructureDir).filter((path) =>
+    path.endsWith(".ts"),
+  )) {
+    for (const specifier of importSpecifiers(read(file))) {
+      const target = resolveTarget(file, specifier);
+      if (file === barrelFile && target === repositoryFile) continue;
+      if (!allowed.has(target)) {
+        violations.push(`${file}: ${specifier} -> ${target}`);
+      }
+    }
+  }
+
+  assert.deepEqual(violations, []);
+});
+
+test("infrastructure no posee Fastify, HTTP, Auth, Clinics, auditoría ni credenciales", () => {
+  const source = walk(infrastructureDir)
+    .filter((path) => path.endsWith(".ts"))
+    .map(read)
+    .join("\n");
+
+  for (const marker of [
+    "Fastify",
+    "http",
+    "authenticate",
+    "session",
+    "cors",
+    "audit",
+    "/clinics/",
+    "credentials",
+    "password",
+    "hashPassword",
+    "permissions.ts",
+  ]) {
+    assert.equal(
+      source.toLowerCase().includes(marker.toLowerCase()),
+      false,
+      marker,
+    );
+  }
+});
+
+test("route consume composition y no conoce repository concreto", () => {
+  const route = read(routeFile);
+  const composition = read(compositionFile);
+  const routeTargets = importSpecifiers(route).map((specifier) =>
+    resolveTarget(routeFile, specifier),
+  );
+  const compositionTargets = importSpecifiers(composition).map(
+    (specifier) => resolveTarget(compositionFile, specifier),
+  );
+
+  assert.ok(routeTargets.includes(compositionFile));
+  assert.equal(routeTargets.includes(repositoryFile), false);
+  assert.equal(routeTargets.includes(barrelFile), false);
+  assert.equal(route.includes("db-admin-users-roles"), false);
+  assert.ok(
+    compositionTargets.includes(
+      `${featureDir}/application/index.ts`,
+    ),
+  );
+  assert.ok(compositionTargets.includes(barrelFile));
+  assert.equal(compositionTargets.includes(repositoryFile), false);
+});
+
+test("no queda shim, reexport ni import productivo al repository raíz retirado", () => {
+  assert.equal(existsSync(resolve(root, legacyFile)), false);
+
+  const consumers = walk("server")
+    .filter((path) => path.endsWith(".ts"))
+    .filter((path) =>
+      importSpecifiers(read(path))
+        .map((specifier) => resolveTarget(path, specifier))
+        .includes(legacyFile),
+    );
+
+  assert.deepEqual(consumers, []);
+});

--- a/test/architecture/users-roles-m43-closeout.test.ts
+++ b/test/architecture/users-roles-m43-closeout.test.ts
@@ -1,0 +1,184 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const root = process.cwd();
+const featureDir = "server/features/users-roles";
+const compositionFile =
+  `${featureDir}/admin-users-roles-route-composition.ts`;
+const repositoryFile =
+  `${featureDir}/infrastructure/admin-users-roles-repository.ts`;
+const routeFile = "server/routes/admin-users-roles.fastify.ts";
+const legacyFile = "server/db-admin-users-roles.ts";
+const permissionsFile = "server/lib/permissions.ts";
+const closeoutFile =
+  "docs/implementation/m43-users-roles-repository-thin-route-closeout.md";
+
+function read(path: string) {
+  return readFileSync(resolve(root, path), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function walk(path: string): string[] {
+  return readdirSync(resolve(root, path), { withFileTypes: true })
+    .flatMap((entry) => {
+      const child = `${path}/${entry.name}`;
+      return entry.isDirectory() ? walk(child) : [child];
+    })
+    .sort();
+}
+
+test("M43 materializa composition e infrastructure y retira el repository raíz", () => {
+  for (const path of [
+    compositionFile,
+    repositoryFile,
+    `${featureDir}/infrastructure/index.ts`,
+    `${featureDir}/infrastructure/README.md`,
+    closeoutFile,
+  ]) {
+    assert.equal(existsSync(resolve(root, path)), true, path);
+  }
+
+  assert.equal(existsSync(resolve(root, legacyFile)), false);
+});
+
+test("composition conserva laziness, singleton y composición única de use cases", () => {
+  const source = read(compositionFile);
+
+  assert.equal(
+    (source.match(/\blet defaultDepsPromise\b/g) ?? []).length,
+    1,
+  );
+  assert.match(source, /if \(!defaultDepsPromise\)/);
+  assert.match(source, /import\("\.\/infrastructure\/index\.ts"\)/);
+  assert.equal(
+    (source.match(/createAdminUsersRolesUseCases\s*\(/g) ?? []).length,
+    1,
+  );
+  assert.match(source, /createAdminUsersRolesRouteComposition/);
+  assert.match(source, /options\.getAdminUsersRolesSnapshot/);
+  assert.match(source, /options\.changeClinicUserRole/);
+  assert.match(source, /options\.updateAdminClinicUserCredentials/);
+
+  for (const forbidden of [
+    'from "fastify"',
+    "drizzle-orm",
+    "permissions.ts",
+    "app.get(",
+    "app.patch(",
+    "app.options(",
+  ]) {
+    assert.equal(source.includes(forbidden), false, forbidden);
+  }
+});
+
+test("AdminUsersRolesNativeRoutesOptions conserva su superficie pública", () => {
+  const route = read(routeFile);
+  const composition = read(compositionFile);
+
+  assert.match(
+    route,
+    /export type AdminUsersRolesNativeRoutesOptions\s*=\s*[\s\S]*AdminUsersRolesRouteCompositionOptions/,
+  );
+  for (const option of [
+    "deleteAdminSession",
+    "getAdminSessionWithUser",
+    "updateAdminSessionLastAccess",
+    "hashSessionToken",
+    "getAdminUsersRolesSnapshot",
+    "changeClinicUserRole",
+    "updateAdminClinicUserCredentials",
+    "hashPassword",
+    "writeAuditLog",
+    "now",
+  ]) {
+    assert.match(composition, new RegExp(`\\b${option}\\?`), option);
+  }
+});
+
+test("route registra los seis endpoints en el orden contractual", () => {
+  const source = read(routeFile);
+  const markers = [
+    'app.options("/", optionsHandler)',
+    'app.options("/clinic/:clinicUserId/role", optionsHandler)',
+    'app.options("/clinic/:clinicUserId/credentials", optionsHandler)',
+    "app.get<{ Querystring: AdminUsersRolesRequestQuery }>",
+    "app.patch<{",
+    '}>("/clinic/:clinicUserId/role", async (request, reply) => {',
+    "app.patch<{",
+    '}>("/clinic/:clinicUserId/credentials", async (request, reply) => {',
+  ];
+  let cursor = -1;
+
+  for (const marker of markers) {
+    const next = source.indexOf(marker, cursor + 1);
+    assert.ok(next > cursor, marker);
+    cursor = next;
+  }
+});
+
+test("route es thin y delega en composition sin repository concreto", () => {
+  const source = read(routeFile);
+
+  assert.match(source, /createAdminUsersRolesRouteComposition\(options\)/);
+  assert.match(
+    source,
+    /usersRolesUseCases\.listAdminUsersRoles\(params\)/,
+  );
+  assert.match(
+    source,
+    /usersRolesUseCases\.changeClinicUserRole\(\{/,
+  );
+  for (const forbidden of [
+    "defaultDepsPromise",
+    "loadDefaultDeps",
+    "createAdminUsersRolesUseCases",
+    "db-admin-users-roles",
+    "admin-users-roles-repository",
+    "/infrastructure/",
+    "drizzle-orm",
+    "updateAdminClinicUserCredentialsCommand",
+  ]) {
+    assert.equal(source.includes(forbidden), false, forbidden);
+  }
+});
+
+test("domain, application e infrastructure no poseen credenciales ni permisos", () => {
+  const source = [
+    ...walk(`${featureDir}/domain`),
+    ...walk(`${featureDir}/application`),
+    ...walk(`${featureDir}/infrastructure`),
+  ]
+    .filter((path) => path.endsWith(".ts"))
+    .map(read)
+    .join("\n");
+
+  assert.doesNotMatch(
+    source,
+    /credentials|password|passwordHash|hashPassword/i,
+  );
+  assert.doesNotMatch(
+    source,
+    /lib\/permissions\.ts|getClinicPermissions|ClinicPermissions/,
+  );
+  assert.equal(existsSync(resolve(root, permissionsFile)), true);
+});
+
+test("closeout M43 declara cierre de Fase J sin inventar estado Git", () => {
+  const source = read(closeoutFile);
+
+  for (const marker of [
+    "M43 — Users/Roles repository + thin-route closeout",
+    "da73eb1291bc89b4ec505d22e337b173dd01219e",
+    "M43: cerrado",
+    "Fase J",
+    "Git/GitHub",
+    "Rollback",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+  assert.doesNotMatch(source, /M43:\s*`?NOT_RUN`?/);
+});

--- a/test/helpers/report-foreign-access-scope.ts
+++ b/test/helpers/report-foreign-access-scope.ts
@@ -1,5 +1,5 @@
 const SHARED_BACKEND_SCOPE_EXCEPTIONS = new Set([
-  "server/db-admin-users-roles.ts",
+  "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
   "server/routes/admin-users-roles.fastify.ts",
   "server/features/report-access/infrastructure/report-access-repository.ts",
   "server/db.ts",

--- a/test/unit/application/users-roles/users-roles-suite-completeness.test.ts
+++ b/test/unit/application/users-roles/users-roles-suite-completeness.test.ts
@@ -6,8 +6,11 @@ import test from "node:test";
 const root = process.cwd();
 const domainDir = "server/features/users-roles/domain";
 const applicationDir = "server/features/users-roles/application";
+const infrastructureDir = "server/features/users-roles/infrastructure";
 const domainTestDir = "test/unit/domain/users-roles";
 const applicationTestDir = "test/unit/application/users-roles";
+const infrastructureTestDir =
+  "test/unit/infrastructure/users-roles";
 const self = "users-roles-suite-completeness.test.ts";
 
 function read(path: string) {
@@ -21,7 +24,7 @@ function names(path: string, suffix: string) {
     .sort();
 }
 
-test("cada módulo productivo de domain y application tiene test correlativo", () => {
+test("cada módulo productivo de Users/Roles tiene test correlativo", () => {
   const domainModules = names(domainDir, ".ts").filter(
     (name) => name !== "index",
   );
@@ -32,14 +35,23 @@ test("cada módulo productivo de domain y application tiene test correlativo", (
   const applicationTests = names(applicationTestDir, ".test.ts").filter(
     (name) => `${name}.test.ts` !== self,
   );
+  const infrastructureModules = names(infrastructureDir, ".ts").filter(
+    (name) => name !== "index",
+  );
+  const infrastructureTests = names(
+    infrastructureTestDir,
+    ".test.ts",
+  );
 
   assert.deepEqual(domainTests, domainModules);
   assert.deepEqual(applicationTests, applicationModules);
+  assert.deepEqual(infrastructureTests, infrastructureModules);
 });
 
 test("los barrels cubren todos los módulos y puertos", () => {
   const domainIndex = read(`${domainDir}/index.ts`);
   const applicationIndex = read(`${applicationDir}/index.ts`);
+  const infrastructureIndex = read(`${infrastructureDir}/index.ts`);
   const portsIndex = read(`${applicationDir}/ports/index.ts`);
 
   for (const module of names(domainDir, ".ts").filter(
@@ -56,6 +68,11 @@ test("los barrels cubren todos los módulos y puertos", () => {
     (name) => name !== "index",
   )) {
     assert.match(portsIndex, new RegExp(`\\./${port}\\.ts`));
+  }
+  for (const module of names(infrastructureDir, ".ts").filter(
+    (name) => name !== "index",
+  )) {
+    assert.match(infrastructureIndex, new RegExp(`\\./${module}\\.ts`));
   }
 });
 

--- a/test/unit/contracts/admin/admin-heavy-list-pagination-contract.test.ts
+++ b/test/unit/contracts/admin/admin-heavy-list-pagination-contract.test.ts
@@ -67,7 +67,9 @@ test("listadores backend compartidos normalizan paginación antes de consultar",
 });
 
 test("admin users roles pagina consultas DB antes de combinar resultados", () => {
-  const source = readSource("server/db-admin-users-roles.ts");
+  const source = readSource(
+    "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
+  );
 
   assert.match(
     source,

--- a/test/unit/contracts/admin/admin-users-roles-search-contract.test.ts
+++ b/test/unit/contracts/admin/admin-users-roles-search-contract.test.ts
@@ -11,7 +11,9 @@ function read(relativePath: string): string {
 }
 
 test("getAdminUsersRolesSnapshot filtra por search usando ilike parametrizado (sin concatenar SQL crudo)", () => {
-  const source = read("server/db-admin-users-roles.ts");
+  const source = read(
+    "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
+  );
 
   assert.ok(
     source.includes("ilike(adminUsers.username, `%${search}%`)"),
@@ -34,7 +36,9 @@ test("getAdminUsersRolesSnapshot filtra por search usando ilike parametrizado (s
 });
 
 test("search vacío o undefined equivale a no aplicar filtro (normalizeSearch)", () => {
-  const source = read("server/db-admin-users-roles.ts");
+  const source = read(
+    "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
+  );
 
   const fnStart = source.indexOf("function normalizeSearch(");
   assert.ok(fnStart >= 0, "normalizeSearch debe existir");
@@ -50,7 +54,9 @@ test("search vacío o undefined equivale a no aplicar filtro (normalizeSearch)",
 });
 
 test("search compone (AND) con el filtro de role existente para clinic users", () => {
-  const source = read("server/db-admin-users-roles.ts");
+  const source = read(
+    "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
+  );
 
   const fnStart = source.indexOf(
     "export async function getAdminUsersRolesSnapshot(",
@@ -79,7 +85,9 @@ test("search compone (AND) con el filtro de role existente para clinic users", (
 });
 
 test("search se aplica tanto al conteo (total/totalPages) como al listado paginado", () => {
-  const source = read("server/db-admin-users-roles.ts");
+  const source = read(
+    "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
+  );
 
   const fnStart = source.indexOf(
     "export async function getAdminUsersRolesSnapshot(",

--- a/test/unit/infrastructure/global-performance-resilience-contract.test.ts
+++ b/test/unit/infrastructure/global-performance-resilience-contract.test.ts
@@ -32,7 +32,8 @@ const HEAVY_SURFACES: readonly HeavySurface[] = [
     markers: ["normalizeListPagination", "fetchLimit", ".limit(fetchLimit)"],
   },
   {
-    file: "server/db-admin-users-roles.ts",
+    // M43: Users/Roles persistence moved to its canonical infrastructure layer.
+    file: "server/features/users-roles/infrastructure/admin-users-roles-repository.ts",
     markers: ["normalizeListPagination", ".limit(adminLimit)", ".limit(clinicLimit)"],
   },
   {

--- a/test/unit/infrastructure/users-roles/admin-users-roles-repository.test.ts
+++ b/test/unit/infrastructure/users-roles/admin-users-roles-repository.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import test from "node:test";
+
+const repositoryFile =
+  "server/features/users-roles/infrastructure/admin-users-roles-repository.ts";
+const portFile =
+  "server/features/users-roles/application/ports/admin-users-roles-repository.ts";
+
+function read(path: string) {
+  return readFileSync(resolve(process.cwd(), path), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function importSpecifiers(source: string) {
+  return Array.from(
+    source.matchAll(
+      /\bfrom\s+["']([^"']+)["']|\bimport\s*\(\s*["']([^"']+)["']\s*\)/g,
+    ),
+    (match) => match[1] ?? match[2],
+  );
+}
+
+test("repository Users/Roles implementa exactamente las dos operaciones del puerto", () => {
+  const repository = read(repositoryFile);
+  const port = read(portFile);
+
+  assert.deepEqual(
+    Array.from(
+      repository.matchAll(
+        /export async function (\w+)\s*\(/g,
+      ),
+      (match) => match[1],
+    ),
+    ["getAdminUsersRolesSnapshot", "changeClinicUserRole"],
+  );
+  assert.equal(
+    (port.match(/getAdminUsersRolesSnapshot:/g) ?? []).length,
+    1,
+  );
+  assert.equal(
+    (port.match(/changeClinicUserRole:/g) ?? []).length,
+    1,
+  );
+});
+
+test("repository conserva imports canónicos y no asume ownership HTTP, Auth o Clinics", () => {
+  const source = read(repositoryFile);
+
+  assert.deepEqual(importSpecifiers(source), [
+    "drizzle-orm",
+    "../../../db.ts",
+    "../../../../drizzle/schema.ts",
+    "../domain/index.ts",
+    "../application/index.ts",
+    "../../../lib/list-pagination.ts",
+  ]);
+
+  for (const marker of [
+    "fastify",
+    "FastifyRequest",
+    "FastifyReply",
+    "/routes/",
+    "auth-security",
+    "/clinics/",
+    "credentials",
+    "password",
+    "hashPassword",
+    "permissions.ts",
+  ]) {
+    assert.equal(source.toLowerCase().includes(marker.toLowerCase()), false, marker);
+  }
+});
+
+test("snapshot conserva búsqueda ilike, filtros, counts y paginación combinada", () => {
+  const source = read(repositoryFile);
+
+  for (const marker of [
+    "normalizeListPagination(params)",
+    "ilike(adminUsers.username, `%${search}%`)",
+    "ilike(clinicUsers.username, `%${search}%`)",
+    "ilike(clinics.name, `%${search}%`)",
+    "clinicFilters.push(eq(clinicUsers.role, params.role))",
+    "and(...clinicFilters)",
+    "sql<number>`count(*)::int`",
+    "const [adminCountRows, clinicCountRows] = await Promise.all",
+    "const [adminRows, clinicRows] = await Promise.all",
+    ".limit(adminLimit)",
+    ".offset(adminOffset)",
+    ".limit(clinicLimit)",
+    ".offset(clinicOffset)",
+    "total: adminTotal + clinicTotal",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+});
+
+test("cambio de rol conserva guard del último owner y el límite transaccional existente", () => {
+  const source = read(repositoryFile);
+  const start = source.indexOf(
+    "export async function changeClinicUserRole(",
+  );
+  assert.ok(start >= 0);
+  const changeRole = source.slice(start);
+
+  assert.equal(
+    changeRole.match(/\.transaction\s*\(/g)?.length ?? 0,
+    0,
+    "el baseline M43 no envolvía el cambio de rol en una transacción",
+  );
+  for (const marker of [
+    'reason: "not_found"',
+    'current.role === "clinic_owner"',
+    'input.role === "clinic_staff"',
+    'eq(clinicUsers.role, "clinic_owner")',
+    "ne(clinicUsers.id, input.clinicUserId)",
+    'reason: "last_clinic_owner"',
+    "roleChanged: false",
+    "updatedAt: input.now ?? new Date()",
+    "roleChanged: true",
+  ]) {
+    assert.ok(changeRole.includes(marker), marker);
+  }
+});


### PR DESCRIPTION
## Summary

- Moves the Users/Roles persistence adapter into the canonical feature infrastructure layer.
- Adds lazy route composition and removes repository wiring from the Fastify route.
- Preserves Clinics ownership of credential updates and hashing.
- Keeps `server/lib/permissions.ts` unchanged as the shared authorization kernel.
- Realigns active architecture guards, contracts and source-aware anchors.
- Adds the M43 closeout and completes backend modularization Phase J.

## Scope

- [x] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [ ] Scripts/tooling
- [ ] Repository configuration
- [ ] Other
- [ ] Mixed-scope exception

Tests and documentation support the backend runtime change and do not define an additional primary scope.

## Architecture

```text
admin-users-roles.fastify.ts
|-- HTTP, admin auth, session, CORS, parsing, status and audit
`-- admin-users-roles-route-composition.ts
    |-- application use cases
    |-- Users/Roles infrastructure repository
    |-- existing Auth and security dependencies
    |-- existing audit writer
    `-- existing Clinics credentials command
```

The root `server/db-admin-users-roles.ts` path is removed without a compatibility shim or re-export.

The repository move preserves the baseline implementation one-to-one. Only the five relative imports changed for the new directory depth. No explicit transaction was introduced because the original implementation did not contain one.

## Contracts preserved

- Six routes and their registration order.
- Admin authentication and session last-access behavior.
- CORS, preflight and trusted-origin enforcement.
- Search, filtering, pagination and list limits.
- Status codes, messages and response payloads.
- `not_found`, `last_clinic_owner` and unchanged-role behavior.
- Audit events, metadata, `checkedBy`, `changedBy` and clock behavior.
- Existing partial and complete route dependency injection.
- Clinics credential command order: parse -> hash -> persistence -> audit -> response.

## Validation

- Directed M43 cohort: 151/151 passed.
- Closeout guards: 13/13 passed.
- `pnpm typecheck`: passed.
- `pnpm typecheck:test`: passed.
- `pnpm test`: 3902 passed, 1 skipped, 0 failed.
- `pnpm build`: passed.
- `pnpm security:public-surface`: passed.
- `pnpm audit --prod`: passed.
- `pnpm audit`: passed.
- `pnpm validate:local`: passed.
- `git diff --check`: passed.
- Repository move exactness check: passed.

## Rollback

Revert the M43 commit to restore `server/db-admin-users-roles.ts`, return lazy dependency wiring and use-case composition to `server/routes/admin-users-roles.fastify.ts`, remove the Users/Roles composition and infrastructure files, and realign source-aware anchors to the root repository path.

No schema, migration, data, credential, Auth or permissions rollback is required.

## Exclusions

No changes to frontend, schema, migrations, dependencies, lockfiles, CI workflows, `server/fastify-app.ts`, Auth architecture or `server/lib/permissions.ts`.