### PR TITLE
test(canary): verify architecture declaration rejection

### DIFF
--- a/server/index.ts
+++ b/server/index.ts
@@ -4,7 +4,7 @@ import { createFastifyApp } from "./fastify-app.ts";
 import { ENV } from "./lib/env.ts";
 import { preflight } from "./preflight.ts";
 
-async function closeResources() {
+async function closeResources(): Promise<void> {
   await closeDbConnection();
 }
 


### PR DESCRIPTION
## Summary
- Change type: disposable negative architecture-governance canary
- Context / issue: validate rejection when an architectural path trigger lacks its required declaration
- What changed: added an explicit return type to one existing root backend function while deliberately omitting the Architecture Decision section

## Scope
- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception

## Validation
- [x] `git diff --check`
- [x] exact changed-file allowlist reviewed
- [x] targeted M48 certification test passed
- [x] expected failing PR Governance result will be recorded

## Rollback
- Trigger: expected Architecture Decision failure or any unexpected result
- Steps: close the pull request without merge and delete its exact local and remote branch
- Data impact: none
