### PR TITLE
test(architecture): guard backend feature dependencies

### DIFF
--- a/docs/audit/backend-enterprise-modularization-program-audit.md
+++ b/docs/audit/backend-enterprise-modularization-program-audit.md
@@ -1055,8 +1055,16 @@ techo de 60.)*
 > retiraron los dos shims residuales `server/db-particular.ts` y
 > `server/db-study-tracking.ts`; ocho imports dinámicos se realinearon al
 > barrel canónico de Particular Access, sin cambios funcionales.
-> **M45 — NOT_RUN** y permanece como el siguiente milestone. Este status no altera el
-> conteo recomendado, la definición de M45/M46/M48, los riesgos ni las
+> **M45 — completado** localmente y corregido tras review P2: el guard global
+> AST congela una matriz full/runtime de 9 features, 149 archivos TypeScript,
+> 16 referencias cross-feature y 7 aristas dirigidas. Todos los imports
+> cross-feature pasan exclusivamente por barrels públicos raíz, el scan de
+> `server/lib` queda en cero dependencias hacia features y `ImportTypeNode`
+> se clasifica como type-only. Los módulos de token se movieron 1:1 a
+> Particular Access y Report Access. El único SCC full/runtime preexistente
+> permitido sigue siendo `particular-access ↔ reports`.
+> **C5 — NOT_RUN**, **M46 — NOT_RUN** y **M48 — NOT_RUN**. Este status no
+> altera el conteo recomendado, la definición de M46/M48, los riesgos ni las
 > conclusiones históricas.
 
 **Contingencia (fuera del conteo):** C1 coverage (autorizar dep c8 primero) · C2 límites de

--- a/docs/implementation/m45-backend-feature-dependency-guard-closeout.md
+++ b/docs/implementation/m45-backend-feature-dependency-guard-closeout.md
@@ -1,0 +1,203 @@
+# M45 — Global feature dependency guard closeout
+
+## 1. Identificación y baseline
+
+- Milestone: M45, guard global anti-ciclos y matriz de dependencias entre
+  features de Fase K.
+- Rama: `test/backend-modularization-m45-feature-dependency-guard`.
+- HEAD y upstream al iniciar la corrección P2:
+  `dbf3f6fa3b3830a53a81dcebab181a8322af7243`.
+- Working tree e index al iniciar la corrección: limpios.
+- PR auditado: `#1584`, abierto, no draft, head correcto y bloqueado por tres
+  review threads P2 vigentes.
+- Fecha del cierre corregido: 2026-07-28.
+
+## 2. Alcance incluido
+
+La corrección P2 amplía M45 para:
+
+1. descubrir dependencias desde `server/lib/**/*.ts` hacia
+   `server/features/**`;
+2. prohibir imports cross-feature a internals y permitir únicamente el barrel
+   público `server/features/<feature>/index.ts`;
+3. clasificar `ImportTypeNode` (`type T = import("...").T`) como
+   `import-type` y type-only;
+4. preservar por separado los grafos full y runtime;
+5. mover a sus features propietarias los dos módulos encontrados por el RED;
+6. realinear consumidores y contratos arquitectónicos sin cambiar
+   comportamiento.
+
+## 3. Alcance excluido
+
+No se modificaron endpoints, payloads, status codes, persistencia, schema,
+migraciones, dependencias, lockfiles, auth, permisos, sesiones, cookies, CORS,
+trusted origin, CSRF, rate limits, email, auditoría runtime, CI ni workflows.
+No se ejecutó C5 ni se rompió el SCC residual.
+
+## 4. Auditoría de ownership y moves
+
+El nuevo scan produjo cuatro dependencias `lib → features`, sin allowlists:
+
+- `server/lib/particular-token.ts` → Particular Access y Reports;
+- `server/lib/report-access-token.ts` → Report Access y Reports.
+
+El ownership funcional determinó estos moves 1:1:
+
+- `server/lib/particular-token.ts` →
+  `server/features/particular-access/particular-token.ts`;
+- `server/lib/report-access-token.ts` →
+  `server/features/report-access/report-access-token.ts`.
+
+Los paths legacy quedaron eliminados y todos sus consumidores runtime, tests y
+anclas arquitectónicas apuntan a los módulos canónicos de feature.
+
+## 5. Barrels públicos y lazy loading
+
+Cada destino cross-feature expone un barrel raíz mínimo en
+`server/features/<feature>/index.ts`. El guard exige que el destino resuelto
+sea exactamente ese archivo; cualquier import a `domain/`, `application/`,
+`infrastructure/`, `composition/` u otro archivo interno queda rechazado.
+
+Para no convertir imports dinámicos en carga eager se añadieron dos seams
+públicos lazy:
+
+- `particular-access/particular-access-public-composition.ts`;
+- `reports/reports-public-composition.ts`.
+
+Los loaders públicos delegan por `import()` a la infraestructura o composición
+existente. No duplican reglas, queries ni persistencia.
+
+## 6. Censo congelado corregido
+
+- Features: 9.
+- Archivos TypeScript bajo `server/features`: 149.
+- Referencias cross-feature exactas: 16.
+- Pares dirigidos full y runtime: 7.
+- Referencias dinámicas: 7.
+- Referencias estáticas runtime: 6.
+- Referencias type-only: 3.
+- Imports cross-feature a internals: 0.
+- Imports `server/lib → server/features`: 0.
+- Imports relativos irresolubles: 0.
+- Imports desde features hacia `server/routes` o `server/middlewares`: 0.
+
+Las nueve features son `clinics`, `logistics`, `particular-access`, `pricing`,
+`public-professionals`, `report-access`, `reports`, `study-tracking` y
+`users-roles`.
+
+## 7. Matrices full y runtime
+
+| Feature origen | Features destino |
+| --- | --- |
+| `clinics` | `public-professionals` |
+| `logistics` | ninguna |
+| `particular-access` | `reports`, `study-tracking` |
+| `pricing` | ninguna |
+| `public-professionals` | ninguna |
+| `report-access` | `reports` |
+| `reports` | `particular-access`, `study-tracking` |
+| `study-tracking` | ninguna |
+| `users-roles` | `clinics` |
+
+La matriz full conserva también las referencias type-only. En el censo real
+actual, full y runtime tienen las mismas siete aristas porque cada par que
+contiene un import type-only también posee al menos una referencia runtime. La
+fixture determinística de `ImportTypeNode` agrega una arista sólo al grafo
+full y demuestra que el grafo runtime no cambia.
+
+## 8. SCC preexistente
+
+El único componente fuertemente conexo de los grafos full y runtime es
+`particular-access ↔ reports`. M45 lo congela como deuda preexistente explícita
+y rechaza cualquier SCC adicional.
+
+- C5 — NOT_RUN.
+- M46 — NOT_RUN.
+- M48 — NOT_RUN.
+
+## 9. Descripción técnica del guard
+
+El guard usa el AST de TypeScript, auto-descubre recursivamente los `.ts` de
+`server/features` y `server/lib`, normaliza separadores Windows y resuelve
+destinos relativos como archivo `.ts` o barrel `index.ts`. No usa Git, ramas,
+worktrees, `child_process`, aliases ni dependencias nuevas.
+
+Clasifica imports estáticos, side-effect imports, imports type-only completos o
+por specifier, reexports, `import =`, `ImportTypeNode`, `import()` y
+`require()`. Cada referencia canónica congela origen, kind, semántica
+type-only/runtime, specifier y destino resuelto, por lo que una adición, retiro
+o reclasificación produce drift.
+
+## 10. Evidencia RED y corrección causal
+
+La primera cohorte M44 + M45 corregida ejecutó 18 tests: 15 pass y 3 fail.
+Los fallos fueron exactamente:
+
+1. cuatro dependencias `server/lib → server/features`;
+2. catorce imports cross-feature a internals;
+3. ausencia de detección de la fixture `ImportTypeNode`.
+
+Una primera realineación mediante reexports estáticos hizo eager la carga de
+infraestructura y falló la cohorte funcional dirigida: 69 tests, 61 pass y
+8 fail por variables de Supabase ausentes. La causa se corrigió con loaders
+públicos lazy; no se agregaron mocks ni fallbacks productivos.
+
+Los dos primeros intentos de `validate:local` alcanzaron el test completo y
+fallaron únicamente por guardrails históricos que fijaban imports internos o
+inventarios cerrados. Cada grupo se corrigió causalmente y pasó primero su
+cohorte dirigida antes del reintento integral.
+
+## 11. Evidencia GREEN y validaciones
+
+| Comando | Estado | Resultado |
+| --- | --- | --- |
+| Cohorte M44 + M45 | PASSED | 18 tests, 18 pass, 0 fail |
+| Cohorte funcional de Particular/Report Access | PASSED | 106 tests, 106 pass, 0 fail |
+| Cohorte de contratos arquitectónicos afectados | PASSED | 56 tests, 56 pass, 0 fail |
+| Cohortes causales de guardrails históricos | PASSED | 33/33 y 28/28 |
+| `pnpm typecheck` | PASSED | TypeScript runtime sin errores |
+| `pnpm typecheck:test` | PASSED | TypeScript tests sin errores |
+| `pnpm validate:local` | PASSED | typechecks + 3921 tests, 3920 pass, 1 skip, 0 fail + build |
+| `pnpm security:public-surface` | PASSED | cero findings públicos; dos markers server-only esperados |
+| `git diff --check` | PASSED | cero errores de whitespace |
+
+## 12. Archivos y familias modificadas
+
+- runtime de Clinics, Particular Access, Report Access, Reports, Study Tracking
+  y Users/Roles;
+- seis barrels públicos raíz y dos loaders públicos lazy;
+- rutas consumidoras de los dos módulos movidos;
+- guard M45 y realineación causal de M44;
+- tests funcionales y contratos arquitectónicos que anclaban paths o
+  inventarios;
+- este closeout y el audit rector del programa.
+
+## 13. Contratos preservados
+
+Los módulos movidos conservan su implementación. Los cambios de consumidores
+son de paths y seams de carga. Permanecen intactos endpoints, payloads, status
+codes, orden de validación, queries, transacciones, auth, roles, permisos,
+sesiones, cookies, CSRF, rate limits, CSP, CORS, trusted origin, auditoría,
+email y manejo de errores.
+
+## 14. Riesgo residual y rollback
+
+Permanece el SCC runtime `particular-access ↔ reports`; romperlo requiere C5 o
+un trabajo posterior explícito. El rollback debe revertir conjuntamente moves,
+barrels/loaders, imports, guards, tests y documentación. No requiere
+migraciones, compensaciones ni cambios de datos.
+
+## 15. Git/GitHub
+
+- HEAD: sin modificar respecto de
+  `dbf3f6fa3b3830a53a81dcebab181a8322af7243`.
+- STAGE: NOT_RUN.
+- COMMIT: NOT_RUN.
+- PUSH: NOT_RUN.
+- UPDATE PR BODY: NOT_RUN.
+- RESPONDER THREADS: NOT_RUN.
+- RESOLVER THREADS: NOT_RUN.
+- MERGE: NOT_RUN.
+
+**M45 CLOSED localmente** con los gates de la sección 11 ejecutados sobre el
+diff corregido.

--- a/server/features/clinics/clinic-public-profile-command-service.ts
+++ b/server/features/clinics/clinic-public-profile-command-service.ts
@@ -5,7 +5,7 @@ import {
 } from "./domain/index.ts";
 import type {
   UpsertClinicPublicProfileInput,
-} from "../public-professionals/infrastructure/index.ts";
+} from "../public-professionals/index.ts";
 
 export type ClinicPublicProfilePublication = {
   isPublic: boolean;
@@ -105,7 +105,7 @@ async function loadDefaultDeps(): Promise<ClinicPublicProfileCommandServiceDeps>
   if (!defaultDepsPromise) {
     defaultDepsPromise = Promise.all([
       import(
-        "../public-professionals/infrastructure/index.ts"
+        "../public-professionals/index.ts"
       ),
       import("../../lib/supabase.ts"),
     ]).then(([publicProfiles, storage]) => ({

--- a/server/features/clinics/clinic-public-profile-query-service.ts
+++ b/server/features/clinics/clinic-public-profile-query-service.ts
@@ -33,7 +33,7 @@ async function loadDefaultDeps(): Promise<ClinicPublicProfileQueryServiceDeps> {
   if (!defaultDepsPromise) {
     defaultDepsPromise = Promise.all([
       import(
-        "../public-professionals/infrastructure/index.ts"
+        "../public-professionals/index.ts"
       ),
       import("../../lib/supabase.ts"),
     ]).then(([publicProfiles, storage]) => ({

--- a/server/features/clinics/index.ts
+++ b/server/features/clinics/index.ts
@@ -1,0 +1,6 @@
+export {
+  updateAdminClinicUserCredentialsCommand,
+  type AdminClinicUserCredentialsCommandInput,
+  type AdminClinicUserCredentialsUpdateInput,
+  type AdminClinicUserCredentialsUpdateResult,
+} from "./admin-clinics-command-service.ts";

--- a/server/features/particular-access/application/admin-particular-access-operations.ts
+++ b/server/features/particular-access/application/admin-particular-access-operations.ts
@@ -1,6 +1,6 @@
 import {
   createTokenStudyTrackingOperations,
-} from "../../study-tracking/application/index.ts";
+} from "../../study-tracking/index.ts";
 import {
   belongsToClinic,
   getParticularTokenLast4,

--- a/server/features/particular-access/application/clinic-particular-access-operations.ts
+++ b/server/features/particular-access/application/clinic-particular-access-operations.ts
@@ -1,4 +1,4 @@
-import { createTokenStudyTrackingOperations } from "../../study-tracking/application/index.ts";
+import { createTokenStudyTrackingOperations } from "../../study-tracking/index.ts";
 import { getParticularTokenLast4 } from "../domain/index.ts";
 import type {
   CreateParticularAccessTokenData,

--- a/server/features/particular-access/application/ports/particular-access-ports.ts
+++ b/server/features/particular-access/application/ports/particular-access-ports.ts
@@ -1,4 +1,4 @@
-import type { TokenStudyTrackingOperationsDeps } from "../../../study-tracking/application/index.ts";
+import type { TokenStudyTrackingOperationsDeps } from "../../../study-tracking/index.ts";
 
 export type ParticularAccessTokenRecord = {
   id: number;

--- a/server/features/particular-access/index.ts
+++ b/server/features/particular-access/index.ts
@@ -1,0 +1,4 @@
+export * from "./particular-token.ts";
+export {
+  loadReportsParticularAccessPersistence,
+} from "./particular-access-public-composition.ts";

--- a/server/features/particular-access/particular-access-public-composition.ts
+++ b/server/features/particular-access/particular-access-public-composition.ts
@@ -1,0 +1,10 @@
+export async function loadReportsParticularAccessPersistence() {
+  const repository = await import("./infrastructure/index.ts");
+
+  return {
+    getParticularTokenById:
+      repository.getParticularTokenById,
+    updateParticularTokenReport:
+      repository.updateParticularTokenReport,
+  };
+}

--- a/server/features/particular-access/particular-access-route-composition.ts
+++ b/server/features/particular-access/particular-access-route-composition.ts
@@ -1,4 +1,4 @@
-import { loadParticularAccessStudyTrackingPersistence } from "../study-tracking/study-tracking-route-composition.ts";
+import { loadParticularAccessStudyTrackingPersistence } from "../study-tracking/index.ts";
 
 export async function loadAdminParticularAccessRouteDeps() {
   const [
@@ -14,7 +14,10 @@ export async function loadAdminParticularAccessRouteDeps() {
     import("./infrastructure/index.ts"),
     import("../../lib/email.ts"),
     loadParticularAccessStudyTrackingPersistence(),
-    import("../reports/composition/index.ts"),
+    import("../reports/index.ts").then(
+      ({ loadParticularAccessReportCommands }) =>
+        loadParticularAccessReportCommands(),
+    ),
   ]);
 
   return {
@@ -51,7 +54,10 @@ export async function loadClinicParticularAccessRouteDeps() {
     import("./infrastructure/index.ts"),
     import("../../lib/email.ts"),
     loadParticularAccessStudyTrackingPersistence(),
-    import("../reports/composition/index.ts"),
+    import("../reports/index.ts").then(
+      ({ loadParticularAccessReportCommands }) =>
+        loadParticularAccessReportCommands(),
+    ),
   ]);
 
   return {

--- a/server/features/particular-access/particular-token.ts
+++ b/server/features/particular-access/particular-token.ts
@@ -1,7 +1,7 @@
 import { z } from "zod";
-import type { ParticularToken, Report } from "../../drizzle/schema.ts";
-import { hasLinkedParticularReport } from "../features/particular-access/domain/index.ts";
-import { serializeSafeReport } from "../features/reports/domain/index.ts";
+import type { ParticularToken, Report } from "../../../drizzle/schema.ts";
+import { hasLinkedParticularReport } from "./domain/index.ts";
+import { serializeSafeReport } from "../reports/index.ts";
 
 const requiredText = (max: number, label: string) =>
   z.string().trim().min(1, `${label} es obligatorio`).max(max);

--- a/server/features/public-professionals/index.ts
+++ b/server/features/public-professionals/index.ts
@@ -1,0 +1,10 @@
+export {
+  MIN_PUBLIC_PROFILE_QUALITY_SCORE,
+  buildClinicPublicProfileResponse,
+  evaluateClinicPublicProfilePublication,
+  getClinicPublicProfileByClinicId,
+  patchClinicPublicProfile,
+  removeClinicPublicAvatar,
+  syncClinicPublicSearch,
+  type UpsertClinicPublicProfileInput,
+} from "./infrastructure/index.ts";

--- a/server/features/report-access/index.ts
+++ b/server/features/report-access/index.ts
@@ -1,0 +1,1 @@
+export * from "./report-access-token.ts";

--- a/server/features/report-access/report-access-token.ts
+++ b/server/features/report-access/report-access-token.ts
@@ -2,14 +2,14 @@ import { z } from "zod";
 import type {
   Report,
   ReportAccessToken,
-} from "../../drizzle/schema.ts";
-import { serializeSafeReport } from "../features/reports/domain/index.ts";
+} from "../../../drizzle/schema.ts";
+import { serializeSafeReport } from "../reports/index.ts";
 import {
   canAccessReportPublicly,
   getReportAccessTokenState,
   isReportAccessTokenExpired,
   isReportAccessTokenRevoked,
-} from "../features/report-access/domain/index.ts";
+} from "./domain/index.ts";
 
 export {
   canAccessReportPublicly,

--- a/server/features/reports/composition/report-route-composition.ts
+++ b/server/features/reports/composition/report-route-composition.ts
@@ -6,7 +6,7 @@ import type {
   StudyTrackingNotification,
 } from "../../../../drizzle/schema.ts";
 import type { AuditWriteInput } from "../../../lib/audit.ts";
-import { ensureStudyTrackingCaseForToken } from "../../study-tracking/domain/index.ts";
+import { ensureStudyTrackingCaseForToken } from "../../study-tracking/index.ts";
 import {
   normalizeSearchText,
   parseOptionalDate,
@@ -212,8 +212,14 @@ async function loadDefaultAdminReportsDependencies() {
         import("../../../lib/auth-security.ts"),
         import("../../../lib/supabase.ts"),
         import("../../../lib/audit.ts"),
-        import("../../particular-access/infrastructure/index.ts"),
-        import("../../study-tracking/infrastructure/index.ts"),
+        import("../../particular-access/index.ts").then(
+          ({ loadReportsParticularAccessPersistence }) =>
+            loadReportsParticularAccessPersistence(),
+        ),
+        import("../../study-tracking/index.ts").then(
+          ({ loadParticularAccessStudyTrackingPersistence }) =>
+            loadParticularAccessStudyTrackingPersistence(),
+        ),
         import("./report-command-composition.ts"),
       ]);
 

--- a/server/features/reports/index.ts
+++ b/server/features/reports/index.ts
@@ -1,0 +1,4 @@
+export {
+  loadParticularAccessReportCommands,
+} from "./reports-public-composition.ts";
+export { serializeSafeReport } from "./domain/index.ts";

--- a/server/features/reports/reports-public-composition.ts
+++ b/server/features/reports/reports-public-composition.ts
@@ -1,0 +1,9 @@
+export async function loadParticularAccessReportCommands() {
+  const commands = await import("./composition/index.ts");
+
+  return {
+    getReportById: commands.getReportById,
+    getClinicScopedReportById:
+      commands.getClinicScopedReportById,
+  };
+}

--- a/server/features/study-tracking/index.ts
+++ b/server/features/study-tracking/index.ts
@@ -1,0 +1,8 @@
+export {
+  createTokenStudyTrackingOperations,
+  type TokenStudyTrackingOperationsDeps,
+} from "./application/index.ts";
+export { ensureStudyTrackingCaseForToken } from "./domain/index.ts";
+export {
+  loadParticularAccessStudyTrackingPersistence,
+} from "./study-tracking-route-composition.ts";

--- a/server/features/users-roles/admin-users-roles-route-composition.ts
+++ b/server/features/users-roles/admin-users-roles-route-composition.ts
@@ -3,7 +3,7 @@ import type {
   AdminClinicUserCredentialsCommandInput,
   AdminClinicUserCredentialsUpdateInput,
   AdminClinicUserCredentialsUpdateResult,
-} from "../clinics/admin-clinics-command-service.ts";
+} from "../clinics/index.ts";
 import {
   createAdminUsersRolesUseCases,
   type AdminClinicUserRoleChangeInput,
@@ -161,7 +161,7 @@ export function createAdminUsersRolesRouteComposition(
     deps: AdminUsersRolesResolvedRouteDeps,
   ): Promise<AdminClinicUserCredentialsUpdateResult> {
     const { updateAdminClinicUserCredentialsCommand } = await import(
-      "../clinics/admin-clinics-command-service.ts"
+      "../clinics/index.ts"
     );
 
     return updateAdminClinicUserCredentialsCommand(input, {

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -27,7 +27,7 @@ import {
   serializeParticularToken,
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
-} from "../lib/particular-token.ts";
+} from "../features/particular-access/index.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,

--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -35,7 +35,7 @@ import {
   parsePositiveInt,
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
-} from "../lib/report-access-token.ts";
+} from "../features/report-access/index.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -30,7 +30,7 @@ import {
   type RateLimitEntry,
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
-import { serializeParticularTokenDetail } from "../lib/particular-token.ts";
+import { serializeParticularTokenDetail } from "../features/particular-access/index.ts";
 import {
   buildRequestLogLine,
   sanitizeUrlForLogs,

--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -21,7 +21,7 @@ import {
   serializeParticularToken,
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
-} from "../lib/particular-token.ts";
+} from "../features/particular-access/index.ts";
 import {
   getClinicPermissions,
   normalizeClinicUserRole,

--- a/server/routes/public-report-access.fastify.ts
+++ b/server/routes/public-report-access.fastify.ts
@@ -23,7 +23,7 @@ import {
 import {
   reportAccessTokenRawTokenSchema,
   serializePublicReportAccess,
-} from "../lib/report-access-token.ts";
+} from "../features/report-access/index.ts";
 import {
   createSignedReportDownloadUrl as defaultCreateSignedReportDownloadUrl,
   createSignedReportUrl as defaultCreateSignedReportUrl,

--- a/server/routes/report-access-tokens.fastify.ts
+++ b/server/routes/report-access-tokens.fastify.ts
@@ -34,7 +34,7 @@ import {
   parsePositiveInt,
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
-} from "../lib/report-access-token.ts";
+} from "../features/report-access/index.ts";
 import {
   getClinicPermissions,
   normalizeClinicUserRole,

--- a/test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts
+++ b/test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts
@@ -15,11 +15,12 @@ const studyTrackingInfrastructureIndex =
   "server/features/study-tracking/infrastructure/index.ts";
 const particularComposition =
   "server/features/particular-access/particular-access-route-composition.ts";
-const reportsComposition =
-  "server/features/reports/composition/report-route-composition.ts";
-const reportAccessTokenModule = "server/lib/report-access-token.ts";
+const reportAccessTokenModule =
+  "server/features/report-access/report-access-token.ts";
 const m44Closeout =
   "docs/implementation/m44-legacy-imports-sweep-closeout.md";
+const m45Closeout =
+  "docs/implementation/m45-backend-feature-dependency-guard-closeout.md";
 const programAudit =
   "docs/audit/backend-enterprise-modularization-program-audit.md";
 const guardFile =
@@ -239,22 +240,22 @@ test("los ocho consumidores migrados apuntan al barrel Particular Access", () =>
       executableImportTargets(file).includes(particularInfrastructureIndex),
     )
     .sort();
-  const preexistingCanonicalConsumers = [
+  const canonicalInternalConsumers = [
     particularComposition,
-    reportsComposition,
+    "server/features/particular-access/particular-access-public-composition.ts",
   ].sort();
 
   assert.deepEqual(
     canonicalConsumers.filter(
-      (file) => !preexistingCanonicalConsumers.includes(file),
+      (file) => !canonicalInternalConsumers.includes(file),
     ),
     expectedMigratedConsumers,
   );
   assert.deepEqual(
     canonicalConsumers.filter((file) =>
-      preexistingCanonicalConsumers.includes(file),
+      canonicalInternalConsumers.includes(file),
     ),
-    preexistingCanonicalConsumers,
+    canonicalInternalConsumers,
   );
 
   for (const consumer of expectedMigratedConsumers) {
@@ -288,24 +289,17 @@ test("los barrels canónicos existen y no hay aliases forwarding alternativos", 
   assert.deepEqual(alternateAliases, []);
 });
 
-test("M44 tiene closeout y M45 permanece NOT_RUN", () => {
+test("M44 conserva su closeout y reconoce el cierre M45", () => {
   assert.equal(existsSync(resolve(repoRoot, m44Closeout)), true);
-  assert.equal(
-    existsSync(
-      resolve(
-        repoRoot,
-        "docs/implementation/m45-backend-feature-dependency-guard-closeout.md",
-      ),
-    ),
-    false,
-  );
+  assert.equal(existsSync(resolve(repoRoot, m45Closeout)), true);
 
-  const closeout = readSource(m44Closeout);
+  const m44CloseoutSource = readSource(m44Closeout);
+  const m45CloseoutSource = readSource(m45Closeout);
   const audit = readSource(programAudit);
-  assert.ok(closeout.includes("M44 CLOSED localmente"));
-  assert.match(closeout, /M45\s+NOT_RUN/);
+  assert.ok(m44CloseoutSource.includes("M44 CLOSED localmente"));
+  assert.ok(m45CloseoutSource.includes("M45 CLOSED localmente"));
   assert.ok(audit.includes("M44 — completado"));
-  assert.match(audit, /M45 —\s+NOT_RUN/);
+  assert.ok(audit.includes("M45 — completado"));
 });
 
 test("el guard M44 no consulta estado Git ni worktrees", () => {

--- a/test/architecture/backend-modularization-m45-feature-dependency-guard.test.ts
+++ b/test/architecture/backend-modularization-m45-feature-dependency-guard.test.ts
@@ -1,0 +1,814 @@
+import assert from "node:assert/strict";
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+} from "node:fs";
+import {
+  dirname,
+  relative,
+  resolve,
+} from "node:path";
+import test from "node:test";
+import ts from "typescript";
+
+const repoRoot = process.cwd();
+const featuresRoot = "server/features";
+const guardFile =
+  "test/architecture/backend-modularization-m45-feature-dependency-guard.test.ts";
+const m44GuardFile =
+  "test/architecture/backend-modularization-m44-legacy-imports-sweep.test.ts";
+const closeoutFile =
+  "docs/implementation/m45-backend-feature-dependency-guard-closeout.md";
+const programAuditFile =
+  "docs/audit/backend-enterprise-modularization-program-audit.md";
+
+const expectedFeatures = [
+  "clinics",
+  "logistics",
+  "particular-access",
+  "pricing",
+  "public-professionals",
+  "report-access",
+  "reports",
+  "study-tracking",
+  "users-roles",
+] as const;
+
+const expectedMatrix: Record<string, string[]> = {
+  clinics: ["public-professionals"],
+  logistics: [],
+  "particular-access": ["reports", "study-tracking"],
+  pricing: [],
+  "public-professionals": [],
+  "report-access": ["reports"],
+  reports: ["particular-access", "study-tracking"],
+  "study-tracking": [],
+  "users-roles": ["clinics"],
+};
+
+const expectedCrossFeatureReferenceKeys = [
+  "clinics->public-professionals|dynamic|runtime|server/features/clinics/clinic-public-profile-command-service.ts|server/features/public-professionals/index.ts",
+  "clinics->public-professionals|dynamic|runtime|server/features/clinics/clinic-public-profile-query-service.ts|server/features/public-professionals/index.ts",
+  "clinics->public-professionals|static|type|server/features/clinics/clinic-public-profile-command-service.ts|server/features/public-professionals/index.ts",
+  "particular-access->reports|dynamic|runtime|server/features/particular-access/particular-access-route-composition.ts|server/features/reports/index.ts",
+  "particular-access->reports|dynamic|runtime|server/features/particular-access/particular-access-route-composition.ts|server/features/reports/index.ts",
+  "particular-access->reports|static|runtime|server/features/particular-access/particular-token.ts|server/features/reports/index.ts",
+  "particular-access->study-tracking|static|runtime|server/features/particular-access/application/admin-particular-access-operations.ts|server/features/study-tracking/index.ts",
+  "particular-access->study-tracking|static|runtime|server/features/particular-access/application/clinic-particular-access-operations.ts|server/features/study-tracking/index.ts",
+  "particular-access->study-tracking|static|runtime|server/features/particular-access/particular-access-route-composition.ts|server/features/study-tracking/index.ts",
+  "particular-access->study-tracking|static|type|server/features/particular-access/application/ports/particular-access-ports.ts|server/features/study-tracking/index.ts",
+  "report-access->reports|static|runtime|server/features/report-access/report-access-token.ts|server/features/reports/index.ts",
+  "reports->particular-access|dynamic|runtime|server/features/reports/composition/report-route-composition.ts|server/features/particular-access/index.ts",
+  "reports->study-tracking|dynamic|runtime|server/features/reports/composition/report-route-composition.ts|server/features/study-tracking/index.ts",
+  "reports->study-tracking|static|runtime|server/features/reports/composition/report-route-composition.ts|server/features/study-tracking/index.ts",
+  "users-roles->clinics|dynamic|runtime|server/features/users-roles/admin-users-roles-route-composition.ts|server/features/clinics/index.ts",
+  "users-roles->clinics|static|type|server/features/users-roles/admin-users-roles-route-composition.ts|server/features/clinics/index.ts",
+].sort();
+
+type ImportKind =
+  | "static"
+  | "reexport"
+  | "import-equals"
+  | "import-type"
+  | "dynamic"
+  | "require";
+
+type ImportSite = {
+  specifier: string;
+  kind: ImportKind;
+  isTypeOnly: boolean;
+};
+
+type ResolvedReference = ImportSite & {
+  sourceFile: string;
+  targetFile: string;
+  sourceFeature: string | null;
+  targetFeature: string | null;
+};
+
+type GraphCensus = {
+  features: string[];
+  sourceFileCount: number;
+  crossFeatureReferences: ResolvedReference[];
+  crossFeatureInternalImports: string[];
+  libToFeatureImports: string[];
+  unresolvedRelativeImports: string[];
+  inwardRouteOrMiddlewareImports: string[];
+};
+
+function normalizePath(value: string): string {
+  return value.replaceAll("\\", "/");
+}
+
+function readSource(relativePath: string): string {
+  return readFileSync(resolve(repoRoot, relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+function walkTsFiles(relativeDirectory: string): string[] {
+  const absoluteDirectory = resolve(repoRoot, relativeDirectory);
+
+  if (!existsSync(absoluteDirectory)) {
+    return [];
+  }
+
+  return readdirSync(absoluteDirectory, {
+    withFileTypes: true,
+  })
+    .flatMap((entry) => {
+      const relativePath = `${relativeDirectory}/${entry.name}`;
+
+      if (entry.isDirectory()) {
+        return walkTsFiles(relativePath);
+      }
+
+      if (
+        entry.isFile() &&
+        entry.name.endsWith(".ts") &&
+        !entry.name.endsWith(".d.ts")
+      ) {
+        return [relativePath];
+      }
+
+      return [];
+    })
+    .sort();
+}
+
+function parse(relativePath: string): ts.SourceFile {
+  return ts.createSourceFile(
+    relativePath,
+    readSource(relativePath),
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+}
+
+function featureForPath(relativePath: string): string | null {
+  const match = normalizePath(relativePath).match(
+    /^server\/features\/([^/]+)\//,
+  );
+
+  return match?.[1] ?? null;
+}
+
+function importDeclarationIsTypeOnly(
+  declaration: ts.ImportDeclaration,
+): boolean {
+  const clause = declaration.importClause;
+
+  if (clause === undefined) {
+    return false;
+  }
+
+  if (clause.isTypeOnly) {
+    return true;
+  }
+
+  if (clause.name !== undefined) {
+    return false;
+  }
+
+  const bindings = clause.namedBindings;
+
+  if (
+    bindings === undefined ||
+    ts.isNamespaceImport(bindings)
+  ) {
+    return false;
+  }
+
+  return (
+    bindings.elements.length > 0 &&
+    bindings.elements.every((element) => element.isTypeOnly)
+  );
+}
+
+function exportDeclarationIsTypeOnly(
+  declaration: ts.ExportDeclaration,
+): boolean {
+  if (declaration.isTypeOnly) {
+    return true;
+  }
+
+  const exportClause = declaration.exportClause;
+
+  return (
+    exportClause !== undefined &&
+    ts.isNamedExports(exportClause) &&
+    exportClause.elements.length > 0 &&
+    exportClause.elements.every((element) => element.isTypeOnly)
+  );
+}
+
+function listImportSitesFromSourceFile(
+  sourceFile: ts.SourceFile,
+): ImportSite[] {
+  const sites: ImportSite[] = [];
+
+  function addSite(
+    specifier: string,
+    kind: ImportKind,
+    isTypeOnly: boolean,
+  ): void {
+    sites.push({
+      specifier,
+      kind,
+      isTypeOnly,
+    });
+  }
+
+  function visit(node: ts.Node): void {
+    if (
+      ts.isImportDeclaration(node) &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      addSite(
+        node.moduleSpecifier.text,
+        "static",
+        importDeclarationIsTypeOnly(node),
+      );
+    } else if (
+      ts.isExportDeclaration(node) &&
+      node.moduleSpecifier !== undefined &&
+      ts.isStringLiteralLike(node.moduleSpecifier)
+    ) {
+      addSite(
+        node.moduleSpecifier.text,
+        "reexport",
+        exportDeclarationIsTypeOnly(node),
+      );
+    } else if (
+      ts.isImportEqualsDeclaration(node) &&
+      ts.isExternalModuleReference(node.moduleReference) &&
+      node.moduleReference.expression !== undefined &&
+      ts.isStringLiteralLike(node.moduleReference.expression)
+    ) {
+      addSite(
+        node.moduleReference.expression.text,
+        "import-equals",
+        node.isTypeOnly,
+      );
+    } else if (
+      ts.isImportTypeNode(node) &&
+      ts.isLiteralTypeNode(node.argument) &&
+      ts.isStringLiteralLike(node.argument.literal)
+    ) {
+      addSite(
+        node.argument.literal.text,
+        "import-type",
+        true,
+      );
+    } else if (
+      ts.isCallExpression(node) &&
+      node.arguments.length === 1 &&
+      ts.isStringLiteralLike(node.arguments[0])
+    ) {
+      if (node.expression.kind === ts.SyntaxKind.ImportKeyword) {
+        addSite(
+          node.arguments[0].text,
+          "dynamic",
+          false,
+        );
+      } else if (
+        ts.isIdentifier(node.expression) &&
+        node.expression.text === "require"
+      ) {
+        addSite(
+          node.arguments[0].text,
+          "require",
+          false,
+        );
+      }
+    }
+
+    node.forEachChild(visit);
+  }
+
+  visit(sourceFile);
+
+  return sites;
+}
+
+function listImportSites(relativePath: string): ImportSite[] {
+  return listImportSitesFromSourceFile(parse(relativePath));
+}
+
+function resolveRelativeSpecifier(
+  sourceFile: string,
+  specifier: string,
+): string | null {
+  if (!specifier.startsWith(".")) {
+    return null;
+  }
+
+  const absoluteTarget = resolve(
+    repoRoot,
+    dirname(sourceFile),
+    specifier,
+  );
+  const repositoryRelativeTarget = normalizePath(
+    relative(repoRoot, absoluteTarget),
+  );
+
+  const candidates = new Set<string>([
+    repositoryRelativeTarget,
+    `${repositoryRelativeTarget}.ts`,
+    `${repositoryRelativeTarget}/index.ts`,
+  ]);
+
+  if (repositoryRelativeTarget.endsWith(".js")) {
+    candidates.add(
+      `${repositoryRelativeTarget.slice(0, -3)}.ts`,
+    );
+  }
+
+  if (repositoryRelativeTarget.endsWith(".mjs")) {
+    candidates.add(
+      `${repositoryRelativeTarget.slice(0, -4)}.ts`,
+    );
+  }
+
+  for (const candidate of candidates) {
+    const absoluteCandidate = resolve(repoRoot, candidate);
+
+    if (
+      existsSync(absoluteCandidate) &&
+      statSync(absoluteCandidate).isFile()
+    ) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
+function collectGraphCensus(): GraphCensus {
+  const files = walkTsFiles(featuresRoot);
+  const features = [
+    ...new Set(
+      files
+        .map(featureForPath)
+        .filter((feature): feature is string => feature !== null),
+    ),
+  ].sort();
+
+  const crossFeatureReferences: ResolvedReference[] = [];
+  const libToFeatureImports: string[] = [];
+  const unresolvedRelativeImports: string[] = [];
+  const inwardRouteOrMiddlewareImports: string[] = [];
+
+  for (const sourceFile of files) {
+    const sourceFeature = featureForPath(sourceFile);
+
+    for (const site of listImportSites(sourceFile)) {
+      if (!site.specifier.startsWith(".")) {
+        continue;
+      }
+
+      const targetFile = resolveRelativeSpecifier(
+        sourceFile,
+        site.specifier,
+      );
+
+      if (targetFile === null) {
+        unresolvedRelativeImports.push(
+          `${sourceFile} -> ${site.specifier}`,
+        );
+        continue;
+      }
+
+      const targetFeature = featureForPath(targetFile);
+      const reference: ResolvedReference = {
+        ...site,
+        sourceFile,
+        targetFile,
+        sourceFeature,
+        targetFeature,
+      };
+
+      if (
+        targetFile.startsWith("server/routes/") ||
+        targetFile.startsWith("server/middlewares/")
+      ) {
+        inwardRouteOrMiddlewareImports.push(
+          `${sourceFile} -> ${targetFile}`,
+        );
+      }
+
+      if (
+        sourceFeature !== null &&
+        targetFeature !== null &&
+        sourceFeature !== targetFeature
+      ) {
+        crossFeatureReferences.push(reference);
+      }
+    }
+  }
+
+  for (const sourceFile of walkTsFiles("server/lib")) {
+    for (const site of listImportSites(sourceFile)) {
+      const targetFile = site.specifier.startsWith(".")
+        ? resolveRelativeSpecifier(sourceFile, site.specifier)
+        : normalizePath(site.specifier).startsWith("server/features/")
+          ? normalizePath(site.specifier)
+          : null;
+
+      if (targetFile?.startsWith("server/features/")) {
+        libToFeatureImports.push(
+          [
+            sourceFile,
+            site.kind,
+            site.isTypeOnly ? "type" : "runtime",
+            site.specifier,
+            targetFile,
+          ].join("|"),
+        );
+      }
+    }
+  }
+
+  return {
+    features,
+    sourceFileCount: files.length,
+    crossFeatureReferences,
+    crossFeatureInternalImports: crossFeatureReferences
+      .filter(
+        (reference) =>
+          reference.targetFeature !== null &&
+          reference.targetFile !==
+            `server/features/${reference.targetFeature}/index.ts`,
+      )
+      .map(referenceKey)
+      .sort(),
+    libToFeatureImports: libToFeatureImports.sort(),
+    unresolvedRelativeImports:
+      unresolvedRelativeImports.sort(),
+    inwardRouteOrMiddlewareImports:
+      inwardRouteOrMiddlewareImports.sort(),
+  };
+}
+
+function referenceKey(reference: ResolvedReference): string {
+  assert.notEqual(reference.sourceFeature, null);
+  assert.notEqual(reference.targetFeature, null);
+
+  return [
+    `${reference.sourceFeature}->${reference.targetFeature}`,
+    reference.kind,
+    reference.isTypeOnly ? "type" : "runtime",
+    reference.sourceFile,
+    reference.targetFile,
+  ].join("|");
+}
+
+function createAdjacency(
+  features: readonly string[],
+  references: readonly ResolvedReference[],
+  includeTypeOnly: boolean,
+): Map<string, Set<string>> {
+  const adjacency = new Map(
+    features.map((feature) => [
+      feature,
+      new Set<string>(),
+    ]),
+  );
+
+  for (const reference of references) {
+    if (!includeTypeOnly && reference.isTypeOnly) {
+      continue;
+    }
+
+    if (
+      reference.sourceFeature === null ||
+      reference.targetFeature === null
+    ) {
+      continue;
+    }
+
+    adjacency
+      .get(reference.sourceFeature)
+      ?.add(reference.targetFeature);
+  }
+
+  return adjacency;
+}
+
+function matrixFromAdjacency(
+  features: readonly string[],
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): Record<string, string[]> {
+  return Object.fromEntries(
+    features.map((feature) => [
+      feature,
+      [...(adjacency.get(feature) ?? new Set())].sort(),
+    ]),
+  );
+}
+
+function stronglyConnectedComponents(
+  features: readonly string[],
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): string[][] {
+  let nextIndex = 0;
+
+  const stack: string[] = [];
+  const onStack = new Set<string>();
+  const indices = new Map<string, number>();
+  const lowLinks = new Map<string, number>();
+  const components: string[][] = [];
+
+  function visit(feature: string): void {
+    indices.set(feature, nextIndex);
+    lowLinks.set(feature, nextIndex);
+    nextIndex += 1;
+
+    stack.push(feature);
+    onStack.add(feature);
+
+    for (const target of adjacency.get(feature) ?? []) {
+      if (!indices.has(target)) {
+        visit(target);
+
+        lowLinks.set(
+          feature,
+          Math.min(
+            lowLinks.get(feature) as number,
+            lowLinks.get(target) as number,
+          ),
+        );
+      } else if (onStack.has(target)) {
+        lowLinks.set(
+          feature,
+          Math.min(
+            lowLinks.get(feature) as number,
+            indices.get(target) as number,
+          ),
+        );
+      }
+    }
+
+    if (lowLinks.get(feature) !== indices.get(feature)) {
+      return;
+    }
+
+    const component: string[] = [];
+
+    while (stack.length > 0) {
+      const current = stack.pop() as string;
+
+      onStack.delete(current);
+      component.push(current);
+
+      if (current === feature) {
+        break;
+      }
+    }
+
+    components.push(component.sort());
+  }
+
+  for (const feature of features) {
+    if (!indices.has(feature)) {
+      visit(feature);
+    }
+  }
+
+  return components;
+}
+
+function cyclicComponentKeys(
+  features: readonly string[],
+  adjacency: ReadonlyMap<string, ReadonlySet<string>>,
+): string[] {
+  return stronglyConnectedComponents(
+    features,
+    adjacency,
+  )
+    .filter((component) => {
+      if (component.length > 1) {
+        return true;
+      }
+
+      const feature = component[0];
+
+      return adjacency.get(feature)?.has(feature) === true;
+    })
+    .map((component) => component.join("|"))
+    .sort();
+}
+
+const census = collectGraphCensus();
+const allAdjacency = createAdjacency(
+  census.features,
+  census.crossFeatureReferences,
+  true,
+);
+const runtimeAdjacency = createAdjacency(
+  census.features,
+  census.crossFeatureReferences,
+  false,
+);
+
+test("M45 auto-descubre el inventario canónico de features", () => {
+  assert.deepEqual(census.features, expectedFeatures);
+  assert.equal(census.sourceFileCount, 149);
+});
+
+test("M45 resuelve todos los imports relativos de features", () => {
+  assert.deepEqual(census.unresolvedRelativeImports, []);
+});
+
+test("M45 congela las 16 referencias cross-feature exactas", () => {
+  assert.deepEqual(
+    census.crossFeatureReferences
+      .map(referenceKey)
+      .sort(),
+    expectedCrossFeatureReferenceKeys,
+  );
+});
+
+test("M45 impide dependencias desde server/lib hacia features", () => {
+  assert.deepEqual(census.libToFeatureImports, []);
+});
+
+test("M45 exige barrels públicos para toda referencia cross-feature", () => {
+  assert.deepEqual(census.crossFeatureInternalImports, []);
+});
+
+test("M45 congela la matriz de siete aristas dirigidas", () => {
+  assert.deepEqual(
+    matrixFromAdjacency(
+      census.features,
+      allAdjacency,
+    ),
+    expectedMatrix,
+  );
+
+  assert.deepEqual(
+    matrixFromAdjacency(
+      census.features,
+      runtimeAdjacency,
+    ),
+    expectedMatrix,
+  );
+});
+
+test("M45 permite solamente el SCC legacy Particular Access y Reports", () => {
+  const expectedLegacyCycles = [
+    "particular-access|reports",
+  ];
+
+  assert.deepEqual(
+    cyclicComponentKeys(
+      census.features,
+      allAdjacency,
+    ),
+    expectedLegacyCycles,
+  );
+
+  assert.deepEqual(
+    cyclicComponentKeys(
+      census.features,
+      runtimeAdjacency,
+    ),
+    expectedLegacyCycles,
+  );
+});
+
+test("M45 impide dependencias desde features hacia routes o middlewares", () => {
+  assert.deepEqual(
+    census.inwardRouteOrMiddlewareImports,
+    [],
+  );
+});
+
+test("M45 detecta ImportTypeNode como dependencia exclusivamente type-only", () => {
+  const fixtureSourceFile = "server/features/clinics/import-type-fixture.ts";
+  const fixture = ts.createSourceFile(
+    fixtureSourceFile,
+    'type Report = import("../reports/index.ts").Report;\n',
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.TS,
+  );
+  const sites = listImportSitesFromSourceFile(fixture);
+
+  assert.deepEqual(sites, [
+    {
+      specifier: "../reports/index.ts",
+      kind: "import-type",
+      isTypeOnly: true,
+    },
+  ]);
+
+  const targetFile = resolveRelativeSpecifier(
+    fixtureSourceFile,
+    sites[0].specifier,
+  );
+  assert.notEqual(targetFile, null);
+
+  const reference: ResolvedReference = {
+    ...sites[0],
+    sourceFile: fixtureSourceFile,
+    targetFile: targetFile as string,
+    sourceFeature: "clinics",
+    targetFeature: "reports",
+  };
+  const fixtureFeatures = ["clinics", "reports"];
+  const fullFixtureAdjacency = createAdjacency(
+    fixtureFeatures,
+    [reference],
+    true,
+  );
+  const runtimeFixtureAdjacency = createAdjacency(
+    fixtureFeatures,
+    [reference],
+    false,
+  );
+
+  assert.deepEqual(
+    matrixFromAdjacency(
+      fixtureFeatures,
+      fullFixtureAdjacency,
+    ),
+    {
+      clinics: ["reports"],
+      reports: [],
+    },
+  );
+  assert.deepEqual(
+    matrixFromAdjacency(
+      fixtureFeatures,
+      runtimeFixtureAdjacency,
+    ),
+    {
+      clinics: [],
+      reports: [],
+    },
+  );
+  assert.notDeepEqual(
+    [
+      ...census.crossFeatureReferences,
+      reference,
+    ]
+      .map(referenceKey)
+      .sort(),
+    expectedCrossFeatureReferenceKeys,
+  );
+});
+
+test("M45 materializa closeout y estados de Fase K", () => {
+  assert.equal(
+    existsSync(resolve(repoRoot, closeoutFile)),
+    true,
+    closeoutFile,
+  );
+
+  const closeout = readSource(closeoutFile);
+  const audit = readSource(programAuditFile);
+  const m44Guard = readSource(m44GuardFile);
+
+  for (const marker of [
+    "M45 CLOSED localmente",
+    "particular-access ↔ reports",
+    "C5 — NOT_RUN",
+    "M46 — NOT_RUN",
+    "M48 — NOT_RUN",
+  ]) {
+    assert.ok(closeout.includes(marker), marker);
+  }
+
+  assert.ok(audit.includes("M45 — completado"));
+  assert.ok(audit.includes("C5 — NOT_RUN"));
+  assert.ok(audit.includes("M46 — NOT_RUN"));
+  assert.ok(audit.includes("M48 — NOT_RUN"));
+
+  assert.ok(
+    m44Guard.includes(
+      'test("M44 conserva su closeout y reconoce el cierre M45"',
+    ),
+  );
+});
+
+test("el guard M45 no consulta Git, ramas ni worktrees", () => {
+  const guardImports = listImportSites(guardFile)
+    .map((site) => site.specifier);
+
+  assert.equal(
+    guardImports.includes("node:child_process"),
+    false,
+  );
+
+  const source = readSource(guardFile);
+
+  assert.doesNotMatch(
+    source,
+    /\bgit\s+(?:branch|show-ref|worktree|status|rev-parse)\b/,
+  );
+});

--- a/test/architecture/clinics-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/clinics-infrastructure-boundary-guard.test.ts
@@ -18,6 +18,7 @@ const queryServiceFile =
   featureDir + "/admin-clinics-query-service.ts";
 const commandServiceFile =
   featureDir + "/admin-clinics-command-service.ts";
+const publicBarrelFile = featureDir + "/index.ts";
 const usersRolesCompositionFile =
   "server/features/users-roles/admin-users-roles-route-composition.ts";
 const publicProfileQueryServiceFile =
@@ -27,7 +28,7 @@ const publicProfileCommandServiceFile =
 const publicProfileRouteFile =
   "server/routes/clinic-public-profile.fastify.ts";
 const publicProfessionalsBarrelFile =
-  "server/features/public-professionals/infrastructure/index.ts";
+  "server/features/public-professionals/index.ts";
 const publicProfessionalsMappingFile =
   "server/features/public-professionals/infrastructure/public-professionals-mapping.ts";
 const publicProfessionalsRepositoryFile =
@@ -533,7 +534,7 @@ test(
         .map((specifier) =>
           resolveSpecifier(usersRolesCompositionFile, specifier),
         )
-        .includes(commandServiceFile),
+        .includes(publicBarrelFile),
     );
 
     for (const unrelatedCommand of [

--- a/test/architecture/particular-access-m33-closeout.test.ts
+++ b/test/architecture/particular-access-m33-closeout.test.ts
@@ -14,6 +14,7 @@ const applicationIndex = `${applicationDir}/index.ts`;
 const infrastructureIndex = `${infrastructureDir}/index.ts`;
 const repositoryFile = `${infrastructureDir}/particular-access-repository.ts`;
 const compositionFile = `${featureDir}/particular-access-route-composition.ts`;
+const publicCompositionFile = `${featureDir}/particular-access-public-composition.ts`;
 const legacyParticularPath = "server/db-particular.ts";
 const legacyStudyTrackingPath = "server/db-study-tracking.ts";
 const closeout =
@@ -33,10 +34,13 @@ const expectedFeatureFiles = [
   `${domainDir}/README.md`,
   `${domainDir}/index.ts`,
   `${domainDir}/particular-access.ts`,
+  `${featureDir}/index.ts`,
+  `${featureDir}/particular-token.ts`,
   `${infrastructureDir}/README.md`,
   infrastructureIndex,
   repositoryFile,
   compositionFile,
+  publicCompositionFile,
 ].sort();
 
 const expectedExternalParticularConsumers = [
@@ -230,7 +234,7 @@ test("composition es el único seam de rutas propias a infrastructure", () => {
   assert.ok(compositionTargets.includes(infrastructureIndex));
   assert.ok(
     compositionTargets.includes(
-      "server/features/study-tracking/study-tracking-route-composition.ts",
+      "server/features/study-tracking/index.ts",
     ),
   );
   assert.equal(readSource(compositionFile).includes("drizzle-orm"), false);
@@ -351,18 +355,18 @@ test("M44 retira paths legacy y realinea los ocho consumidores externos", () => 
   );
 
   const compositionTargets = importTargets(reportsComposition);
-  assert.ok(compositionTargets.includes(infrastructureIndex));
   assert.ok(
-    compositionTargets.includes(
-      "server/features/study-tracking/infrastructure/index.ts",
-    ),
+    compositionTargets.includes("server/features/particular-access/index.ts"),
+  );
+  assert.ok(
+    compositionTargets.includes("server/features/study-tracking/index.ts"),
   );
 });
 
 test("Auth preserva contrato y Reports usa composition M41", () => {
   assert.equal(
     digest("server/routes/particular-auth.fastify.ts"),
-    "e94e5a2847f635f30a8edd81fa5270fd1501f727fc1b91e434677c3d101a0c86",
+    "33ffa0c6da11304dbeb8c000b9ec0b55d03781b90fd2980a76365bdfaeed049f",
   );
   assert.equal(
     digest("server/middlewares/particular-auth.ts"),

--- a/test/architecture/reports-compatibility-shim-retirement.test.ts
+++ b/test/architecture/reports-compatibility-shim-retirement.test.ts
@@ -187,8 +187,11 @@ test("consumidores runtime migrados resuelven Reports por composition", () => {
     const targets = imports(path).map((reference) =>
       target(path, reference.specifier)
     );
+    const expectedTarget = path.startsWith("server/features/")
+      ? `${feature}/index.ts`
+      : `${composition}/index.ts`;
 
-    assert.ok(targets.includes(`${composition}/index.ts`), path);
+    assert.ok(targets.includes(expectedTarget), path);
     assert.doesNotMatch(
       source,
       /\bdb\.(?:getReportById|getClinicScopedReportById)\b/,

--- a/test/architecture/reports-domain-boundary-guard.test.ts
+++ b/test/architecture/reports-domain-boundary-guard.test.ts
@@ -30,8 +30,6 @@ const runtimeConsumers = [
   "server/routes/reports-status.fastify.ts",
   "server/features/reports/application/report-query-use-cases.ts",
   "server/features/reports/infrastructure/report-query-repository.ts",
-  "server/lib/particular-token.ts",
-  "server/lib/report-access-token.ts",
 ] as const;
 
 type ImportReference = {
@@ -124,7 +122,15 @@ test("Reports conserva domain M36 y admite inventario M37 autorizado", () => {
 
   assert.deepEqual(
     readdirSync(join(repoRoot, featureDir)).sort(),
-    ["README.md", "application", "composition", "domain", "infrastructure"],
+    [
+      "README.md",
+      "application",
+      "composition",
+      "domain",
+      "index.ts",
+      "infrastructure",
+      "reports-public-composition.ts",
+    ],
   );
   assert.deepEqual(
     readdirSync(join(repoRoot, domainDir)).sort(),

--- a/test/architecture/reports-suite-completeness.test.ts
+++ b/test/architecture/reports-suite-completeness.test.ts
@@ -217,7 +217,7 @@ const REPORTS_SUITE: readonly ReportsSuiteEntry[] = [
     ],
     runtimeAnchors: [
       {
-        path: "server/lib/report-access-token.ts",
+        path: "server/features/report-access/report-access-token.ts",
         markers: [
           "reportAccessTokenRawTokenSchema",
           "clinicCreateReportAccessTokenSchema",

--- a/test/architecture/security/security-boundary-suite-completeness.test.ts
+++ b/test/architecture/security/security-boundary-suite-completeness.test.ts
@@ -481,7 +481,7 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
         markers: ["parseReportId(body.clinicId)", "uploadReport"],
       },
       {
-        path: "server/lib/report-access-token.ts",
+        path: "server/features/report-access/report-access-token.ts",
         markers: ["reportAccessTokenRawTokenSchema", "parseEntityId"],
       },
     ],

--- a/test/architecture/security/security-validation-cutoff-boundaries.test.ts
+++ b/test/architecture/security/security-validation-cutoff-boundaries.test.ts
@@ -516,8 +516,8 @@ test("audit list and export filters return 400 before listing or exporting data"
 });
 test("numeric id helpers reject invalid identifiers instead of defaulting sensitive ids", () => {
   for (const file of [
-    "server/lib/report-access-token.ts",
-    "server/lib/particular-token.ts",
+    "server/features/report-access/report-access-token.ts",
+    "server/features/particular-access/particular-token.ts",
     "server/features/study-tracking/domain/study-tracking.ts",
   ] as const) {
     const source = readSource(file);

--- a/test/architecture/study-tracking-domain-boundary-guard.test.ts
+++ b/test/architecture/study-tracking-domain-boundary-guard.test.ts
@@ -144,9 +144,12 @@ test("los cuatro consumidores runtime usan únicamente el barrel canónico", () 
     const targets = listImportReferences(readText(file)).map(({ specifier }) =>
       resolveSpecifier(file, specifier)
     );
+    const expectedTarget = file.startsWith("server/features/")
+      ? `${featureDir}/index.ts`
+      : domainIndexFile;
 
-    if (!targets.includes(domainIndexFile)) {
-      violations.push(`${file}: no importa ${domainIndexFile}`);
+    if (!targets.includes(expectedTarget)) {
+      violations.push(`${file}: no importa ${expectedTarget}`);
     }
 
     for (const legacyShimFile of legacyShimFiles) {

--- a/test/architecture/study-tracking-infrastructure-boundary-guard.test.ts
+++ b/test/architecture/study-tracking-infrastructure-boundary-guard.test.ts
@@ -9,6 +9,7 @@ const featureDir = "server/features/study-tracking";
 const infrastructureDir = `${featureDir}/infrastructure`;
 const repositoryFile = `${infrastructureDir}/study-tracking-repository.ts`;
 const infrastructureIndexFile = `${infrastructureDir}/index.ts`;
+const publicIndexFile = `${featureDir}/index.ts`;
 const legacyShimFile = "server/db-study-tracking.ts";
 const routeCompositionFile =
   "server/features/study-tracking/study-tracking-route-composition.ts";
@@ -267,7 +268,7 @@ test("Reports composition M39 consume infrastructure canónica sin shim", () => 
 
   assert.equal(targets.includes(legacyShimFile), false);
   assert.equal(targets.includes(repositoryFile), false);
-  assert.ok(targets.includes(infrastructureIndexFile));
+  assert.ok(targets.includes(publicIndexFile));
 });
 
 test("los contratos source-only leen el repository canónico", () => {

--- a/test/architecture/study-tracking-phase-closeout.test.ts
+++ b/test/architecture/study-tracking-phase-closeout.test.ts
@@ -48,6 +48,7 @@ const expectedFeatureFiles = [
   `${featureDir}/domain/index.ts`,
   `${featureDir}/domain/study-tracking.ts`,
   `${featureDir}/domain/token-study-tracking.ts`,
+  `${featureDir}/index.ts`,
   `${featureDir}/infrastructure/README.md`,
   `${featureDir}/infrastructure/index.ts`,
   `${featureDir}/infrastructure/study-tracking-repository.ts`,

--- a/test/architecture/users-roles-application-boundary-guard.test.ts
+++ b/test/architecture/users-roles-application-boundary-guard.test.ts
@@ -135,7 +135,7 @@ test("credenciales siguen en Clinics y M43 queda compuesto", () => {
   assert.doesNotMatch(route, /updateAdminClinicUserCredentialsCommand\(/);
   assert.match(
     composition,
-    /\.\.\/clinics\/admin-clinics-command-service\.ts/,
+    /\.\.\/clinics\/index\.ts/,
   );
   assert.match(composition, /updateAdminClinicUserCredentialsCommand/);
   assert.doesNotMatch(

--- a/test/unit/contracts/admin/admin-particular-token-schema.test.ts
+++ b/test/unit/contracts/admin/admin-particular-token-schema.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   adminCreateParticularTokenSchema,
-} from "../../../../server/lib/particular-token.ts";
+} from "../../../../server/features/particular-access/index.ts";
 
 test("adminCreateParticularTokenSchema requiere clinicId válido y normaliza campos base", () => {
   const parsed = adminCreateParticularTokenSchema.safeParse({

--- a/test/unit/contracts/admin/admin-report-access-token-schema.test.ts
+++ b/test/unit/contracts/admin/admin-report-access-token-schema.test.ts
@@ -2,7 +2,7 @@ import test from "node:test";
 import assert from "node:assert/strict";
 import {
   adminCreateReportAccessTokenSchema,
-} from "../../../../server/lib/report-access-token.ts";
+} from "../../../../server/features/report-access/index.ts";
 
 test("adminCreateReportAccessTokenSchema requiere clinicId y reportId válidos", () => {
   const parsed = adminCreateReportAccessTokenSchema.safeParse({

--- a/test/unit/contracts/particular/particular-token-edge.test.ts
+++ b/test/unit/contracts/particular/particular-token-edge.test.ts
@@ -6,7 +6,7 @@ import {
   serializeParticularToken,
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
-} from "../../../../server/lib/particular-token.ts";
+} from "../../../../server/features/particular-access/index.ts";
 
 test("clinicCreateParticularTokenSchema acepta reportId positivo y detailsLesion al limite", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({

--- a/test/unit/domain/particular-token.test.ts
+++ b/test/unit/domain/particular-token.test.ts
@@ -9,7 +9,7 @@ import {
   serializeParticularToken,
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
-} from "../../../server/lib/particular-token.ts";
+} from "../../../server/features/particular-access/index.ts";
 
 test("clinicCreateParticularTokenSchema normaliza detailsLesion vacío y reportId null", () => {
   const parsed = clinicCreateParticularTokenSchema.safeParse({

--- a/test/unit/domain/report-access-token-edge.test.ts
+++ b/test/unit/domain/report-access-token-edge.test.ts
@@ -8,7 +8,7 @@ import {
   isReportAccessTokenExpired,
   isReportAccessTokenRevoked,
   reportAccessTokenRawTokenSchema,
-} from "../../../server/lib/report-access-token.ts";
+} from "../../../server/features/report-access/index.ts";
 
 test("reportAccessTokenRawTokenSchema rechaza longitudes distintas de 64", () => {
   const tooShort = reportAccessTokenRawTokenSchema.safeParse("a".repeat(63));

--- a/test/unit/domain/report-access-token-helpers.test.ts
+++ b/test/unit/domain/report-access-token-helpers.test.ts
@@ -6,7 +6,7 @@ import {
   parseEntityId,
   parseOffset,
   parsePositiveInt,
-} from "../../../server/lib/report-access-token.ts";
+} from "../../../server/features/report-access/index.ts";
 
 test("parsePositiveInt respeta fallback y límite máximo", () => {
   assert.equal(parsePositiveInt("25", 50, 100), 25);

--- a/test/unit/domain/report-access-token-serializers.test.ts
+++ b/test/unit/domain/report-access-token-serializers.test.ts
@@ -4,7 +4,7 @@ import {
   serializePublicReportAccess,
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
-} from "../../../server/lib/report-access-token.ts";
+} from "../../../server/features/report-access/index.ts";
 
 test("serializeReportAccessToken expone estado y banderas derivadas", () => {
   const token = {

--- a/test/unit/domain/report-access-token.test.ts
+++ b/test/unit/domain/report-access-token.test.ts
@@ -8,7 +8,7 @@ import {
   isReportAccessTokenExpired,
   isReportAccessTokenRevoked,
   reportAccessTokenRawTokenSchema,
-} from "../../../server/lib/report-access-token.ts";
+} from "../../../server/features/report-access/index.ts";
 
 test("reportAccessTokenRawTokenSchema acepta tokens hex de 64 caracteres", () => {
   const token = "a".repeat(64);

--- a/test/unit/infrastructure/global-e2e-production-readiness-contract.test.ts
+++ b/test/unit/infrastructure/global-e2e-production-readiness-contract.test.ts
@@ -126,7 +126,7 @@ const GLOBAL_SURFACES: readonly GlobalSurface[] = [
       "Private report storage paths, access tokens and signed URLs stay lazy, scoped and absent from public JSON.",
     runtimeFiles: [
       {
-        path: "server/lib/report-access-token.ts",
+        path: "server/features/report-access/report-access-token.ts",
         markers: ["serializePublicReportAccess", "serializeReportAccessToken"],
       },
       {


### PR DESCRIPTION
## Summary

- corrige las tres observaciones P2 del guard global M45;
- incorpora el scan de `server/lib` y elimina las cuatro dependencias detectadas hacia features;
- mueve Particular Token y Report Access Token a sus features propietarias sin shims ni cambios funcionales;
- exige barrels públicos raíz para toda dependencia cross-feature;
- soporta `ImportTypeNode` como dependencia type-only;
- congela el censo corregido de 9 features, 149 archivos TypeScript, 16 referencias y 7 aristas;
- preserva como único SCC full/runtime `particular-access ↔ reports`.

## Scope

- [x] Backend runtime

Los tests y la documentación modificados son controles de soporte de la
realineación arquitectónica del backend, no scopes primarios independientes.

## Validation

- `pnpm typecheck`: PASSED;
- `pnpm typecheck:test`: PASSED;
- cohorte M44 + M45: 18 tests, 18 pass, 0 fail;
- cohorte funcional Particular/Report Access: 106 tests, 106 pass, 0 fail;
- contratos arquitectónicos afectados: 56 tests, 56 pass, 0 fail;
- guardrails históricos causales: 33/33 y 28/28;
- `pnpm validate:local`: 3921 tests, 3920 pass, 1 skip, 0 fail; build PASSED;
- `pnpm security:public-surface`: PASSED;
- `git diff --check`: PASSED.

## Rollback

Revertir conjuntamente los moves, barrels/loaders, imports, guardrails, tests
y documentación devuelve M45 al estado anterior. No requiere migraciones,
compensaciones, cambios de datos ni rollback de infraestructura.