### PR TITLE
test(canary): verify docs-only CI contexts

### DIFF
--- a/docs/audit/pr-ci-04-docs-only-canary.md
+++ b/docs/audit/pr-ci-04-docs-only-canary.md
@@ -1,0 +1,14 @@
+# PR-CI-04 Docs-Only Canary
+
+Disposable evidence for the always-present Backend CI and Frontend CI pull-request contexts.
+
+Expected behavior:
+
+- backend detector: success;
+- backend heavy validation: skipped;
+- validate-backend: success;
+- frontend detector: success;
+- frontend heavy validation: skipped;
+- validate-frontend: success.
+
+This pull request must be closed without merge.


### PR DESCRIPTION
## Summary
- Change type: disposable docs-only CI canary
- Context / issue: verify that Backend CI and Frontend CI expose stable successful contexts without running heavy validation for documentation-only changes
- What changed: added one disposable documentation evidence file

## Scope
- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [x] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

## Validation
- [x] `git diff --check`
- [x] exact docs-only scope reviewed
- [ ] Relevant CI checks passed

Expected CI behavior:
- Backend detector succeeds.
- Backend heavy validation is skipped.
- `validate-backend` succeeds.
- Frontend detector succeeds.
- Frontend heavy validation is skipped.
- `validate-frontend` succeeds.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Rollback
- Trigger: completion of the disposable docs-only canary or any unexpected CI result
- Steps: close this pull request without merge and delete its exact local and remote branch
- Data impact: none
