### PR TITLE
test(architecture): normalize M35b import targets

### DIFF
--- a/test/architecture/token-access-m35b-closeout.test.ts
+++ b/test/architecture/token-access-m35b-closeout.test.ts
@@ -153,9 +153,37 @@ function parse(path: string): ts.SourceFile {
 }
 
 function resolveImportTarget(path: string, specifier: string): string {
-  return specifier.startsWith(".")
-    ? relative(root, resolve(root, dirname(path), specifier)).replaceAll("\\", "/")
-    : specifier;
+  if (!specifier.startsWith(".")) {
+    return specifier;
+  }
+  const target = relative(
+    root,
+    resolve(root, dirname(path), specifier),
+  ).replaceAll("\\", "/");
+  if (target.endsWith(".ts")) {
+    return target;
+  }
+
+  let emittedTypeScriptTarget: string | null = null;
+  if (target.endsWith(".mjs")) {
+    emittedTypeScriptTarget = `${target.slice(0, -4)}.ts`;
+  } else if (target.endsWith(".js")) {
+    emittedTypeScriptTarget = `${target.slice(0, -3)}.ts`;
+  }
+
+  if (
+    emittedTypeScriptTarget !== null &&
+    existsSync(resolve(root, emittedTypeScriptTarget))
+  ) {
+    return emittedTypeScriptTarget;
+  }
+
+  if (existsSync(resolve(root, `${target}.ts`))) {
+    return `${target}.ts`;
+  }
+  return existsSync(resolve(root, `${target}/index.ts`))
+    ? `${target}/index.ts`
+    : target;
 }
 
 function executableImportTargets(path: string): string[] {
@@ -297,6 +325,45 @@ test("M35b ancla la matriz ejecutable conjunta por tests y escenarios concretos"
 });
 
 test("M35b prohíbe repositories legacy e imports ejecutables directos desde rutas", () => {
+  assert.equal(
+    resolveImportTarget("server/preflight.ts", "./db.ts"),
+    "server/db.ts",
+  );
+  assert.equal(
+    resolveImportTarget("server/preflight.ts", "./db"),
+    "server/db.ts",
+  );
+  assert.equal(
+    resolveImportTarget("server/preflight.ts", "./db.js"),
+    "server/db.ts",
+  );
+  assert.equal(
+    resolveImportTarget("server/preflight.ts", "./db.mjs"),
+    "server/db.ts",
+  );
+  assert.equal(
+    resolveImportTarget(
+      "server/preflight.ts",
+      "./db-report-access.js",
+    ),
+    "server/db-report-access.js",
+  );
+  assert.equal(
+    resolveImportTarget(
+      "server/routes/admin-particular-tokens.fastify.ts",
+      "../features/particular-access/infrastructure",
+    ),
+    particularInfrastructureIndex,
+  );
+  assert.equal(
+    resolveImportTarget("server/preflight.ts", "./db-report-access"),
+    "server/db-report-access",
+  );
+  assert.equal(
+    resolveImportTarget("server/preflight.ts", "typescript"),
+    "typescript",
+  );
+
   assert.equal(existsSync(resolve(root, "server/db-report-access.ts")), false);
 
   for (const path of walk("server").filter((file) => file.endsWith(".ts"))) {


### PR DESCRIPTION
## Summary

- corrige la resolución de imports relativos del guard M35b;
- normaliza separadores Windows;
- preserva destinos `.ts` explícitos;
- resuelve imports sin extensión a `${target}.ts`;
- resuelve imports de directorio a `${target}/index.ts`;
- conserva paquetes externos y targets no resolubles sin cambios;
- mantiene intacta la semántica de imports type-only;
- agrega regresiones dentro del test existente, sin aumentar el conteo global;
- no modifica runtime, docs, Auth, DB, schema, dependencias ni configuración.

## Scope

- [x] Tests

Archivo modificado:

- `test/architecture/token-access-m35b-closeout.test.ts`

## Root cause

El resolver anterior convertía:

`import("../db-particular")`

en:

`server/db-particular`

mientras las comprobaciones prohibidas comparaban contra:

`server/db-particular.ts`

Esto permitía que un import extensionless válido evadiera la comprobación específica del guard.

## Fix

La resolución relativa ahora:

1. normaliza `\` a `/`;
2. preserva `.ts` explícito;
3. prueba `${target}.ts`;
4. prueba `${target}/index.ts`;
5. conserva el target normalizado como fallback;
6. deja paquetes no relativos sin cambios.

El patrón replica conceptualmente la estrategia ya usada por el guard M33, manteniendo M35b autocontenido.

## Regression coverage

Los asserts añadidos verifican:

- `.ts` explícito;
- archivo existente sin extensión;
- directorio con `index.ts`;
- fallback no resoluble;
- paquete externo.

No se añadió ningún `test(...)` de nivel superior.

## Validation

- M35b aislado: 6 pass, 0 fail;
- grupo M33/M35b/M44/M45/M46/M48: 75 pass, 0 fail;
- arquitectura completa: 583 total, 582 pass, 1 skip, 0 fail;
- `pnpm typecheck:test`: PASSED;
- `pnpm validate:local`: 3.963 total, 3.962 pass, 1 skip, 0 fail;
- build: PASSED, `dist/index.js` 922,4 kb;
- `git diff --check`: PASSED;
- runtime diff: cero;
- docs diff: cero;
- `security:public-surface`: NOT_RUN, sin superficie pública modificada;
- schema: NOT_RUN.

## Historical review

Este PR corrige causalmente el thread P2 pendiente del PR #1574:

`Normalize imports before checking banned shims`

El thread se responderá y resolverá únicamente después del merge.

## Rollback

Revertir este PR restaura solamente la implementación anterior del guard M35b.

No requiere rollback de runtime, Auth, DB, schema, datos, dependencias, CI ni infraestructura.