### PR TITLE
refactor(backend): retire residual legacy imports

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -1051,6 +1051,14 @@ global anti-ciclos + matriz de deps entre features · **M46** reclasificación r
 **M48** certificación final con evidencia acumulada. *(M47 infra-residual: opcional, dentro del
 techo de 60.)*
 
+> **Status de ejecución (2026-07-28):** **M44 — completado** localmente. Se
+> retiraron los dos shims residuales `server/db-particular.ts` y
+> `server/db-study-tracking.ts`; ocho imports dinámicos se realinearon al
+> barrel canónico de Particular Access, sin cambios funcionales.
+> **M45 — NOT_RUN** y permanece como el siguiente milestone. Este status no altera el
+> conteo recomendado, la definición de M45/M46/M48, los riesgos ni las
+> conclusiones históricas.
+
 **Contingencia (fuera del conteo):** C1 coverage (autorizar dep c8 primero) · C2 límites de
 complejidad · C3 `lib/shared` · C4 secuencia de seguridad Auth (diseño separado + sign-off) ·
 C5 ciclos residuales imprevistos.

--- a/docs/implementation/m44-legacy-imports-sweep-closeout.md
+++ b/docs/implementation/m44-legacy-imports-sweep-closeout.md
@@ -1,0 +1,189 @@
+# M44 — Legacy imports sweep closeout
+
+## 1. Identificación y baseline
+
+- Milestone: M44, apertura de Fase K.
+- Rama: `refactor/backend-modularization-m44-legacy-imports-sweep`.
+- Baseline y HEAD inicial:
+  `7f9644fbc0d38bf604218dc6b2a87f037da10f44`.
+- `origin/main` remoto verificado en el mismo commit.
+- Working tree e índice iniciales: limpios.
+- Worktrees: únicamente `C:/PORTAL-VETNEB`.
+- Riesgo: R2 estructural backend autorizado exclusivamente para M44.
+
+## 2. Alcance M44
+
+Incluido: retiro de dos shims residuales, realineación de ocho imports
+dinámicos, guards y hashes afectados, documentación vigente, guard global y
+closeout. Excluido: anti-ciclos, matriz cross-feature, reclasificación de
+`server/lib`, Auth, comportamiento funcional, movimientos adicionales, capas,
+dependencias, schema, migraciones, frontend, scripts y CI.
+
+## 3. Censo inicial bruto
+
+`rg` sobre `server/**` y `test/**` confirmó ocho referencias productivas a
+`server/db-particular.ts`, cero consumidores productivos de
+`server/db-study-tracking.ts` y referencias source-only en los guards
+M33/M35/M35b. El árbol inicial contenía exactamente los dos shims declarados
+por el censo congelado.
+
+## 4. Censo AST focalizado
+
+El censo TypeScript AST contempló imports estáticos ejecutables, reexports,
+`require()` e `import()`. La allowlist productiva quedó congelada en:
+
+1. `server/middlewares/particular-auth.ts`;
+2. `server/preflight.ts`;
+3. `server/routes/admin-study-tracking.fastify.ts`;
+4. `server/routes/auth.fastify.ts`;
+5. `server/routes/particular-audit.fastify.ts`;
+6. `server/routes/particular-auth.fastify.ts`;
+7. `server/routes/particular-study-tracking.fastify.ts`;
+8. `server/routes/study-tracking.fastify.ts`.
+
+## 5. Falsos positivos descartados
+
+`server/lib/report-access-token.ts` se preservó intacto. El módulo contiene
+schemas Zod, parsing, serialización y comportamiento real; no es un shim puro.
+
+## 6. Dos shims retirados
+
+- `server/db-particular.ts`;
+- `server/db-study-tracking.ts`.
+
+No se crearon reexports alternativos, aliases, wrappers, barrels raíz,
+service locators ni adapters forwarding.
+
+## 7. Ocho consumidores realineados
+
+Cada consumidor de §4 cambió una sola línea: el specifier del `import()`.
+Los archivos bajo `middlewares/` y `routes/` usan
+`../features/particular-access/infrastructure/index.ts`; `preflight.ts` usa
+`./features/particular-access/infrastructure/index.ts`.
+
+El `git diff --numstat` productivo mostró `1/1` para cada archivo: total
+esperado de ocho líneas eliminadas y ocho agregadas.
+
+## 8. Equivalencia del objeto módulo
+
+El shim retirado hacía exclusivamente `export *` del barrel
+`server/features/particular-access/infrastructure/index.ts`. El `import()`
+directo carga ese mismo barrel y expone el mismo namespace utilizado por las
+variables receptoras existentes. No cambiaron destructuring, nombres,
+`Promise.all`, orden, lazy loading ni manejo de errores.
+
+## 9. Auth preservado sin reorganización
+
+Los archivos Auth afectados conservaron variables, dependencias, handlers,
+cookies, sesiones, autenticadores, rate limits, auditoría, CORS, trusted
+origin, payloads, status, mensajes y control flow. M44 sólo cambió el
+specifier dinámico autorizado.
+
+## 10. Study Tracking con cero consumidores residuales
+
+El censo inicial confirmó cero consumidores de
+`server/db-study-tracking.ts`. Sus rutas propias continúan atravesando
+`study-tracking-route-composition.ts`; Reports continúa usando su composición
+canónica.
+
+## 11. Guards realineados
+
+Se realinearon los guards M33, M35b, infrastructure Study Tracking, closeout
+M35, thin routes clínica/particular y completeness. El censo de hashes detectó
+además un anchor real en
+`test/architecture/study-tracking-admin-thin-route.test.ts`; se agregó a la
+allowlist efectiva únicamente para actualizar sus dos digests.
+
+## 12. Hashes actualizados y método de comprobación
+
+Antes de actualizar los hashes se ejecutó `git diff --numstat`,
+`git diff --unified=0` y `git diff --check` sobre los ocho archivos
+productivos. Cada diff mostró una única sustitución de specifier.
+
+| Archivo | SHA-256 anterior | SHA-256 nuevo |
+| --- | --- | --- |
+| `server/middlewares/particular-auth.ts` | `fc551f73cc21beb99d35e97cc9abde62d10e98621185b8d829f5bbe9919dc17b` | `5004967d61238de6d5fc38582ca48e0da1468189e418d279a4cd9786126c4683` |
+| `server/routes/particular-auth.fastify.ts` | `5ed5bf6f6ec6edb72983cdcfca84b283b89a3db4ff3b408349b557aa9a0d1561` | `e94e5a2847f635f30a8edd81fa5270fd1501f727fc1b91e434677c3d101a0c86` |
+| `server/routes/study-tracking.fastify.ts` | `f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319` | `aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7` |
+| `server/routes/particular-study-tracking.fastify.ts` | `ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb` | `88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa` |
+| `server/routes/admin-study-tracking.fastify.ts` | `15aab9bd2b23caf27644185b5421cabe206644ed5b837c54e3dac66fa109c892` | `4454a06d394f6d377eedfb1420bc2e3a6e8e651096d3a230c2cd809db0dcb6de` |
+
+## 13. Guard global M44
+
+`test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts`
+usa `node:test`, `node:assert/strict` y TypeScript AST. Protege paths ausentes,
+cero imports legacy, cero shims puros raíz, clasificación real de
+`report-access-token`, consumidores y barrels exactos, ausencia de aliases,
+closeout M44 y estado M45.
+
+## 14. Contratos funcionales preservados
+
+Bootstrap/preflight, cleanup de sesiones expiradas, autenticación de clínica,
+particular y admin, login/logout, sesiones/cookies, last-access, rate limits,
+auditoría particular, Study Tracking por los tres realms, email, errores,
+status, payloads, orden y lazy module loading quedaron sin cambios funcionales.
+
+## 15. Validaciones con exit code real
+
+| Gate | Estado | Exit |
+| --- | --- | ---: |
+| Cohorte dirigida M44 | PASSED — 262/262 final | 0 |
+| `pnpm typecheck` | PASSED | 0 |
+| `pnpm typecheck:test` | PASSED | 0 |
+| `pnpm test` | PASSED — 3910 total, 3909 pass, 1 skip | 0 |
+| `pnpm build` | PASSED | 0 |
+| `pnpm security:public-surface` | PASSED — cero findings públicos; dos markers server-only esperados | 0 |
+| `pnpm audit --prod` | PASSED — cero vulnerabilidades conocidas | 0 |
+| `pnpm audit` | PASSED — cero vulnerabilidades conocidas | 0 |
+| `pnpm validate:local` | PASSED — typechecks + 3910/3909/1/0 + build | 0 |
+| `git diff --check` | PASSED | 0 |
+| `git diff --cached --check` | PASSED — índice vacío | 0 |
+
+## 16. Fail-fast y reintentos reales
+
+Las precondiciones, lecturas, censos y comprobación del diff productivo
+terminaron con exit code 0. La cohorte dirigida tuvo tres corridas FAILED
+source-only:
+
+1. 259/262: marker M45 partido por Markdown, aserción autorreferencial del
+   guard y marker histórico M33 exigido en el README vigente;
+2. 260/262: dos markers seguían sin tolerar el wording/salto real;
+3. 261/262: el prefijo `>` del bloque Markdown aún separaba M45 de NOT_RUN.
+
+Cada causa se corrigió únicamente en guards/documentación M44 y se repitió la
+cohorte completa. La cuarta corrida quedó 262/262 PASSED, exit code 0. No hubo
+fallos runtime. Todos los gates amplios posteriores terminaron PASSED en la
+primera corrida.
+
+## 17. Riesgos
+
+El riesgo principal es que un consumidor legacy o anchor hash quede omitido.
+Se mitiga con censo AST global, allowlist exacta, hashes derivados sólo después
+del diff 1:1, guards enfocados y validación completa. Riesgo residual de datos:
+ninguno; no cambian queries, schema, migraciones ni transacciones.
+
+## 18. Rollback
+
+Revertir M44 restaura ambos shims, devuelve los ocho specifiers a sus paths
+anteriores y revierte guards/docs/hashes. No requiere migración, cambio de
+schema, compensación, modificación de datos ni reorganización de Auth.
+
+## 19. Exclusiones
+
+No se modificaron frontend, schema, migraciones, Supabase, manifests,
+lockfiles, dependencias, scripts, workflows, Docker,
+`server/fastify-app.ts`, `server/db.ts`, repositories/barrels canónicos,
+`server/lib/report-access-token.ts`, permissions, helpers CORS/session, email,
+audit infrastructure, Auth architecture, ramas ni worktrees ajenos.
+
+## 20. Git/GitHub NOT_RUN y estado Fase K
+
+- STAGE: NOT_RUN
+- COMMIT: NOT_RUN
+- AMEND: NOT_RUN
+- PUSH: NOT_RUN
+- PR: NOT_RUN
+- MERGE: NOT_RUN
+
+**M44 CLOSED localmente** tras completar los gates documentados. **M45
+NOT_RUN** y permanece como el siguiente milestone de Fase K.

--- a/server/db-particular.ts
+++ b/server/db-particular.ts
@@ -1,1 +1,0 @@
-export * from "./features/particular-access/infrastructure/index.ts";

--- a/server/db-study-tracking.ts
+++ b/server/db-study-tracking.ts
@@ -1,1 +1,0 @@
-export * from "./features/study-tracking/infrastructure/index.ts";

--- a/server/features/particular-access/README.md
+++ b/server/features/particular-access/README.md
@@ -9,7 +9,20 @@ tokens particulares.
 - `particular-access-route-composition.ts`: único seam de las rutas propias a
   infraestructura y a la composición canónica de Study Tracking.
 
-`server/db-particular.ts` queda como shim de compatibilidad controlado. Owner:
-Particular Access. Retiro futuro: milestone de Auth/consumidores externos aún
-no planificado; M34 y M35b no forman parte de este cierre.
-`server/routes/admin-reports.fastify.ts` permanece allowlisted hasta M36.
+M33 introdujo `server/db-particular.ts` como compatibilidad temporal. M44
+retiró ese shim y realineó sus ocho consumidores externos al barrel canónico
+`server/features/particular-access/infrastructure/index.ts`:
+
+- `server/middlewares/particular-auth.ts`;
+- `server/preflight.ts`;
+- `server/routes/admin-study-tracking.fastify.ts`;
+- `server/routes/auth.fastify.ts`;
+- `server/routes/particular-audit.fastify.ts`;
+- `server/routes/particular-auth.fastify.ts`;
+- `server/routes/particular-study-tracking.fastify.ts`;
+- `server/routes/study-tracking.fastify.ts`.
+
+Las rutas propias continúan llegando a infrastructure mediante
+`particular-access-route-composition.ts`; Reports conserva su composición
+canónica. M44 no reorganizó Auth ni cambió comportamiento funcional, lazy
+loading, sesiones, cookies, rate limits, auditoría o contratos HTTP.

--- a/server/features/particular-access/infrastructure/README.md
+++ b/server/features/particular-access/infrastructure/README.md
@@ -1,5 +1,7 @@
 # Particular Access infrastructure
 
 `particular-access-repository.ts` contiene el traslado 1:1 de las queries de
-`server/db-particular.ts`. El shim histórico permanece para Auth y consumidores
-fuera de M33; las rutas propias sólo llegan aquí mediante composición.
+`server/db-particular.ts` realizado en M33. M44 retiró ese shim histórico: sus
+ocho consumidores externos cargan ahora `index.ts` directamente y las rutas
+propias continúan llegando aquí mediante composición. Auth no fue reorganizado
+y no hubo cambios funcionales.

--- a/server/features/study-tracking/README.md
+++ b/server/features/study-tracking/README.md
@@ -22,14 +22,10 @@ Bounded context backend cerrado en M35 después de M30, M31, M32 y M32b.
 - `server/lib/study-tracking.ts` y
   `server/lib/token-study-tracking.ts` fueron retirados en M35: el censo
   textual y AST confirmó cero consumidores ejecutables.
-- `server/db-study-tracking.ts` permanece como shim externo controlado de una
-  línea. Las tres rutas propias no lo consumen y, tras M33, su allowlist
-  residual exacta
-  es:
-
-| Consumidor | Owner | Retiro |
-| --- | --- | --- |
-| `server/routes/admin-reports.fastify.ts` | Reports | M36 |
+- M35 conservó `server/db-study-tracking.ts` como shim externo temporal. Tras
+  M41 su censo residual ya era cero; M44 retiró el path y confirmó cero imports
+  ejecutables. Las tres rutas propias continúan usando su composición
+  feature-level y Reports continúa usando su composición canónica.
 
 M32 adelgazó únicamente `study-tracking.fastify.ts` y
 `particular-study-tracking.fastify.ts`. M32b adelgaza exclusivamente
@@ -40,5 +36,6 @@ filtro clinic-scoped opcional, CORS, payloads, SQL, schema y migraciones no
 cambian.
 
 M30, M31, M32, M32b y M35 están cerrados. M33 retiró los dos consumidores de
-Particular Access mediante composition y el barrel application canónico. No se
-afirma RLS; Reports continúa pendiente para M36.
+Particular Access mediante composition y el barrel application canónico; M44
+retiró el shim DB ya sin consumidores. Auth no fue reorganizado y no hubo
+cambios funcionales. No se afirma RLS.

--- a/server/features/study-tracking/infrastructure/README.md
+++ b/server/features/study-tracking/infrastructure/README.md
@@ -6,10 +6,11 @@ Repositorio canónico de persistencia movido en M31:
 - `index.ts`: único barrel público de infraestructura.
 
 El move conserva queries, filtros, orden, paginación, timestamps y resultados.
-`server/db-study-tracking.ts` permanece como shim externo controlado únicamente
-para `admin-reports.fastify.ts` (Reports, M36). M33 retiró ambos consumidores
-Particular Access mediante la composición canónica. Las rutas propias de Study
-Tracking consumen infrastructure únicamente mediante composición feature-level.
+M35 conservó `server/db-study-tracking.ts` como shim externo temporal; M44 lo
+retiró después de confirmar cero consumidores residuales. Las rutas propias de
+Study Tracking consumen infrastructure únicamente mediante composición
+feature-level y Reports conserva su composición canónica. Auth no fue
+reorganizado y no hubo cambios funcionales.
 
 Esta capa sólo puede depender de Drizzle, `server/db.ts`,
 `drizzle/schema.ts` y `server/lib/list-pagination.ts`. No contiene Fastify,

--- a/server/middlewares/particular-auth.ts
+++ b/server/middlewares/particular-auth.ts
@@ -50,7 +50,7 @@ let defaultDepsPromise: Promise<ParticularAuthDeps> | null = null;
 async function loadDefaultDeps(): Promise<ParticularAuthDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
-      const db = await import("../db-particular.ts");
+      const db = await import("../features/particular-access/infrastructure/index.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const envModule = await import("../lib/env.ts");
 

--- a/server/preflight.ts
+++ b/server/preflight.ts
@@ -51,7 +51,7 @@ export async function preflight(
     supabaseModule,
   ] = await Promise.all([
     import("./db.ts"),
-    import("./db-particular.ts"),
+    import("./features/particular-access/infrastructure/index.ts"),
     import("./lib/supabase.ts"),
   ]);
 

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -199,7 +199,7 @@ async function loadDefaultDeps(): Promise<NativeAdminStudyTrackingDeps> {
   const reportCommands = await import(
     "../features/reports/composition/index.ts"
   );
-  const dbParticular = await import("../db-particular.ts");
+  const dbParticular = await import("../features/particular-access/infrastructure/index.ts");
   const email = await import("../lib/email.ts");
   const audit = await import("../lib/audit.ts");
   const { loadAdminStudyTrackingPersistence } = await import(

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -279,7 +279,7 @@ async function loadDefaultDeps(): Promise<NativeAuthDefaultDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
-      const dbParticular = await import("../db-particular.ts");
+      const dbParticular = await import("../features/particular-access/infrastructure/index.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const audit = await import("../lib/audit.ts");
       const getClinicUserByIdentifier = async (identifier: string) =>

--- a/server/routes/particular-audit.fastify.ts
+++ b/server/routes/particular-audit.fastify.ts
@@ -100,7 +100,7 @@ async function loadDefaultDeps(): Promise<NativeParticularAuditDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const authSecurity = await import("../lib/auth-security.ts");
-      const dbParticular = await import("../db-particular.ts");
+      const dbParticular = await import("../features/particular-access/infrastructure/index.ts");
       const dbAudit = await import("../db-audit.ts");
 
       return {

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -150,7 +150,7 @@ async function loadDefaultDeps(): Promise<NativeParticularAuthDefaultDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = (async () => {
       const db = await import("../db.ts");
-      const dbParticular = await import("../db-particular.ts");
+      const dbParticular = await import("../features/particular-access/infrastructure/index.ts");
       const authSecurity = await import("../lib/auth-security.ts");
       const supabase = await import("../lib/supabase.ts");
       const reportCommands = await import(

--- a/server/routes/particular-study-tracking.fastify.ts
+++ b/server/routes/particular-study-tracking.fastify.ts
@@ -110,7 +110,7 @@ type NativeParticularStudyTrackingDeps = Required<
 >;
 
 async function loadDefaultDeps(): Promise<NativeParticularStudyTrackingDeps> {
-  const dbParticular = await import("../db-particular.ts");
+  const dbParticular = await import("../features/particular-access/infrastructure/index.ts");
   const authSecurity = await import("../lib/auth-security.ts");
   const { loadParticularStudyTrackingPersistence } = await import(
     "../features/study-tracking/study-tracking-route-composition.ts"

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -219,7 +219,7 @@ async function loadDefaultDeps(): Promise<NativeStudyTrackingDeps> {
   const reportCommands = await import(
     "../features/reports/composition/index.ts"
   );
-  const dbParticular = await import("../db-particular.ts");
+  const dbParticular = await import("../features/particular-access/infrastructure/index.ts");
   const email = await import("../lib/email.ts");
   const audit = await import("../lib/audit.ts");
   const { loadClinicStudyTrackingPersistence } = await import(

--- a/test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts
+++ b/test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts
@@ -1,0 +1,318 @@
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve } from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const repoRoot = process.cwd();
+const legacyPaths = [
+  "server/db-particular.ts",
+  "server/db-study-tracking.ts",
+] as const;
+const particularInfrastructureIndex =
+  "server/features/particular-access/infrastructure/index.ts";
+const studyTrackingInfrastructureIndex =
+  "server/features/study-tracking/infrastructure/index.ts";
+const particularComposition =
+  "server/features/particular-access/particular-access-route-composition.ts";
+const reportsComposition =
+  "server/features/reports/composition/report-route-composition.ts";
+const reportAccessTokenModule = "server/lib/report-access-token.ts";
+const m44Closeout =
+  "docs/implementation/m44-legacy-imports-sweep-closeout.md";
+const programAudit =
+  "docs/audit/backend-enterprise-modularization-program-audit.md";
+const guardFile =
+  "test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts";
+
+const expectedMigratedConsumers = [
+  "server/middlewares/particular-auth.ts",
+  "server/preflight.ts",
+  "server/routes/admin-study-tracking.fastify.ts",
+  "server/routes/auth.fastify.ts",
+  "server/routes/particular-audit.fastify.ts",
+  "server/routes/particular-auth.fastify.ts",
+  "server/routes/particular-study-tracking.fastify.ts",
+  "server/routes/study-tracking.fastify.ts",
+].sort();
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function walkTsFiles(relativeDir: string): string[] {
+  const absoluteDir = resolve(repoRoot, relativeDir);
+  if (!existsSync(absoluteDir)) {
+    return [];
+  }
+
+  return readdirSync(absoluteDir, { withFileTypes: true }).flatMap((entry) => {
+    const path = `${relativeDir}/${entry.name}`;
+    if (entry.isDirectory()) {
+      return walkTsFiles(path);
+    }
+    return entry.isFile() && entry.name.endsWith(".ts") ? [path] : [];
+  });
+}
+
+function parse(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readSource(relativePath),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function normalizePath(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+function resolveSpecifier(file: string, specifier: string): string {
+  if (!specifier.startsWith(".")) {
+    return specifier;
+  }
+
+  const target = normalizePath(
+    relative(repoRoot, resolve(repoRoot, dirname(file), specifier)),
+  );
+  if (target.endsWith(".ts")) {
+    return target;
+  }
+  if (existsSync(resolve(repoRoot, `${target}.ts`))) {
+    return `${target}.ts`;
+  }
+  return existsSync(resolve(repoRoot, `${target}/index.ts`))
+    ? `${target}/index.ts`
+    : target;
+}
+
+function executableImportTargets(relativePath: string): string[] {
+  const targets: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const clause = node.importClause;
+      const bindings = clause?.namedBindings;
+      const typeOnlyBindings =
+        bindings &&
+        ts.isNamedImports(bindings) &&
+        bindings.elements.length > 0 &&
+        bindings.elements.every((element) => element.isTypeOnly);
+      if (!clause?.isTypeOnly && (clause?.name || !typeOnlyBindings)) {
+        targets.push(resolveSpecifier(relativePath, node.moduleSpecifier.text));
+      }
+    } else if (
+      ts.isExportDeclaration(node) &&
+      !node.isTypeOnly &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      targets.push(resolveSpecifier(relativePath, node.moduleSpecifier.text));
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      !node.isTypeOnly &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression &&
+      ts.isStringLiteral(node.moduleReference.expression)
+    ) {
+      targets.push(
+        resolveSpecifier(
+          relativePath,
+          node.moduleReference.expression.text,
+        ),
+      );
+    } else if (
+      ts.isCallExpression(node) &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      (
+        node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === "require")
+      )
+    ) {
+      targets.push(resolveSpecifier(relativePath, node.arguments[0].text));
+    }
+
+    node.forEachChild(visit);
+  }
+
+  visit(parse(relativePath));
+  return targets;
+}
+
+function reexportTargets(relativePath: string): string[] {
+  return parse(relativePath).statements
+    .filter(
+      (statement): statement is ts.ExportDeclaration =>
+        ts.isExportDeclaration(statement) &&
+        statement.moduleSpecifier !== undefined &&
+        ts.isStringLiteral(statement.moduleSpecifier),
+    )
+    .map((statement) =>
+      resolveSpecifier(
+        relativePath,
+        (statement.moduleSpecifier as ts.StringLiteral).text,
+      ),
+    );
+}
+
+function isPureFeatureReexportShim(relativePath: string): boolean {
+  const statements = parse(relativePath).statements;
+  return (
+    statements.length > 0 &&
+    statements.every(
+      (statement) =>
+        ts.isExportDeclaration(statement) &&
+        statement.moduleSpecifier !== undefined &&
+        ts.isStringLiteral(statement.moduleSpecifier) &&
+        resolveSpecifier(relativePath, statement.moduleSpecifier.text).startsWith(
+          "server/features/",
+        ),
+    )
+  );
+}
+
+test("M44 retira ambos paths legacy y sus imports ejecutables", () => {
+  for (const legacyPath of legacyPaths) {
+    assert.equal(existsSync(resolve(repoRoot, legacyPath)), false, legacyPath);
+  }
+
+  const violations = ["server", "test"].flatMap((root) =>
+    walkTsFiles(root).flatMap((file) =>
+      executableImportTargets(file)
+        .filter((target) =>
+          legacyPaths.includes(target as (typeof legacyPaths)[number]),
+        )
+        .map((target) => `${file} -> ${target}`),
+    ),
+  );
+  assert.deepEqual(violations, []);
+});
+
+test("M44 no deja shims puros raíz hacia features", () => {
+  const rootDbFiles = readdirSync(resolve(repoRoot, "server"), {
+    withFileTypes: true,
+  })
+    .filter(
+      (entry) =>
+        entry.isFile() &&
+        /^db-.+\.ts$/.test(entry.name),
+    )
+    .map((entry) => `server/${entry.name}`);
+  const candidates = [
+    ...rootDbFiles,
+    ...walkTsFiles("server/lib"),
+  ];
+
+  assert.deepEqual(
+    candidates.filter(isPureFeatureReexportShim),
+    [],
+  );
+});
+
+test("report-access-token permanece módulo real y no shim", () => {
+  assert.equal(existsSync(resolve(repoRoot, reportAccessTokenModule)), true);
+  assert.equal(isPureFeatureReexportShim(reportAccessTokenModule), false);
+
+  const source = readSource(reportAccessTokenModule);
+  for (const marker of [
+    "reportAccessTokenRawTokenSchema",
+    "parsePositiveInt",
+    "serializeReportAccessToken",
+    "serializePublicReportAccess",
+  ]) {
+    assert.ok(source.includes(marker), marker);
+  }
+});
+
+test("los ocho consumidores migrados apuntan al barrel Particular Access", () => {
+  const canonicalConsumers = walkTsFiles("server")
+    .filter((file) =>
+      executableImportTargets(file).includes(particularInfrastructureIndex),
+    )
+    .sort();
+  const preexistingCanonicalConsumers = [
+    particularComposition,
+    reportsComposition,
+  ].sort();
+
+  assert.deepEqual(
+    canonicalConsumers.filter(
+      (file) => !preexistingCanonicalConsumers.includes(file),
+    ),
+    expectedMigratedConsumers,
+  );
+  assert.deepEqual(
+    canonicalConsumers.filter((file) =>
+      preexistingCanonicalConsumers.includes(file),
+    ),
+    preexistingCanonicalConsumers,
+  );
+
+  for (const consumer of expectedMigratedConsumers) {
+    assert.equal(
+      executableImportTargets(consumer).filter(
+        (target) => target === particularInfrastructureIndex,
+      ).length,
+      1,
+      consumer,
+    );
+  }
+});
+
+test("los barrels canónicos existen y no hay aliases forwarding alternativos", () => {
+  for (const barrel of [
+    particularInfrastructureIndex,
+    studyTrackingInfrastructureIndex,
+  ]) {
+    assert.equal(existsSync(resolve(repoRoot, barrel)), true, barrel);
+  }
+
+  const alternateAliases = walkTsFiles("server").flatMap((file) =>
+    reexportTargets(file)
+      .filter(
+        (target) =>
+          target === particularInfrastructureIndex ||
+          target === studyTrackingInfrastructureIndex,
+      )
+      .map((target) => `${file} -> ${target}`),
+  );
+  assert.deepEqual(alternateAliases, []);
+});
+
+test("M44 tiene closeout y M45 permanece NOT_RUN", () => {
+  assert.equal(existsSync(resolve(repoRoot, m44Closeout)), true);
+  assert.equal(
+    existsSync(
+      resolve(
+        repoRoot,
+        "docs/implementation/m45-backend-feature-dependency-guard-closeout.md",
+      ),
+    ),
+    false,
+  );
+
+  const closeout = readSource(m44Closeout);
+  const audit = readSource(programAudit);
+  assert.ok(closeout.includes("M44 CLOSED localmente"));
+  assert.match(closeout, /M45\s+NOT_RUN/);
+  assert.ok(audit.includes("M44 — completado"));
+  assert.match(audit, /M45 —\s+NOT_RUN/);
+});
+
+test("el guard M44 no consulta estado Git ni worktrees", () => {
+  const source = readSource(guardFile);
+  assert.equal(
+    executableImportTargets(guardFile).includes("node:child_process"),
+    false,
+  );
+  assert.doesNotMatch(source, /\bgit\s+(?:branch|show-ref|worktree)\b/);
+});

--- a/test/architecture/particular-access-m33-closeout.test.ts
+++ b/test/architecture/particular-access-m33-closeout.test.ts
@@ -14,8 +14,8 @@ const applicationIndex = `${applicationDir}/index.ts`;
 const infrastructureIndex = `${infrastructureDir}/index.ts`;
 const repositoryFile = `${infrastructureDir}/particular-access-repository.ts`;
 const compositionFile = `${featureDir}/particular-access-route-composition.ts`;
-const dbShim = "server/db-particular.ts";
-const studyShim = "server/db-study-tracking.ts";
+const legacyParticularPath = "server/db-particular.ts";
+const legacyStudyTrackingPath = "server/db-study-tracking.ts";
 const closeout =
   "docs/implementation/m33-particular-access-domain-repository-thin-closeout.md";
 const routes = [
@@ -39,7 +39,7 @@ const expectedFeatureFiles = [
   compositionFile,
 ].sort();
 
-const particularShimConsumers = [
+const expectedExternalParticularConsumers = [
   "server/middlewares/particular-auth.ts",
   "server/preflight.ts",
   "server/routes/admin-study-tracking.fastify.ts",
@@ -218,8 +218,8 @@ test("composition es el único seam de rutas propias a infrastructure", () => {
     const targets = importTargets(route);
     assert.ok(targets.includes(applicationIndex), route);
     assert.ok(targets.includes(compositionFile), route);
-    assert.equal(targets.includes(dbShim), false, route);
-    assert.equal(targets.includes(studyShim), false, route);
+    assert.equal(targets.includes(legacyParticularPath), false, route);
+    assert.equal(targets.includes(legacyStudyTrackingPath), false, route);
     assert.equal(
       targets.some((target) => target.startsWith(`${infrastructureDir}/`)),
       false,
@@ -318,28 +318,38 @@ test("Options y endpoints de ambas rutas permanecen completos", () => {
   }
 });
 
-test("shims conservan una línea y allowlists residuales exactas", () => {
-  assert.equal(
-    readSource(dbShim).trim(),
-    'export * from "./features/particular-access/infrastructure/index.ts";',
+test("M44 retira paths legacy y realinea los ocho consumidores externos", () => {
+  assert.equal(existsSync(resolve(repoRoot, legacyParticularPath)), false);
+  assert.equal(existsSync(resolve(repoRoot, legacyStudyTrackingPath)), false);
+
+  const legacyViolations = ["server", "test"].flatMap((root) =>
+    walkFiles(root)
+      .filter((file) => file.endsWith(".ts"))
+      .flatMap((file) =>
+        importTargets(file)
+          .filter(
+            (target) =>
+              target === legacyParticularPath ||
+              target === legacyStudyTrackingPath,
+          )
+          .map((target) => `${file} -> ${target}`),
+      ),
   );
-  assert.equal(
-    readSource(studyShim).trim(),
-    'export * from "./features/study-tracking/infrastructure/index.ts";',
-  );
-  const actualParticularConsumers = walkFiles("server")
-    .filter((file) => file.endsWith(".ts") && file !== dbShim)
-    .filter((file) => importTargets(file).includes(dbShim))
-    .sort();
-  assert.deepEqual(actualParticularConsumers, particularShimConsumers);
-  const actualStudyConsumers = walkFiles("server")
-    .filter((file) => file.endsWith(".ts") && file !== studyShim)
-    .filter((file) => importTargets(file).includes(studyShim))
-    .sort();
-  assert.deepEqual(actualStudyConsumers, [
-  ]);
+  assert.deepEqual(legacyViolations, []);
+
   const reportsComposition =
     "server/features/reports/composition/report-route-composition.ts";
+  const actualExternalParticularConsumers = walkFiles("server")
+    .filter((file) => file.endsWith(".ts"))
+    .filter((file) => !file.startsWith(`${featureDir}/`))
+    .filter((file) => file !== reportsComposition)
+    .filter((file) => importTargets(file).includes(infrastructureIndex))
+    .sort();
+  assert.deepEqual(
+    actualExternalParticularConsumers,
+    expectedExternalParticularConsumers,
+  );
+
   const compositionTargets = importTargets(reportsComposition);
   assert.ok(compositionTargets.includes(infrastructureIndex));
   assert.ok(
@@ -352,11 +362,11 @@ test("shims conservan una línea y allowlists residuales exactas", () => {
 test("Auth preserva contrato y Reports usa composition M41", () => {
   assert.equal(
     digest("server/routes/particular-auth.fastify.ts"),
-    "5ed5bf6f6ec6edb72983cdcfca84b283b89a3db4ff3b408349b557aa9a0d1561",
+    "e94e5a2847f635f30a8edd81fa5270fd1501f727fc1b91e434677c3d101a0c86",
   );
   assert.equal(
     digest("server/middlewares/particular-auth.ts"),
-    "fc551f73cc21beb99d35e97cc9abde62d10e98621185b8d829f5bbe9919dc17b",
+    "5004967d61238de6d5fc38582ca48e0da1468189e418d279a4cd9786126c4683",
   );
   const reports = readSource("server/routes/admin-reports.fastify.ts");
   assert.ok(reports.includes("createAdminReportsRouteComposition"));
@@ -364,19 +374,27 @@ test("Auth preserva contrato y Reports usa composition M41", () => {
   assert.equal(reports.includes("../db-study-tracking.ts"), false);
 });
 
-test("README y closeout documentan owners, seguridad y milestones pendientes", () => {
-  for (const file of [`${featureDir}/README.md`, closeout]) {
-    const source = readSource(file);
-    for (const marker of [
-      "server/db-particular.ts",
-      "admin-reports.fastify.ts",
-      "M34",
-      "M35b",
-    ]) {
-      assert.ok(source.includes(marker), `${file}: ${marker}`);
-    }
+test("README vigente M44 y closeout histórico M33 permanecen trazables", () => {
+  const readme = readSource(`${featureDir}/README.md`);
+  for (const marker of [
+    "server/db-particular.ts",
+    "M44",
+    "ocho consumidores externos",
+    "M44 no reorganizó Auth",
+  ]) {
+    assert.ok(readme.includes(marker), `${featureDir}/README.md: ${marker}`);
   }
-  const source = readSource(closeout);
+
+  const historicalCloseout = readSource(closeout);
+  for (const marker of [
+    "server/db-particular.ts",
+    "admin-reports.fastify.ts",
+    "M34",
+    "M35b",
+  ]) {
+    assert.ok(historicalCloseout.includes(marker), `${closeout}: ${marker}`);
+  }
+
   for (const marker of [
     "cross-tenant",
     "anti-enumeración",
@@ -384,6 +402,6 @@ test("README y closeout documentan owners, seguridad y milestones pendientes", (
     "No se afirma RLS",
     "Rollback",
   ]) {
-    assert.ok(source.includes(marker), marker);
+    assert.ok(historicalCloseout.includes(marker), marker);
   }
 });

--- a/test/architecture/study-tracking-admin-thin-route.test.ts
+++ b/test/architecture/study-tracking-admin-thin-route.test.ts
@@ -372,14 +372,14 @@ test("M32b composición admin selecciona sólo el barrel de infrastructure", () 
   assert.equal(source.includes("drizzle-orm"), false);
 });
 
-test("M32b conserva rutas y M41 migra sólo el owner Reports clínico", () => {
+test("M44 preserva rutas M32 y realinea sólo el specifier Particular Access", () => {
   assert.equal(
     digest(clinicRouteFile),
-    "f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319",
+    "aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7",
   );
   assert.equal(
     digest(particularRouteFile),
-    "ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb",
+    "88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa",
   );
 });
 

--- a/test/architecture/study-tracking-clinic-particular-thin-routes.test.ts
+++ b/test/architecture/study-tracking-clinic-particular-thin-routes.test.ts
@@ -252,17 +252,17 @@ test("M32 routes no importan shim ni infrastructure y particular resuelve lazy p
   );
 });
 
-test("M32 preserva rutas y M41 migra sólo el owner Reports clínico", () => {
+test("M44 preserva rutas M32 y realinea sólo el specifier Particular Access", () => {
   assert.equal(
     createHash("sha256")
       .update(readFileSync(resolve(repoRoot, clinicRoute)))
       .digest("hex"),
-    "f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319",
+    "aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7",
   );
   assert.equal(
     createHash("sha256")
       .update(readFileSync(resolve(repoRoot, particularRoute)))
       .digest("hex"),
-    "ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb",
+    "88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa",
   );
 });

--- a/test/architecture/study-tracking-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/study-tracking-infrastructure-boundary-guard.test.ts
@@ -2,6 +2,7 @@ import assert from "node:assert/strict";
 import { existsSync, readFileSync, readdirSync } from "node:fs";
 import { dirname, join, relative } from "node:path";
 import test from "node:test";
+import ts from "typescript";
 
 const repoRoot = process.cwd();
 const featureDir = "server/features/study-tracking";
@@ -102,7 +103,58 @@ function resolveSpecifier(file: string, specifier: string): string {
   return existsSync(join(repoRoot, indexFile)) ? indexFile : resolved;
 }
 
-test("M31 mueve el repository completo a infrastructure con barrel y shim", () => {
+function executableImportTargets(relativePath: string): string[] {
+  const sourceFile = ts.createSourceFile(
+    relativePath,
+    readText(relativePath),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const targets: string[] = [];
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      const clause = node.importClause;
+      const bindings = clause?.namedBindings;
+      const typeOnlyBindings =
+        bindings &&
+        ts.isNamedImports(bindings) &&
+        bindings.elements.length > 0 &&
+        bindings.elements.every((element) => element.isTypeOnly);
+      if (!clause?.isTypeOnly && (clause?.name || !typeOnlyBindings)) {
+        targets.push(resolveSpecifier(relativePath, node.moduleSpecifier.text));
+      }
+    } else if (
+      ts.isExportDeclaration(node) &&
+      !node.isTypeOnly &&
+      node.moduleSpecifier &&
+      ts.isStringLiteral(node.moduleSpecifier)
+    ) {
+      targets.push(resolveSpecifier(relativePath, node.moduleSpecifier.text));
+    } else if (
+      ts.isCallExpression(node) &&
+      node.arguments[0] &&
+      ts.isStringLiteral(node.arguments[0]) &&
+      (
+        node.expression.kind === ts.SyntaxKind.ImportKeyword ||
+        (ts.isIdentifier(node.expression) && node.expression.text === "require")
+      )
+    ) {
+      targets.push(resolveSpecifier(relativePath, node.arguments[0].text));
+    }
+
+    node.forEachChild(visit);
+  }
+
+  visit(sourceFile);
+  return targets;
+}
+
+test("M44 conserva repository y barrel canónicos y retira el shim", () => {
   assert.deepEqual(walkTsFiles(infrastructureDir).sort(), [
     infrastructureIndexFile,
     repositoryFile,
@@ -111,10 +163,16 @@ test("M31 mueve el repository completo a infrastructure con barrel y shim", () =
     readText(infrastructureIndexFile).trim(),
     'export * from "./study-tracking-repository.ts";',
   );
-  assert.equal(
-    readText(legacyShimFile).trim(),
-    'export * from "./features/study-tracking/infrastructure/index.ts";',
+  assert.equal(existsSync(join(repoRoot, legacyShimFile)), false);
+
+  const violations = ["server", "test"].flatMap((root) =>
+    walkTsFiles(root)
+      .filter((file) =>
+        executableImportTargets(file).includes(legacyShimFile),
+      )
+      .map((file) => `${file} -> ${legacyShimFile}`),
   );
+  assert.deepEqual(violations, []);
 });
 
 test("el repository conserva la superficie pública completa", () => {

--- a/test/architecture/study-tracking-phase-closeout.test.ts
+++ b/test/architecture/study-tracking-phase-closeout.test.ts
@@ -10,7 +10,7 @@ const featureDir = "server/features/study-tracking";
 const applicationIndex = `${featureDir}/application/index.ts`;
 const infrastructureIndex = `${featureDir}/infrastructure/index.ts`;
 const compositionFile = `${featureDir}/study-tracking-route-composition.ts`;
-const dbShim = "server/db-study-tracking.ts";
+const legacyDbPath = "server/db-study-tracking.ts";
 const domainShims = [
   "server/lib/study-tracking.ts",
   "server/lib/token-study-tracking.ts",
@@ -22,9 +22,9 @@ const routes = {
 } as const;
 
 const routeHashes = new Map<string, string>([
-  [routes.clinic, "f2b8e5afbe0ded7fcb75ece389cfd476d8667c49f792a104f9ee3bb7379f7319"],
-  [routes.particular, "ed7d3f4a949af488a9dab5a9a89ccc9e89d19399ddde7230a25a3189a32591fb"],
-  [routes.admin, "15aab9bd2b23caf27644185b5421cabe206644ed5b837c54e3dac66fa109c892"],
+  [routes.clinic, "aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7"],
+  [routes.particular, "88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa"],
+  [routes.admin, "4454a06d394f6d377eedfb1420bc2e3a6e8e651096d3a230c2cd809db0dcb6de"],
 ]);
 
 const expectedFeatureFiles = [
@@ -173,31 +173,19 @@ test("M35 retira ambos shims domain y prohíbe imports globales a sus paths", ()
   assert.deepEqual(violations, []);
 });
 
-test("M35 conserva el shim DB de una linea con allowlist externa exacta", () => {
-  assert.equal(
-    readSource(dbShim).trim(),
-    'export * from "./features/study-tracking/infrastructure/index.ts";',
+test("M44 retira el path DB legacy de Study Tracking sin consumidores", () => {
+  assert.equal(existsSync(resolve(repoRoot, legacyDbPath)), false);
+
+  const actualConsumers = ["server", "test"].flatMap((root) =>
+    walkFiles(root)
+      .filter((file) => file.endsWith(".ts"))
+      .filter((file) => importTargets(file).includes(legacyDbPath)),
   );
-
-  const actualConsumers = walkFiles("server")
-    .filter((file) => file.endsWith(".ts") && file !== dbShim)
-    .filter((file) => importTargets(file).includes(dbShim))
-    .sort();
-
-  assert.deepEqual(actualConsumers, [...residualDbConsumers.keys()].sort());
+  assert.deepEqual(actualConsumers, []);
 });
 
-test("cada consumidor residual del shim DB tiene owner y milestone documentados", () => {
-  const readme = readSource(`${featureDir}/README.md`);
-  const closeout = readSource("docs/implementation/m35-study-tracking-phase-closeout.md");
-
-  for (const [consumer, ownership] of residualDbConsumers) {
-    for (const source of [readme, closeout]) {
-      assert.ok(source.includes(consumer), consumer);
-      assert.ok(source.includes(ownership.owner), ownership.owner);
-      assert.ok(source.includes(ownership.milestone), ownership.milestone);
-    }
-  }
+test("residualDbConsumers permanece vacío después de M44", () => {
+  assert.equal(residualDbConsumers.size, 0);
 });
 
 test("las tres rutas permanecen exactas y sólo atraviesan application y composition", () => {
@@ -207,7 +195,7 @@ test("las tres rutas permanecen exactas y sólo atraviesan application y composi
     const targets = importTargets(route);
     assert.ok(targets.includes(applicationIndex), route);
     assert.ok(targets.includes(compositionFile), route);
-    assert.equal(targets.includes(dbShim), false, route);
+    assert.equal(targets.includes(legacyDbPath), false, route);
     assert.equal(
       targets.some((target) => target.startsWith(`${featureDir}/infrastructure/`)),
       false,

--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -57,6 +57,22 @@ const ownRoutes = [
   "server/routes/public-report-access.fastify.ts",
 ] as const;
 
+const legacyParticularPath = "server/db-particular.ts";
+const particularInfrastructureIndex =
+  "server/features/particular-access/infrastructure/index.ts";
+const reportsComposition =
+  "server/features/reports/composition/report-route-composition.ts";
+const expectedExternalParticularConsumers = [
+  "server/middlewares/particular-auth.ts",
+  "server/preflight.ts",
+  "server/routes/admin-study-tracking.fastify.ts",
+  "server/routes/auth.fastify.ts",
+  "server/routes/particular-audit.fastify.ts",
+  "server/routes/particular-auth.fastify.ts",
+  "server/routes/particular-study-tracking.fastify.ts",
+  "server/routes/study-tracking.fastify.ts",
+].sort();
+
 const globalGuardAnchors = [
   {
     path: "test/architecture/security/security-access-lifecycle-boundaries.test.ts",
@@ -231,34 +247,6 @@ function scenarioNames(path: string, variableName: string): string[] {
   return names;
 }
 
-function stringArrayInitializer(path: string, variableName: string): string[] {
-  let values: string[] | undefined;
-  function visit(node: ts.Node): void {
-    if (
-      ts.isVariableDeclaration(node) &&
-      ts.isIdentifier(node.name) &&
-      node.name.text === variableName &&
-      node.initializer
-    ) {
-      const initializer =
-        ts.isCallExpression(node.initializer) &&
-        ts.isPropertyAccessExpression(node.initializer.expression) &&
-        node.initializer.expression.name.text === "sort"
-          ? node.initializer.expression.expression
-          : node.initializer;
-      if (ts.isArrayLiteralExpression(initializer)) {
-        values = initializer.elements
-          .filter(ts.isStringLiteral)
-          .map((element) => element.text);
-      }
-    }
-    node.forEachChild(visit);
-  }
-  parse(path).forEachChild(visit);
-  assert.ok(values, `${variableName} must remain an explicit string array`);
-  return values;
-}
-
 test("M35b conserva features, closeouts y evidencia canónicos", () => {
   for (const { feature, required } of featureLayers) {
     for (const layer of required) {
@@ -333,28 +321,43 @@ test("M35b prohíbe repositories legacy e imports ejecutables directos desde rut
   }
 });
 
-test("M35b reutiliza la allowlist M33 de shims Particular sin ampliarla", () => {
-  const m33Guard = "test/architecture/particular-access-m33-closeout.test.ts";
-  const expected = stringArrayInitializer(m33Guard, "particularShimConsumers")
-    .slice()
-    .sort();
-  assert.equal(expected.length, 8);
+test("M44 retira el shim Particular y fija ocho consumidores canónicos", () => {
+  assert.equal(existsSync(resolve(root, legacyParticularPath)), false);
 
-  const actual = walk("server")
-    .filter((file) => file.endsWith(".ts") && file !== "server/db-particular.ts")
+  const legacyViolations = ["server", "test"].flatMap((scanRoot) =>
+    walk(scanRoot)
+      .filter((file) => file.endsWith(".ts"))
+      .filter((file) =>
+        executableImportTargets(file).includes(legacyParticularPath),
+      ),
+  );
+  assert.deepEqual(legacyViolations, []);
+
+  const actualExternalConsumers = walk("server")
+    .filter((file) => file.endsWith(".ts"))
+    .filter(
+      (file) =>
+        !file.startsWith("server/features/particular-access/") &&
+        file !== reportsComposition,
+    )
     .filter((file) =>
-      executableImportTargets(file).includes("server/db-particular.ts"),
+      executableImportTargets(file).includes(particularInfrastructureIndex),
     )
     .sort();
-  assert.deepEqual(actual, expected);
-
-  const source = read(m33Guard);
-  assert.equal(
-    source.includes(
-      'test("shims conservan una línea y allowlists residuales exactas"',
-    ),
-    true,
+  assert.deepEqual(
+    actualExternalConsumers,
+    expectedExternalParticularConsumers,
   );
+
+  for (const route of ownRoutes) {
+    assert.equal(
+      executableImportTargets(route).some((target) =>
+        target.includes("/infrastructure/"),
+      ),
+      false,
+      route,
+    );
+  }
 });
 
 test("M35b mantiene conectados los guards globales de token access", () => {

--- a/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
+++ b/test/unit/contracts/study-tracking/study-tracking-suite-completeness.test.ts
@@ -146,14 +146,14 @@ const STUDY_TRACKING_SUITE: readonly StudyTrackingSuiteEntry[] = [
         markers: [
           "M32 conserva exactamente Options y endpoints",
           "M32 routes delegan",
-          "M32 preserva rutas y M41 migra s\u00f3lo el owner Reports cl\u00ednico",
+          "M44 preserva rutas M32 y realinea s\u00f3lo el specifier Particular Access",
         ],
       },
       {
         path: "test/architecture/study-tracking-phase-closeout.test.ts",
         markers: [
           "M33 extiende el inventario canonico de Study Tracking",
-          "M35 conserva el shim DB de una linea con allowlist externa exacta",
+          "M44 retira el path DB legacy de Study Tracking sin consumidores",
           "los tres realms quedan separados con evidencia runtime",
         ],
       },


### PR DESCRIPTION
## Summary

- Retires the final two root compatibility shims from the backend modularization program.
- Realigns eight dynamic imports to the canonical Particular Access infrastructure barrel.
- Removes the Study Tracking root shim after confirming zero executable consumers.
- Realigns active guards, hashes, suite completeness and current documentation.
- Adds the global M44 guard and closeout.
- Preserves Auth ownership and runtime behavior.

## Scope

- [x] Backend runtime
- [ ] Frontend runtime
- [ ] Tests
- [ ] Workflows/CI
- [ ] Migrations/schema
- [ ] Docs
- [ ] Dependencies
- [ ] Scripts/tooling
- [ ] Repository configuration
- [ ] Other
- [ ] Mixed-scope exception

Tests and documentation support the backend runtime structural change and do not define another primary scope.

## Architecture

Removed legacy paths:

- server/db-particular.ts
- server/db-study-tracking.ts

Canonical paths:

- server/features/particular-access/infrastructure/index.ts
- server/features/study-tracking/infrastructure/index.ts

The Particular Access shim only re-exported its canonical barrel. The eight consumers now import the same barrel directly without changing the received module namespace, exported functions, lazy loading or execution order.

Study Tracking had zero executable consumers of its root shim before removal.

## Contracts preserved

- Bootstrap and preflight cleanup.
- Clinic, particular and admin authentication.
- Sessions, cookies and last-access behavior.
- Login, logout and rate limiting.
- CORS, trusted-origin and CSRF enforcement.
- Particular audit behavior.
- Study Tracking clinic, particular and admin routes.
- Email and audit side effects.
- Status codes, payloads, messages and errors.
- Auth architecture and ownership.

## Validation

- Focused M44 cohort: 262/262 passed.
- Global M44 guard: 7/7 passed.
- pnpm typecheck: passed.
- pnpm typecheck:test: passed.
- pnpm test: 3909 passed, 1 skipped, 0 failed.
- pnpm build: passed.
- pnpm security:public-surface: passed.
- pnpm audit --prod: passed.
- pnpm audit: passed.
- pnpm validate:local: passed.
- git diff --check: passed.
- Productive diff: exactly eight additions and eight deletions.
- Changed paths: exactly 24.

## Rollback

Revert the M44 commit. This restores both compatibility shims, returns the eight dynamic imports to server/db-particular.ts and restores the previous guards, hashes and documentation.

No schema migration, data compensation, Auth reorganization or dependency rollback is required.

## Exclusions

No changes to frontend, schema, migrations, Supabase, dependencies, lockfiles, scripts, CI workflows, Docker, server/fastify-app.ts, server/db.ts, canonical repositories, canonical barrels, server/lib/report-access-token.ts, server/lib/permissions.ts, email implementation or audit infrastructure.

M45 anti-cycle analysis and the cross-feature dependency matrix remain NOT_RUN.