### PR TITLE
fix(ci): compute PR impact from merge base

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -64,8 +64,23 @@ jobs:
           git cat-file -e "${BASE_SHA}^{commit}"
           git cat-file -e "${HEAD_SHA}^{commit}"
 
+          if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "Unable to determine pull request merge base." >&2
+            exit 1
+          fi
+
+          if [[ ! "$MERGE_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid pull request merge base." >&2
+            exit 1
+          fi
+
+          if ! git cat-file -e "${MERGE_BASE}^{commit}"; then
+            echo "Pull request merge base commit is unavailable." >&2
+            exit 1
+          fi
+
           changed_file_list="${RUNNER_TEMP}/backend-changed-files"
-          git diff --name-only -z --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA" > "$changed_file_list"
+          git diff --name-only -z --diff-filter=ACDMRTUXB "$MERGE_BASE" "$HEAD_SHA" > "$changed_file_list"
 
           should_run=false
           while IFS= read -r -d '' changed_path; do

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -63,8 +63,23 @@ jobs:
           git cat-file -e "${BASE_SHA}^{commit}"
           git cat-file -e "${HEAD_SHA}^{commit}"
 
+          if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then
+            echo "Unable to determine pull request merge base." >&2
+            exit 1
+          fi
+
+          if [[ ! "$MERGE_BASE" =~ ^[0-9a-f]{40}$ ]]; then
+            echo "Invalid pull request merge base." >&2
+            exit 1
+          fi
+
+          if ! git cat-file -e "${MERGE_BASE}^{commit}"; then
+            echo "Pull request merge base commit is unavailable." >&2
+            exit 1
+          fi
+
           changed_file_list="${RUNNER_TEMP}/frontend-changed-files"
-          git diff --name-only -z --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA" > "$changed_file_list"
+          git diff --name-only -z --diff-filter=ACDMRTUXB "$MERGE_BASE" "$HEAD_SHA" > "$changed_file_list"
 
           should_run=false
           while IFS= read -r -d '' changed_path; do

--- a/docs/architecture/ci-always-run-gates-rfc.md
+++ b/docs/architecture/ci-always-run-gates-rfc.md
@@ -30,6 +30,10 @@ Each workflow uses three stages:
 
 For push events already supported by the workflows, heavy validation remains mandatory.
 
+For pull requests, each detector computes changed files from the common merge base of the base
+and head commits through the candidate head. Changes that exist only on a base branch that
+advanced after the pull-request branch diverged are not classified as pull-request impact.
+
 The final job fails closed when detection fails, when required heavy validation fails or is cancelled, or when an unexpected job state is observed.
 
 ## Preserved invariants
@@ -38,6 +42,8 @@ The final job fails closed when detection fails, when required heavy validation 
 - PostgreSQL remains isolated to backend heavy validation.
 - Playwright installation and execution remain isolated to frontend heavy validation.
 - Existing permissions, timeouts, concurrency and SHA-pinned Actions remain enforced.
+- Legitimate heavy-validation skips are preserved for outdated pull-request branches whose only
+  candidate changes are unrelated to that heavy.
 - No application runtime, authentication, database, schema, dependency or production configuration is changed.
 - No failure is hidden with `continue-on-error`.
 

--- a/test/unit/infrastructure/backend-ci-workflow.test.ts
+++ b/test/unit/infrastructure/backend-ci-workflow.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
 const workflowPath = resolve(
   process.cwd(),
@@ -12,6 +20,89 @@ const workflowPath = resolve(
 
 function readWorkflow(): string {
   return readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n");
+}
+
+function runGit(repository: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], {
+    cwd: repository,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function initializeFixtureRepository(repository: string): void {
+  runGit(repository, ["init", "-b", "main"]);
+
+  const disabledHooksPath = resolve(repository, ".git", "disabled-hooks");
+  mkdirSync(disabledHooksPath, { recursive: true });
+
+  runGit(repository, ["config", "--local", "commit.gpgSign", "false"]);
+  runGit(repository, [
+    "config",
+    "--local",
+    "core.hooksPath",
+    ".git/disabled-hooks",
+  ]);
+  runGit(repository, ["config", "--local", "user.name", "VETNEB CI Test"]);
+  runGit(repository, [
+    "config",
+    "--local",
+    "user.email",
+    "ci-test@invalid.local",
+  ]);
+
+  assert.equal(
+    runGit(repository, ["config", "--local", "--get", "commit.gpgSign"]),
+    "false",
+  );
+  assert.equal(
+    runGit(repository, ["config", "--local", "--get", "core.hooksPath"]),
+    ".git/disabled-hooks",
+  );
+}
+
+function commitFile(
+  repository: string,
+  relativePath: string,
+  content: string,
+  message: string,
+): string {
+  const absolutePath = resolve(repository, relativePath);
+
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content, "utf8");
+  runGit(repository, ["add", "--", relativePath]);
+  runGit(repository, ["commit", "-m", message]);
+
+  return runGit(repository, ["rev-parse", "HEAD"]);
+}
+
+function changedFiles(
+  repository: string,
+  fromCommit: string,
+  toCommit: string,
+): string[] {
+  return execFileSync(
+    "git",
+    [
+      "diff",
+      "--name-only",
+      "-z",
+      "--diff-filter=ACDMRTUXB",
+      fromCommit,
+      toCommit,
+    ],
+    { cwd: repository, encoding: "utf8" },
+  )
+    .split("\0")
+    .filter(Boolean);
+}
+
+function shouldRunBackend(changedPaths: readonly string[]): boolean {
+  return changedPaths.some(
+    (changedPath) =>
+      !changedPath.startsWith("docs/") && !changedPath.endsWith(".md"),
+  );
 }
 
 function assertContains(source: string, expected: string): void {
@@ -125,9 +216,83 @@ test("Backend CI detecta impacto con rango PR seguro, push pesado y fallo cerrad
   assertContains(detector, 'git cat-file -e "${HEAD_SHA}^{commit}"');
   assertContains(
     detector,
-    'git diff --name-only -z --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA" > "$changed_file_list"',
+    'if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then',
+  );
+  assertContains(
+    detector,
+    'if [[ ! "$MERGE_BASE" =~ ^[0-9a-f]{40}$ ]]; then',
+  );
+  assertContains(detector, 'git cat-file -e "${MERGE_BASE}^{commit}"');
+  assertContains(
+    detector,
+    'git diff --name-only -z --diff-filter=ACDMRTUXB "$MERGE_BASE" "$HEAD_SHA" > "$changed_file_list"',
+  );
+  assertNotContains(
+    detector,
+    'git diff --name-only -z --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA"',
   );
   assertNotContains(detector, "continue-on-error");
+});
+
+test("Backend CI excluye cambios exclusivos de una base que avanzó", () => {
+  const repository = mkdtempSync(join(tmpdir(), "vetneb-backend-ci-"));
+
+  try {
+    initializeFixtureRepository(repository);
+
+    const commonCommit = commitFile(
+      repository,
+      "README.md",
+      "common\n",
+      "common commit",
+    );
+
+    runGit(repository, ["switch", "-c", "docs-only"]);
+    runGit(repository, ["switch", "main"]);
+    const baseSha = commitFile(
+      repository,
+      "server/base-only.ts",
+      "export const baseOnly = true;\n",
+      "advance main",
+    );
+
+    runGit(repository, ["switch", "docs-only"]);
+    const docsHeadSha = commitFile(
+      repository,
+      "docs/pull-request.md",
+      "# Pull request\n",
+      "docs-only change",
+    );
+
+    const directRangeFiles = changedFiles(repository, baseSha, docsHeadSha);
+    assert.ok(directRangeFiles.includes("server/base-only.ts"));
+
+    const mergeBase = runGit(repository, [
+      "merge-base",
+      baseSha,
+      docsHeadSha,
+    ]);
+    assert.equal(mergeBase, commonCommit);
+
+    const pullRequestFiles = changedFiles(
+      repository,
+      mergeBase,
+      docsHeadSha,
+    );
+    assert.deepEqual(pullRequestFiles, ["docs/pull-request.md"]);
+    assert.equal(shouldRunBackend(pullRequestFiles), false);
+
+    const backendHeadSha = commitFile(
+      repository,
+      "server/pull-request.ts",
+      "export const pullRequestChange = true;\n",
+      "backend change",
+    );
+    const backendFiles = changedFiles(repository, mergeBase, backendHeadSha);
+    assert.equal(shouldRunBackend(backendFiles), true);
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+  }
 });
 
 test("Backend CI omite docs y Markdown pero solicita heavy para cualquier otro archivo", () => {

--- a/test/unit/infrastructure/frontend-ci-workflow.test.ts
+++ b/test/unit/infrastructure/frontend-ci-workflow.test.ts
@@ -1,7 +1,15 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
-import { resolve } from "node:path";
+import { execFileSync } from "node:child_process";
+import {
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
 
 const workflowPath = resolve(
   process.cwd(),
@@ -18,8 +26,99 @@ const frontendPathFilters = [
   "      - '.github/workflows/frontend-ci.yml'",
 ] as const;
 
+const frontendImpactPaths = new Set([
+  "pnpm-lock.yaml",
+  "pnpm-workspace.yaml",
+  "package.json",
+  ".github/workflows/frontend-ci.yml",
+]);
+
 function readWorkflow(): string {
   return readFileSync(workflowPath, "utf8").replace(/\r\n/g, "\n");
+}
+
+function runGit(repository: string, args: readonly string[]): string {
+  return execFileSync("git", [...args], {
+    cwd: repository,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  }).trim();
+}
+
+function initializeFixtureRepository(repository: string): void {
+  runGit(repository, ["init", "-b", "main"]);
+
+  const disabledHooksPath = resolve(repository, ".git", "disabled-hooks");
+  mkdirSync(disabledHooksPath, { recursive: true });
+
+  runGit(repository, ["config", "--local", "commit.gpgSign", "false"]);
+  runGit(repository, [
+    "config",
+    "--local",
+    "core.hooksPath",
+    ".git/disabled-hooks",
+  ]);
+  runGit(repository, ["config", "--local", "user.name", "VETNEB CI Test"]);
+  runGit(repository, [
+    "config",
+    "--local",
+    "user.email",
+    "ci-test@invalid.local",
+  ]);
+
+  assert.equal(
+    runGit(repository, ["config", "--local", "--get", "commit.gpgSign"]),
+    "false",
+  );
+  assert.equal(
+    runGit(repository, ["config", "--local", "--get", "core.hooksPath"]),
+    ".git/disabled-hooks",
+  );
+}
+
+function commitFile(
+  repository: string,
+  relativePath: string,
+  content: string,
+  message: string,
+): string {
+  const absolutePath = resolve(repository, relativePath);
+
+  mkdirSync(dirname(absolutePath), { recursive: true });
+  writeFileSync(absolutePath, content, "utf8");
+  runGit(repository, ["add", "--", relativePath]);
+  runGit(repository, ["commit", "-m", message]);
+
+  return runGit(repository, ["rev-parse", "HEAD"]);
+}
+
+function changedFiles(
+  repository: string,
+  fromCommit: string,
+  toCommit: string,
+): string[] {
+  return execFileSync(
+    "git",
+    [
+      "diff",
+      "--name-only",
+      "-z",
+      "--diff-filter=ACDMRTUXB",
+      fromCommit,
+      toCommit,
+    ],
+    { cwd: repository, encoding: "utf8" },
+  )
+    .split("\0")
+    .filter(Boolean);
+}
+
+function shouldRunFrontend(changedPaths: readonly string[]): boolean {
+  return changedPaths.some(
+    (changedPath) =>
+      changedPath.startsWith("frontend/") ||
+      frontendImpactPaths.has(changedPath),
+  );
 }
 
 function assertContains(source: string, expected: string): void {
@@ -136,9 +235,87 @@ test("Frontend CI detecta impacto con rango PR seguro, push pesado y fallo cerra
   assertContains(detector, 'git cat-file -e "${HEAD_SHA}^{commit}"');
   assertContains(
     detector,
-    'git diff --name-only -z --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA" > "$changed_file_list"',
+    'if ! MERGE_BASE="$(git merge-base "$BASE_SHA" "$HEAD_SHA")"; then',
+  );
+  assertContains(
+    detector,
+    'if [[ ! "$MERGE_BASE" =~ ^[0-9a-f]{40}$ ]]; then',
+  );
+  assertContains(detector, 'git cat-file -e "${MERGE_BASE}^{commit}"');
+  assertContains(
+    detector,
+    'git diff --name-only -z --diff-filter=ACDMRTUXB "$MERGE_BASE" "$HEAD_SHA" > "$changed_file_list"',
+  );
+  assertNotContains(
+    detector,
+    'git diff --name-only -z --diff-filter=ACDMRTUXB "$BASE_SHA" "$HEAD_SHA"',
   );
   assertNotContains(detector, "continue-on-error");
+});
+
+test("Frontend CI excluye cambios exclusivos de una base que avanzó", () => {
+  const repository = mkdtempSync(join(tmpdir(), "vetneb-frontend-ci-"));
+
+  try {
+    initializeFixtureRepository(repository);
+
+    const commonCommit = commitFile(
+      repository,
+      "README.md",
+      "common\n",
+      "common commit",
+    );
+
+    runGit(repository, ["switch", "-c", "docs-only"]);
+    runGit(repository, ["switch", "main"]);
+    const baseSha = commitFile(
+      repository,
+      "frontend/base-only.ts",
+      "export const baseOnly = true;\n",
+      "advance main",
+    );
+
+    runGit(repository, ["switch", "docs-only"]);
+    const docsHeadSha = commitFile(
+      repository,
+      "docs/pull-request.md",
+      "# Pull request\n",
+      "docs-only change",
+    );
+
+    const directRangeFiles = changedFiles(repository, baseSha, docsHeadSha);
+    assert.ok(directRangeFiles.includes("frontend/base-only.ts"));
+
+    const mergeBase = runGit(repository, [
+      "merge-base",
+      baseSha,
+      docsHeadSha,
+    ]);
+    assert.equal(mergeBase, commonCommit);
+
+    const pullRequestFiles = changedFiles(
+      repository,
+      mergeBase,
+      docsHeadSha,
+    );
+    assert.deepEqual(pullRequestFiles, ["docs/pull-request.md"]);
+    assert.equal(shouldRunFrontend(pullRequestFiles), false);
+
+    const frontendHeadSha = commitFile(
+      repository,
+      "frontend/pull-request.ts",
+      "export const pullRequestChange = true;\n",
+      "frontend change",
+    );
+    const frontendFiles = changedFiles(
+      repository,
+      mergeBase,
+      frontendHeadSha,
+    );
+    assert.equal(shouldRunFrontend(frontendFiles), true);
+  } finally {
+    rmSync(repository, { recursive: true, force: true });
+  }
 });
 
 test("Frontend CI usa exactamente las cinco rutas vigentes para solicitar heavy", () => {

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -79,8 +79,8 @@ const mutableActionReferences = [
 
 const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
-  [".github/workflows/backend-ci.yml", "cfb2eeb59d24cf12bdca161b3f1bfeea420416bd6d2f7e8c0f885f5e8042f4e6"],
-  [".github/workflows/frontend-ci.yml", "f84f9744494ca5c0ca6d58dfea4fe132aa6149134a60cedb2e604378ec2ff5cf"],
+  [".github/workflows/backend-ci.yml", "e696873b397ae05da365e436c9e150bef7a98517cdce545a9a9549252b1037b3"],
+  [".github/workflows/frontend-ci.yml", "77a0134fad5d81c78e47ff0d1e30c7e3d6d1e32b597580f08cc4a7541d878586"],
   [".github/workflows/pr-governance.yml", "4e0bf177a8581c9dd655f1ca6aa1510a823cdd976c885c4ba50b41129e4157d7"],
   [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],
   [".github/workflows/visual-regression-manual.yml", "86784fe26f1f15e2ae6fb60ee8c26ef050f311bcebab72a2e1732739e035fee9"],


### PR DESCRIPTION
## Summary
- Change type: corrective CI workflow repair.
- Context / issue: direct base/head comparison can include changes that exist only on an advanced base branch.
- What changed: both PR impact detectors now use the validated common merge base through the candidate head.

## Scope
Scope: workflows/ci
- [x] workflows/ci

## Architecture Decision
- [x] ADR/RFC linked
- [ ] Not applicable

- Reference: [CI Always-Run Gates RFC](docs/architecture/ci-always-run-gates-rfc.md)
- Justification: Pull-request impact must be computed from the common merge base to the candidate head so paths introduced only by a newer base branch cannot trigger unrelated heavy validation. This repair preserves stable final contexts, fail-closed routing, and the conditional-heavy architecture accepted for block 04.

## Validation
- [x] `git diff --check`
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] Directed CI/governance contract cohort: 113 passed
- [x] Workflow security validator
- [x] `pnpm test`: 4011 passed, 1 skipped, 0 failed
- [x] `pnpm build`
- [x] Frontend lint, typecheck and build
- [ ] Relevant GitHub CI checks pending after PR creation

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed: not applicable.
- [x] Dependency and supply-chain impact reviewed: no dependency changes.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented: not applicable.
- [x] Actions remain SHA-pinned and permissions remain `contents: read`.
- [x] No `continue-on-error` introduced.

## Rollback
- Trigger: incorrect PR impact routing or unexpected heavy-validation selection.
- Steps: Revertir únicamente este PR técnico. No revertir ni modificar branch protection.
- Data impact: ninguno.
