### PR TITLE
docs(governance): harden agent operations contract for R2/R3 domains

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -166,8 +166,9 @@ PASSED        = ejecutado, exit code 0
 FAILED        = ejecutado, falló
 NOT_RUN       = no seleccionado para este cambio
 NOT_AVAILABLE = el script no existe (reportar, no inventar equivalentes)
-BLOCKED       = el script existe pero el entorno requerido no está disponible
-                (DB, navegadores Playwright, staging, secretos)
+BLOCKED       = no puede ejecutarse por falta de autorización, entorno, secreto, DB,
+                navegador, staging, permiso externo o precondición; aplica a scripts
+                existentes y a acciones no-script R2/R3
 ```
 
 No simular éxito. Nunca marcar PASSED sin exit code 0 observado.
@@ -282,8 +283,8 @@ Nombres `data-*` en `frontend/src` no pueden contener stems sensibles (token/ses
 
 Evidencia sanitizada — regla transversal (detalle operativo en §§14–17). Ningún artefacto
 producido por el trabajo (captura, log, acta, fixture, export, adjunto de PR, respuesta) puede
-contener: secretos o valores de variables de entorno, cookies o session IDs, tokens crudos o sus
-hashes, signed URLs completas, paths privados de storage, connection strings, dumps o backups,
+contener: secretos o valores de variables de entorno, cookies o session IDs, tokens crudos, hashes de passwords, hashes de credenciales, hashes de sesiones o
+hashes derivados de secretos, signed URLs completas, paths privados de storage, connection strings, dumps o backups,
 datos clínicos, nombres reales de pacientes o tutores, emails reales sin sanitizar, ni payloads o
 headers completos de request/response. Los fixtures y datos de prueba usan valores sintéticos, no
 copias de datos reales. Un artefacto que incumple esto se descarta: no se recorta, no se difumina
@@ -532,3 +533,4 @@ protocolo es **política futura**: fija las condiciones de cualquier migración,
 
 Criterio de salida: ninguna estructura física se movió sin auditoría aprobada y autorización; toda
 propuesta declara boundaries, ownership, tests afectados, rollback y compatibilidad CI/Render.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -533,4 +533,3 @@ protocolo es **política futura**: fija las condiciones de cualquier migración,
 
 Criterio de salida: ninguna estructura física se movió sin auditoría aprobada y autorización; toda
 propuesta declara boundaries, ownership, tests afectados, rollback y compatibilidad CI/Render.
-

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,13 @@ INSTRUCCIONES_DE_PLATAFORMA_O_SISTEMA
 → INFERENCIAS
 ```
 
+Resolución de contradicciones: ante conflicto entre este archivo, un `AGENTS.md` anidado, código
+o configuración ejecutable y documentación, prevalece el nivel más alto de la lista y, dentro del
+mismo nivel, la regla **más restrictiva**. La contradicción se reporta a Nico en la respuesta
+final; no se resuelve silenciosamente, no se elige la lectura más permisiva y no se edita la
+fuente en conflicto fuera del scope autorizado. Para el estado efectivo de GitHub (branch
+protection, required checks, settings) manda la configuración real, no su descripción documental.
+
 ## 1. Identidad y entorno
 
 - Usuario: Nico. Senior Web Developer. Autoriza scope, escrituras git/gh y operaciones sensibles.
@@ -68,7 +75,14 @@ R3 = operación destructiva/productiva → BLOQUEADO sin autorización específi
   riesgo → esperar aprobación. (Protocolo único; no se repite en otras secciones.)
 - R3: migraciones ejecutadas contra DB real, deploys, workflows que tocan variables productivas
   (p. ej. force update de versión), borrado de datos, reinicios de servicios, cualquier acción
-  sobre producción o staging remoto.
+  sobre producción o staging remoto. Incluye además: ejecución de policies/roles RLS contra
+  cualquier DB real (§14), restore drill y rollback drill sobre entorno remoto o datos reales
+  (§15), recolección de evidencia en staging o producción controlada (§17) y mutación de settings
+  de GitHub (branch protection, required checks, environments, secret scanning, política de
+  Actions, Dependabot).
+- Bloqueo efectivo: una acción R2/R3 sin autorización no se ejecuta, no se simula, no se sustituye
+  por un equivalente más débil y no se pospone en silencio. Se reporta como BLOCKED con el
+  comando o archivo exacto y queda listada como [MANUAL-NICO] en la respuesta final.
 - Autorización: es por tarea y por mensaje; no se generaliza de una tarea a la siguiente.
 - Preservación: nunca revertir, stashear ni sobrescribir cambios preexistentes de Nico en el
   árbol de trabajo; registrarlos, preservarlos y trabajar alrededor.
@@ -81,6 +95,23 @@ las R2/R3 sin autorización quedan bloqueadas y reportadas.
 Limitar el trabajo al scope indicado del PR o tarea. No mezclar: Dependabot, refactors globales,
 backend/DB/migraciones/dependencias no solicitados, cambios visuales fuera del módulo, cambios
 estructurales de login/auth, cambios de CI/workflows, limpiezas masivas. Salir del scope = R2.
+
+PR mínimo: un scope primario, una causa, un rollback. Si el trabajo requiere dos scopes primarios
+(p. ej. backend + frontend, o ci + dependencias), el default es **split obligatorio** en PRs
+independientes y secuenciados; la excepción mixed-scope existe pero exige enumerar cada scope
+afectado y justificar por qué los dominios no pueden entregarse por separado, cuál es la frontera
+de acoplamiento y cuál la de rollback. Conveniencia, prisa o "ya que estoy" no son justificación.
+
+No-alcance explícito: toda entrega declara qué quedó deliberadamente fuera. Un hallazgo real
+detectado fuera del scope se **reporta**, no se corrige de contrabando; si es crítico, se detiene
+y se pide autorización. Los ajustes que un cambio in-scope rompe legítimamente (guards, censos,
+contratos de arquitectura que anclan paths o literales) se realinean **en el mismo PR** y nunca
+se debilitan, se silencian ni se marcan como skip.
+
+Reglas de scope por tipo de trabajo (aplican también a §§14–18): docs-only, scripts-only,
+ci-only, test-only, backend-only, frontend-only, config-only y ops-only se entregan separados. Un
+PR documental no ejecuta operaciones reales, y una operación real no reescribe política en el
+mismo cambio salvo autorización explícita de Nico.
 
 ## 5. Git y GitHub CLI
 
@@ -99,6 +130,22 @@ estructurales de login/auth, cambios de CI/workflows, limpiezas masivas. Salir d
 `git add|commit|push|reset|clean|checkout -- .|restore|merge|rebase|stash|tag`,
 `gh pr create|merge`, `gh run`, cualquier `gh` de escritura. El agente puede ejecutar `gh` de
 solo lectura (p. ej. `gh pr checks` sin `--watch`) únicamente si Nico lo pide en la tarea actual.
+
+Prohibiciones adicionales, sin excepción por urgencia ni por "es reversible":
+
+```text
+git push --force | --force-with-lease      git branch -D | -d           git tag -d
+git rebase (incl. -i, --onto, --continue)  git merge (incl. --abort)    git cherry-pick
+git stash (incl. pop/apply/drop/clear)     git reset (soft|mixed|hard)  git clean -fd
+git worktree add|remove|prune              git filter-branch            git reflog expire
+gh api con -X POST|PATCH|PUT|DELETE        gh workflow run|enable|disable
+gh secret|variable|release|repo edit       gh api .../protection | .../environments (escritura)
+```
+
+`git rebase` y `git merge` no se ejecutan ni siquiera para "actualizar la rama": si el PR está
+detrás de `main`, se reporta y Nico decide. Nunca revertir, stashear ni sobrescribir cambios
+preexistentes de Nico (§3). `--admin` para eludir checks requeridos está prohibido siempre,
+también para Nico, según `docs/ops/CI_PR_CHECKS_RUNBOOK.md`.
 
 ### [MANUAL-NICO] — comandos que Nico ejecuta manualmente; el agente NO los ejecuta
 
@@ -154,10 +201,31 @@ Matriz por dominio (todos los comandos existen en el repo):
 CI real que el trabajo debe sobrevivir: `backend-ci` = `audit --prod → audit → db:migrate →
 typecheck → typecheck:test → test → build` (los audits corren siempre en CI; localmente solo son
 obligatorios cuando el cambio toca dependencias/lockfiles o cuando se declara cobertura
-equivalente completa); `frontend-ci` = `lint → typecheck → build → security:public-surface → e2e:smoke
-+ e2e:admin-mobile + e2e:visual-contract + e2e:public-clinic` (Chromium). `pr-governance` valida
-metadatos del PR. La validación local debe cubrir, como mínimo, los gates de CI afectados por el
-cambio (`db:migrate` local suele quedar BLOCKED sin DB: reportarlo así).
+equivalente completa); `frontend-ci` = `lint → typecheck → build → security:public-surface →
+e2e:ci` (cohorte `ci`, Chromium). `pr-governance` valida metadatos y scope del PR;
+`qga-governance` valida la política de seguridad de workflows. La validación local debe cubrir,
+como mínimo, los gates de CI afectados por el cambio (`db:migrate` local suele quedar BLOCKED sin
+DB: reportarlo así).
+
+Contextos required de `main` — los cuatro bloquean el merge:
+
+```text
+validate-pr-governance     validate-backend
+qga-workflow-security      validate-frontend
+```
+
+En backend y frontend el contexto final está siempre presente y el job pesado es condicional por
+impacto (rango merge-base → head): un heavy `skipped` solo es legítimo con detector
+`impact=false` y contexto final en `SUCCESS`. `E2E Completeness` (`e2e:full`, catálogo completo)
+**no** es required y no sustituye a `validate-frontend`. Mapa operativo y estados bloqueantes:
+`docs/ops/CI_PR_CHECKS_RUNBOOK.md`; la fuente ejecutable es la configuración efectiva de GitHub.
+
+Selección de gates por impacto: elegir por los paths realmente cambiados, no por costumbre ni por
+el nombre del PR. Un gate no seleccionado se reporta NOT_RUN con el motivo; un gate imposible de
+ejecutar por falta de entorno (DB, navegadores, staging, secretos, autorización) se reporta
+BLOCKED. Prohibido: declarar cobertura equivalente a CI sin haberla ejecutado, sustituir un gate
+por otro más barato y llamarlo equivalente, o inferir PASSED de una corrida anterior, de otra
+rama o de otro entorno.
 
 Criterio de salida: cada gate seleccionado reporta exactamente un estado canónico; ningún gate
 general se ejecuta con el gate específico previo en FAILED sin diagnóstico.
@@ -212,6 +280,15 @@ Hashes — prohibición acotada:
 Nombres `data-*` en `frontend/src` no pueden contener stems sensibles (token/session/cookie…):
 `security:public-surface` lo bloquea.
 
+Evidencia sanitizada — regla transversal (detalle operativo en §§14–17). Ningún artefacto
+producido por el trabajo (captura, log, acta, fixture, export, adjunto de PR, respuesta) puede
+contener: secretos o valores de variables de entorno, cookies o session IDs, tokens crudos o sus
+hashes, signed URLs completas, paths privados de storage, connection strings, dumps o backups,
+datos clínicos, nombres reales de pacientes o tutores, emails reales sin sanitizar, ni payloads o
+headers completos de request/response. Los fixtures y datos de prueba usan valores sintéticos, no
+copias de datos reales. Un artefacto que incumple esto se descarta: no se recorta, no se difumina
+y no se adjunta "con cuidado".
+
 Invariantes productivas a preservar siempre: `admin_session_id` (Admin), `app_session_id`
 (Clínica), auth, roles, permisos, CSRF, rate limits, CSP, `no-store` en superficies privadas,
 no filtración de errores de DB, no stack traces al cliente, no mocks silenciosos en producción,
@@ -258,6 +335,7 @@ Cambio trivial y de bajo riesgo          → solo informe final en la respuesta
 Auditoría                                 → solo respuesta, salvo que Nico pida documento
 Cambio arquitectónico                     → documento en docs/implementation (si hay escritura autorizada)
 Seguridad / schema / workflow / migración → documentación detallada obligatoria
+RLS / DB / restore / rollback / staging   → acta obligatoria con evidencia sanitizada (§§14–17)
 ```
 
 Seguir el patrón existente del repositorio. `IMPLEMENTATION_NOTES/` se consolidó en
@@ -286,5 +364,171 @@ git status --short → git diff --stat → git diff --check → git diff --name-
 
 La respuesta final debe indicar: (1) qué se hizo, (2) archivos modificados, (3) validaciones
 con estado canónico cada una, (4) exclusiones respetadas, (5) estado final, (6) comandos
-[MANUAL-NICO] pendientes, sin ejecutarlos. Una tarea está terminada solo cuando los gates
-seleccionados por §6 están PASSED o justificadamente BLOCKED/NOT_RUN, y el diff es mínimo.
+[MANUAL-NICO] pendientes, sin ejecutarlos, (7) las acciones R2/R3 que quedaron BLOCKED por falta
+de autorización y (8) los riesgos residuales conocidos. Una tarea está terminada solo cuando los
+gates seleccionados por §6 están PASSED o justificadamente BLOCKED/NOT_RUN, y el diff es mínimo.
+
+Las secciones §§14–18 son protocolos operativos que se **suman** a §§1–13 para dominios de alto
+riesgo (RLS/DB, backup/restore/rollback, observabilidad, evidencia staging, arquitectura
+monorepo). No relajan ninguna regla anterior y no reemplazan esta secuencia de cierre, que sigue
+siendo el último paso de toda implementación.
+
+## 14. RLS / DB Change Safety Protocol
+
+Aplica a RLS, schema, migraciones, roles de base de datos, policies, ownership y modelo de
+conexión. Fuentes rectoras: `docs/architecture/rls-tenant-isolation-adr.md` (Accepted,
+Alternativa D), `docs/security/rls-enforcement-matrix.md` y `ERM-CTRL-018` del
+`docs/governance/enterprise-control-register.md`.
+
+```text
+Diseño, ADR, matriz, schema o migración escrita   → R2 como mínimo
+Ejecución contra DB real, staging o productiva    → R3
+```
+
+- El aislamiento tenant **aplicativo** es obligatorio antes, durante y después de RLS. RLS es una
+  segunda barrera; nunca reemplaza el scoping aplicativo, y ninguna implementación de RLS
+  autoriza a retirarlo.
+- El piloto RLS permanece **BLOQUEADO** hasta cerrar todos los entry criteria: backup y restore
+  validados, rollback validado, observabilidad mínima, evidencia cross-tenant, matriz RLS
+  aprobada, entorno no productivo controlado, datos Clinic A/B, responsables de seguridad y DB
+  asignados, y autorización explícita de Nico. Un entry criterion no verificado es BLOCKED.
+- Verificación previa obligatoria antes de diseñar policies: rol efectivo de la conexión,
+  `rolsuper`, `rolbypassrls`, ownership de las tablas, tipo y modo del pooler, soporte
+  transaccional, y policies creadas fuera del repositorio. Sin esa verificación no se diseña ni
+  se propone SQL de policies.
+- Verificaciones mínimas del piloto: tenant A no **lee** ni **muta** filas de tenant B; la
+  ausencia de contexto no concede acceso; el contexto inválido no concede acceso; admin
+  autorizado conserva sus operaciones; particular y token público quedan limitados al recurso
+  vinculado; los jobs usan rol explícito; no hay contaminación de contexto entre conexiones;
+  deny-by-default y least privilege verificados por rol.
+- El contexto tenant se deriva **exclusivamente** de la identidad autenticada, se aplica por
+  transacción sobre la misma conexión y no sobrevive entre requests. Prohibido confiar en un
+  identificador de tenant enviado por el cliente y prohibido `SET` persistente sobre conexiones
+  reutilizadas.
+- PROHIBIDO ejecutar una migración sin rollback documentado; el rollback se prueba antes que la
+  migración llegue a un entorno con datos reales.
+- PROHIBIDO mezclar RLS con observabilidad, dependencias, frontend, required checks de CI o
+  refactors funcionales. Cada uno es un PR separado (§4).
+- Evidencia sanitizada obligatoria (§9): sin connection strings, credenciales, dumps, datos
+  clínicos ni identificadores reales.
+- Salida obligatoria: cada verificación reporta PASSED / FAILED / BLOCKED / NOT_RUN (§6).
+  Prohibido declarar RLS "activo", "verificado" o "cerrado" sin evidencia runtime observada.
+
+Criterio de salida: la clasificación R2/R3 está declarada por acción, cada entry criterion tiene
+estado canónico y ninguna sentencia se ejecutó contra una DB real sin autorización específica y
+actual de Nico.
+
+## 15. Backup, Restore and Rollback Drill Protocol
+
+Fuente rectora: `docs/ops/BACKUP_RESTORE_ROLLBACK.md`, que además registra el estado vigente
+(sin backups automáticos de plataforma; dump de DB y export de Storage ejecutados y verificados
+fuera del repositorio; **restore drill pendiente de ejecución**).
+
+```text
+Política, acta, checklist o RPO/RTO documentados     → R1 docs-only
+Preparación local de un drill, sin entorno remoto    → R2
+Drill que toca entorno remoto o datos reales         → R3
+```
+
+- **RPO y RTO se declaran numéricamente y por clase de dato** (DB, Storage, audit log) antes de
+  ejecutar cualquier drill. Un adjetivo no es un objetivo y no habilita la ejecución.
+- Ejecutar solo en el entorno autorizado, identificado por nombre y confirmado como no
+  productivo, salvo autorización R3 específica y actual para otro entorno.
+- PROHIBIDO usar datos clínicos reales, dumps completos, connection strings o credenciales en la
+  evidencia. Los dumps y backups viven fuera del repositorio y nunca se versionan.
+- Acta mínima: entorno, commit/deploy, timestamp UTC, operador responsable, alcance, pasos
+  ejecutados, duración medida, resultado, validaciones post-restore/post-rollback y riesgos
+  residuales.
+- Validaciones mínimas post-restore: verificación de schema, smoke público, smoke privado
+  autorizado, integridad mínima de los datos de prueba, y duración medida contra el RTO objetivo.
+- Validaciones mínimas post-rollback: health del backend, rutas públicas, superficie privada
+  correctamente bloqueada sin cookie válida, y smoke crítico del release afectado.
+- PROHIBIDO declarar el sistema "recuperable", "con DR" o "rollback probado" sin un drill
+  observado y registrado. Backup no probado no es backup; runbook escrito no es drill ejecutado.
+- No mezclar la ejecución real de un drill con el cambio documental de la política en el mismo
+  PR, salvo autorización explícita de Nico.
+
+Criterio de salida: RPO/RTO declarados, acta completa con evidencia sanitizada y cada validación
+con estado canónico. Sin drill observado, el estado es BLOCKED o NOT_RUN, nunca PASSED.
+
+## 16. Observability and Logging Safety Protocol
+
+Aplica a todo cambio que introduzca o modifique logging, métricas, health endpoints o correlación
+de requests. Referencias: `docs/ops/METRICS_BASELINE.md` (baseline documental, sin colectores ni
+alertas) y `ERM-CTRL-021`.
+
+- **Structured logging obligatorio** para toda observabilidad runtime nueva o modificada: nivel
+  explícito, timestamp y campos discretos parseables; no cadenas concatenadas irrecuperables.
+- **Correlation/request id obligatorio** en rutas privadas y en todo error relevante, de forma que
+  request, error y auditoría puedan unirse sin exponer identidad ni datos clínicos.
+- **Redacción obligatoria**: tokens, cookies, passwords, hashes de credenciales, signed URLs,
+  headers sensibles (`authorization`, `cookie`, `set-cookie`), errores de DB crudos, stack traces
+  hacia el cliente, datos clínicos y payloads sensibles. La redacción vive en el logger, no
+  depende de que cada llamador se acuerde.
+- **Health endpoints**: no exponen secretos, stack traces, configuración interna, tokens, DSN,
+  connection strings ni datos clínicos. Reportan estado y poco más.
+- **Métricas agregadas**, nunca personales ni clínicas. Prohibido usar como dimensión un
+  identificador de paciente, tutor, email real, token o session id.
+- Un log que contiene datos sensibles **no es evidencia**: se descarta, no se adjunta recortado.
+- PROHIBIDO que un cambio de observabilidad altere el contrato HTTP (status, headers, body,
+  caché) sin un test que lo cubra. Preservar `no-store` en superficies privadas y la ausencia de
+  caché en respuestas con cookie.
+- Validación mínima: tests de redacción, guard de caché privada / `no-store`, smoke de health, y
+  revisión del diff buscando campos que se loguean sin redactar.
+
+Criterio de salida: la observabilidad agregada es estructurada, correlacionada y redactada; el
+contrato HTTP previo se mantiene o su cambio está cubierto por test, con estados canónicos.
+
+## 17. Staging Evidence and Sanitization Protocol
+
+Aplica a toda evidencia obtenida fuera del árbol local: staging, producción controlada, smoke
+cross-tenant, capturas y logs. Fuente rectora del caso cross-tenant:
+`docs/ops/CROSS_TENANT_SMOKE_EVIDENCE_RUNBOOK.md` (CT-01..CT-16).
+
+- Toda evidencia declara el **commit/deploy exacto** bajo prueba. Evidencia sin referencia de
+  commit/deploy no es evidencia y no cierra ningún control ni gap.
+- PROHIBIDO capturar o pegar secretos, cookies, tokens, hashes, signed URLs completas, paths
+  privados de storage, datos clínicos reales, emails reales sin sanitizar o información comercial
+  sensible (§9).
+- Usar tenants y usuarios de prueba. Nunca datos de una clínica real para demostrar un contrato.
+- Acta mínima: entorno, URL o superficie, rol/actor, timestamp UTC, commit/deploy, pasos,
+  resultado, artefactos sanitizados y riesgos residuales.
+- Si staging no está disponible, no está autorizado o no tiene datos de prueba: reportar
+  **BLOCKED**. PROHIBIDO simular PASSED, inferirlo de otro entorno, deducirlo de tests locales o
+  presentar un runbook como si fuera una ejecución.
+- La evidencia cross-tenant separa explícitamente `Clinic A` y `Clinic B` con datos controlados y
+  registra tanto el acceso propio permitido como el ajeno bloqueado, con status HTTP y ausencia
+  de disclosure.
+- Evidencia visual: capturas sin datos reales. Los artefactos generados fuera del scope se
+  limpian antes de cerrar (§13); las capturas de evidencia no se guardan en `test-results/`
+  (Playwright borra ese directorio al inicio de cada corrida) ni quedan en el diff.
+
+Criterio de salida: cada ítem de evidencia tiene entorno, commit/deploy, resultado canónico y
+artefactos sanitizados; lo no ejecutado queda BLOCKED o NOT_RUN, con el motivo explícito.
+
+## 18. Enterprise Monorepo Boundary Protocol
+
+Estado actual verificable: monorepo PNPM workspace con el backend en la raíz
+(`portal-vetneb-backend`) y el frontend como único package del workspace
+(`pnpm-workspace.yaml` → `packages: ["frontend"]`). No existen `apps/` ni `packages/`. Este
+protocolo es **política futura**: fija las condiciones de cualquier migración, no la autoriza.
+
+- Cualquier migración a `apps/backend`, `apps/frontend` o `packages/*` es R2 como mínimo, y R3
+  cuando toca lockfile, workflows, build/deploy de Render o resolución productiva.
+- PROHIBIDO mover estructura física sin una auditoría específica de arquitectura monorepo,
+  aprobada y con plan por fases. Ningún "primer paso pequeño" está exento.
+- Toda propuesta declara, antes de mover un archivo: imports permitidos y prohibidos entre
+  packages, ownership por package en `.github/CODEOWNERS`, selección de tests afectados por
+  package, paths de `tsconfig`, grafo de build, tipos compartidos, configuración compartida y
+  test-utils compartidos.
+- PROHIBIDO mezclar migración monorepo con RLS, observabilidad, release, dependencias o refactors
+  funcionales (§4).
+- Todo package nuevo declara owner, scripts mínimos (`typecheck` y `build`/`test` según aplique),
+  validaciones asociadas y no-alcance explícito.
+- Todo plan de migración incluye rollback lógico y compatibilidad verificada con Render, el
+  workspace PNPM y los cuatro required checks de §6.
+- Los guards de `test/architecture/` anclan paths y censos reales: una migración que los rompa
+  debe realinearlos en el mismo PR, nunca debilitarlos, saltearlos ni marcarlos como skip.
+
+Criterio de salida: ninguna estructura física se movió sin auditoría aprobada y autorización; toda
+propuesta declara boundaries, ownership, tests afectados, rollback y compatibilidad CI/Render.


### PR DESCRIPTION
## Summary
- Change type: docs/governance-only.
- Context / issue: harden `AGENTS.md` before entering R2/R3 domains: RLS, DB, backup/restore, rollback, observability, staging evidence, release readiness and monorepo boundaries.
- What changed: reinforced the agent operating contract with additive protocols for RLS/DB safety, backup/restore/rollback drills, observability/logging safety, staging evidence sanitization and enterprise monorepo boundaries.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [x] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

## Mixed-Scope Justification
Not applicable. This PR has exactly one primary scope: docs/governance-only.

## Other Scope Detail
Not applicable.

## Architecture Decision
- [ ] ADR/RFC linked
- [x] Not applicable

- Reference: Not applicable.
- Justification: This PR modifies only `AGENTS.md`. It does not alter architectural boundaries, runtime behavior, data model, workflows, CI implementation, backend, frontend, database schema, migrations or production configuration.

## Validation
- [ ] `pnpm typecheck`
- [ ] `pnpm typecheck:test`
- [ ] `pnpm test`
- [ ] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected)
- [ ] `pnpm --dir frontend typecheck` (if frontend affected)
- [ ] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [x] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Manual/local validation reported before PR:
- `git diff --check`: PASSED
- `git diff --name-only`: PASSED
- `git diff --stat`: PASSED
- Scope docs-only confirmed: PASSED
- Markdown review manual: PASSED
- `pnpm validate:local`: NOT_RUN, docs-only/governance-only
- Frontend gates: NOT_RUN, no frontend impact
- E2E cohorts: NOT_RUN, no visual/runtime impact
- `pnpm audit` / `pnpm audit --prod`: NOT_RUN, no dependency or lockfile impact

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Rollback
- Trigger: PR governance regression, unclear agent instructions, or downstream confusion caused by the new protocols.
- Steps: revert this docs-only PR.
- Data impact: none. No runtime, DB, migration, dependency, workflow or production configuration changes.
