### PR TITLE
feat(observability): add structured logging and metrics

### DIFF
--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -195,12 +195,12 @@ newline final no se cuenta.
 | Área | Archivos TypeScript | LOC |
 | --- | ---: | ---: |
 | `server/features` | 149 | 16.980 |
-| `server/routes` | 35 | 22.943 |
-| `server/lib` | 28 | 4.521 |
+| `server/routes` | 35 | 22.934 |
+| `server/lib` | 28 | 4.599 |
 | `server/middlewares` | 7 | 947 |
-| raíz/entrypoints `server/*.ts` | 9 | 2.367 |
+| raíz/entrypoints `server/*.ts` | 9 | 2.397 |
 | otros | 0 | 0 |
-| **Total `server`** | **228** | **47.758** |
+| **Total `server`** | **228** | **47.857** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por

--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -195,12 +195,12 @@ newline final no se cuenta.
 | Área | Archivos TypeScript | LOC |
 | --- | ---: | ---: |
 | `server/features` | 149 | 16.980 |
-| `server/routes` | 35 | 23.033 |
-| `server/lib` | 27 | 3.863 |
-| `server/middlewares` | 7 | 861 |
-| raíz/entrypoints `server/*.ts` | 9 | 2.278 |
+| `server/routes` | 35 | 22.943 |
+| `server/lib` | 28 | 4.521 |
+| `server/middlewares` | 7 | 947 |
+| raíz/entrypoints `server/*.ts` | 9 | 2.367 |
 | otros | 0 | 0 |
-| **Total `server`** | **227** | **47.015** |
+| **Total `server`** | **228** | **47.758** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por

--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -198,9 +198,9 @@ newline final no se cuenta.
 | `server/routes` | 35 | 22.934 |
 | `server/lib` | 28 | 4.612 |
 | `server/middlewares` | 7 | 947 |
-| raíz/entrypoints `server/*.ts` | 9 | 2.390 |
+| raíz/entrypoints `server/*.ts` | 9 | 2.371 |
 | otros | 0 | 0 |
-| **Total `server`** | **228** | **47.863** |
+| **Total `server`** | **228** | **47.844** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por

--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -196,11 +196,11 @@ newline final no se cuenta.
 | --- | ---: | ---: |
 | `server/features` | 149 | 16.980 |
 | `server/routes` | 35 | 22.934 |
-| `server/lib` | 28 | 4.612 |
+| `server/lib` | 28 | 4.628 |
 | `server/middlewares` | 7 | 947 |
 | raíz/entrypoints `server/*.ts` | 9 | 2.371 |
 | otros | 0 | 0 |
-| **Total `server`** | **228** | **47.844** |
+| **Total `server`** | **228** | **47.860** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por

--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -196,11 +196,11 @@ newline final no se cuenta.
 | --- | ---: | ---: |
 | `server/features` | 149 | 16.980 |
 | `server/routes` | 35 | 22.934 |
-| `server/lib` | 28 | 4.599 |
+| `server/lib` | 28 | 4.612 |
 | `server/middlewares` | 7 | 947 |
-| raíz/entrypoints `server/*.ts` | 9 | 2.397 |
+| raíz/entrypoints `server/*.ts` | 9 | 2.390 |
 | otros | 0 | 0 |
-| **Total `server`** | **228** | **47.857** |
+| **Total `server`** | **228** | **47.863** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -159,8 +159,10 @@ import {
 } from "./lib/http/api-request-id.ts";
 import { logError } from "./lib/logger.ts";
 import {
+  createObservabilityRequestFinalizer,
   getObservabilityMetricsRegistry,
   type ObservabilityMetricsRegistry,
+  type ObservabilityRequestFinalizer,
 } from "./lib/observability-metrics.ts";
 import { createRuntimeTimer, type RuntimeTimer } from "./lib/runtime-timing.ts";
 
@@ -340,11 +342,20 @@ function addApiErrorRequestIdToJsonPayload(
   });
 }
 
-const REQUEST_TIMER_KEY = "__observabilityRequestTimer";
+const REQUEST_OBSERVABILITY_KEY = "__observabilityRequestState";
+
+type ObservabilityRequestState = {
+  timer: RuntimeTimer;
+  finalizer: ObservabilityRequestFinalizer;
+};
 
 type ObservabilityFastifyRequest = FastifyRequest & {
-  [REQUEST_TIMER_KEY]?: RuntimeTimer;
+  [REQUEST_OBSERVABILITY_KEY]?: ObservabilityRequestState;
 };
+
+function getObservabilityRequestState(request: FastifyRequest) {
+  return (request as ObservabilityFastifyRequest)[REQUEST_OBSERVABILITY_KEY];
+}
 
 function getFastifyRouteTemplate(request: FastifyRequest): string {
   return normalizeRouteTemplate(request.routeOptions?.url);
@@ -417,9 +428,17 @@ export async function createFastifyApp(
 
   app.addHook("onRequest", async (request, reply) => {
     runFailSafe(() => {
-      (request as ObservabilityFastifyRequest)[REQUEST_TIMER_KEY] =
-        createRuntimeTimer();
+      const timer = createRuntimeTimer();
+
       metricsRegistry.recordRequestStarted();
+
+      // El estado sólo se publica una vez que el inicio quedó contabilizado,
+      // para que ninguna finalización pueda decrementar un in-flight que nunca
+      // se incrementó.
+      (request as ObservabilityFastifyRequest)[REQUEST_OBSERVABILITY_KEY] = {
+        timer,
+        finalizer: createObservabilityRequestFinalizer(metricsRegistry),
+      };
     });
 
     applyApiRequestIdHeader(request, reply);
@@ -440,15 +459,27 @@ export async function createFastifyApp(
 
   app.addHook("onResponse", async (request, reply) => {
     runFailSafe(() => {
-      const timer =
-        (request as ObservabilityFastifyRequest)[REQUEST_TIMER_KEY] ??
-        createRuntimeTimer();
-      metricsRegistry.recordRequestCompleted({
+      const state = getObservabilityRequestState(request);
+
+      if (!state) {
+        return;
+      }
+
+      state.finalizer.recordCompleted({
         method: request.method,
         routeTemplate: getFastifyRouteTemplate(request),
         statusCode: reply.statusCode,
-        durationMs: timer.elapsedMs(),
+        durationMs: state.timer.elapsedMs(),
       });
+    });
+  });
+
+  // El cliente cortó la conexión antes de la respuesta: se libera el in-flight
+  // sin inventar un status code, porque no existe taxonomía aprobada para un
+  // request abortado.
+  app.addHook("onRequestAbort", async (request) => {
+    runFailSafe(() => {
+      getObservabilityRequestState(request)?.finalizer.recordAborted();
     });
   });
 
@@ -464,7 +495,6 @@ export async function createFastifyApp(
     const status = getFastifyErrorStatus(error);
     const message = getFastifyErrorMessage(error);
     const requestId = getSafeApiResponseRequestId(request, reply);
-
     const safeCode = getFastifyErrorSafeCode(error);
 
     // Metadata allowlisted: nunca URL, query, path con IDs, error crudo ni stack.

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -157,7 +157,7 @@ import {
   generateFastifyRequestId,
   getSafeApiResponseRequestId,
 } from "./lib/http/api-request-id.ts";
-import { logError } from "./lib/logger.ts";
+import { logError, serializeError } from "./lib/logger.ts";
 import {
   createObservabilityRequestFinalizer,
   getObservabilityMetricsRegistry,
@@ -186,25 +186,14 @@ function getFastifyErrorMessage(error: unknown) {
   return "Unexpected error";
 }
 
-const SAFE_ERROR_NAME_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
-
-function getFastifyErrorName(error: unknown) {
-  const name =
-    error instanceof Error
-      ? error.name
-      : error && typeof error === "object" && "name" in error
-        ? (error as { name?: unknown }).name
-        : undefined;
-
-  return typeof name === "string" && SAFE_ERROR_NAME_PATTERN.test(name)
-    ? name
-    : "UnknownError";
-}
+const SAFE_ERROR_CODE_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
 
 /**
  * Sólo se exporta un `code` con forma de identificador corto (p. ej. SQLSTATE o
  * un código de librería). Cualquier otra cosa se descarta para no filtrar
- * mensajes ni detalle de driver DB.
+ * mensajes ni detalle de driver DB. Esta regex sintáctica es deliberadamente
+ * distinta de la allowlist finita de nombres de Error de serializeError: un
+ * `code` corto no es un nombre de clase y no exige lista cerrada.
  */
 function getFastifyErrorSafeCode(error: unknown) {
   const code =
@@ -212,7 +201,7 @@ function getFastifyErrorSafeCode(error: unknown) {
       ? (error as { code?: unknown }).code
       : undefined;
 
-  return typeof code === "string" && SAFE_ERROR_NAME_PATTERN.test(code)
+  return typeof code === "string" && SAFE_ERROR_CODE_PATTERN.test(code)
     ? code
     : undefined;
 }
@@ -502,7 +491,7 @@ export async function createFastifyApp(
       method: request.method,
       routeTemplate: getFastifyRouteTemplate(request),
       status,
-      errorName: getFastifyErrorName(error),
+      errorName: serializeError(error).name,
       ...(safeCode ? { safeCode } : {}),
       ...(requestId ? { requestId } : {}),
     });
@@ -613,6 +602,10 @@ export async function createFastifyApp(
 
   await app.register(adminSystemHealthNativeRoutes, {
     prefix: "/api/admin/system/health",
+    // La superficie privada de metricas debe leer la misma instancia que
+    // instrumenta esta app; sin este getter el plugin caeria en el singleton de
+    // proceso y podria reportar series distintas de las medidas aqui.
+    getObservabilityMetricsSnapshot: () => metricsRegistry.getSnapshot(),
     ...(options.adminSystemHealthRoutes ?? {}),
   });
 

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -4,7 +4,10 @@ import Fastify, {
   type FastifyRequest,
 } from "fastify";
 import { ENV } from "./lib/env.ts";
-import { sanitizeUrlForLogs } from "./middlewares/request-logger.ts";
+import {
+  normalizeRouteTemplate,
+  sanitizeUrlForLogs,
+} from "./middlewares/request-logger.ts";
 import {
   adminAuditNativeRoutes,
   type AdminAuditNativeRoutesOptions,
@@ -154,6 +157,12 @@ import {
   generateFastifyRequestId,
   getSafeApiResponseRequestId,
 } from "./lib/http/api-request-id.ts";
+import { logError } from "./lib/logger.ts";
+import {
+  getObservabilityMetricsRegistry,
+  type ObservabilityMetricsRegistry,
+} from "./lib/observability-metrics.ts";
+import { createRuntimeTimer, type RuntimeTimer } from "./lib/runtime-timing.ts";
 
 type HealthCheckResponse = {
   statusCode: number;
@@ -173,6 +182,37 @@ function getFastifyErrorMessage(error: unknown) {
   }
 
   return "Unexpected error";
+}
+
+const SAFE_ERROR_NAME_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
+
+function getFastifyErrorName(error: unknown) {
+  const name =
+    error instanceof Error
+      ? error.name
+      : error && typeof error === "object" && "name" in error
+        ? (error as { name?: unknown }).name
+        : undefined;
+
+  return typeof name === "string" && SAFE_ERROR_NAME_PATTERN.test(name)
+    ? name
+    : "UnknownError";
+}
+
+/**
+ * Sólo se exporta un `code` con forma de identificador corto (p. ej. SQLSTATE o
+ * un código de librería). Cualquier otra cosa se descarta para no filtrar
+ * mensajes ni detalle de driver DB.
+ */
+function getFastifyErrorSafeCode(error: unknown) {
+  const code =
+    error && typeof error === "object" && "code" in error
+      ? (error as { code?: unknown }).code
+      : undefined;
+
+  return typeof code === "string" && SAFE_ERROR_NAME_PATTERN.test(code)
+    ? code
+    : undefined;
 }
 
 function getFastifyErrorStatus(error: unknown) {
@@ -300,7 +340,30 @@ function addApiErrorRequestIdToJsonPayload(
   });
 }
 
+const REQUEST_TIMER_KEY = "__observabilityRequestTimer";
+
+type ObservabilityFastifyRequest = FastifyRequest & {
+  [REQUEST_TIMER_KEY]?: RuntimeTimer;
+};
+
+function getFastifyRouteTemplate(request: FastifyRequest): string {
+  return normalizeRouteTemplate(request.routeOptions?.url);
+}
+
+/**
+ * La instrumentacion nunca debe alterar la respuesta: cualquier fallo interno
+ * de metricas o logging se descarta en lugar de propagarse al request.
+ */
+function runFailSafe(operation: () => void) {
+  try {
+    operation();
+  } catch {
+    // fail-safe: la observabilidad no puede tumbar una respuesta HTTP
+  }
+}
+
 export type CreateFastifyAppOptions = {
+  observabilityMetricsRegistry?: ObservabilityMetricsRegistry;
   getNativeHealthCheckResponse?: HealthCheckFactory;
   getServiceInfoPayload?: ServiceInfoFactory;
   appVersionRoutes?: AppVersionNativeRoutesOptions;
@@ -349,7 +412,16 @@ export async function createFastifyApp(
     trustProxy: ENV.trustProxy,
   });
 
+  const metricsRegistry =
+    options.observabilityMetricsRegistry ?? getObservabilityMetricsRegistry();
+
   app.addHook("onRequest", async (request, reply) => {
+    runFailSafe(() => {
+      (request as ObservabilityFastifyRequest)[REQUEST_TIMER_KEY] =
+        createRuntimeTimer();
+      metricsRegistry.recordRequestStarted();
+    });
+
     applyApiRequestIdHeader(request, reply);
     applyApiSecurityHeaders(request, reply);
   });
@@ -366,6 +438,20 @@ export async function createFastifyApp(
     },
   );
 
+  app.addHook("onResponse", async (request, reply) => {
+    runFailSafe(() => {
+      const timer =
+        (request as ObservabilityFastifyRequest)[REQUEST_TIMER_KEY] ??
+        createRuntimeTimer();
+      metricsRegistry.recordRequestCompleted({
+        method: request.method,
+        routeTemplate: getFastifyRouteTemplate(request),
+        statusCode: reply.statusCode,
+        durationMs: timer.elapsedMs(),
+      });
+    });
+  });
+
   app.setNotFoundHandler((request, reply) => {
     return reply.code(404).send({
       success: false,
@@ -379,13 +465,16 @@ export async function createFastifyApp(
     const message = getFastifyErrorMessage(error);
     const requestId = getSafeApiResponseRequestId(request, reply);
 
-    console.error("[API ERROR]", {
+    const safeCode = getFastifyErrorSafeCode(error);
+
+    // Metadata allowlisted: nunca URL, query, path con IDs, error crudo ni stack.
+    logError("API_ERROR", {
       method: request.method,
-      path: request.url,
+      routeTemplate: getFastifyRouteTemplate(request),
       status,
-      message,
+      errorName: getFastifyErrorName(error),
+      ...(safeCode ? { safeCode } : {}),
       ...(requestId ? { requestId } : {}),
-      error,
     });
 
     return reply.code(status).send({

--- a/server/fastify-app.ts
+++ b/server/fastify-app.ts
@@ -186,26 +186,6 @@ function getFastifyErrorMessage(error: unknown) {
   return "Unexpected error";
 }
 
-const SAFE_ERROR_CODE_PATTERN = /^[A-Za-z0-9_]{1,64}$/;
-
-/**
- * Sólo se exporta un `code` con forma de identificador corto (p. ej. SQLSTATE o
- * un código de librería). Cualquier otra cosa se descarta para no filtrar
- * mensajes ni detalle de driver DB. Esta regex sintáctica es deliberadamente
- * distinta de la allowlist finita de nombres de Error de serializeError: un
- * `code` corto no es un nombre de clase y no exige lista cerrada.
- */
-function getFastifyErrorSafeCode(error: unknown) {
-  const code =
-    error && typeof error === "object" && "code" in error
-      ? (error as { code?: unknown }).code
-      : undefined;
-
-  return typeof code === "string" && SAFE_ERROR_CODE_PATTERN.test(code)
-    ? code
-    : undefined;
-}
-
 function getFastifyErrorStatus(error: unknown) {
   if (
     error &&
@@ -484,15 +464,16 @@ export async function createFastifyApp(
     const status = getFastifyErrorStatus(error);
     const message = getFastifyErrorMessage(error);
     const requestId = getSafeApiResponseRequestId(request, reply);
-    const safeCode = getFastifyErrorSafeCode(error);
 
     // Metadata allowlisted: nunca URL, query, path con IDs, error crudo ni stack.
+    // Sin `code`: una regex sintactica sobre error.code acepta identificadores
+    // con forma de PII (p. ej. "Paciente_307"), y no existe una allowlist
+    // cerrada de SQLSTATE/codigos de libreria que valga la pena mantener aqui.
     logError("API_ERROR", {
       method: request.method,
       routeTemplate: getFastifyRouteTemplate(request),
       status,
       errorName: serializeError(error).name,
-      ...(safeCode ? { safeCode } : {}),
       ...(requestId ? { requestId } : {}),
     });
 

--- a/server/lib/http/api-request-id.ts
+++ b/server/lib/http/api-request-id.ts
@@ -5,15 +5,23 @@ import { shouldApplyApiSecurityHeaders } from "./api-response-security.ts";
 
 export const API_REQUEST_ID_HEADER_NAME = "X-Request-ID";
 export const API_REQUEST_ID_HEADER_KEY = "x-request-id";
-export const API_REQUEST_ID_MAX_LENGTH = 128;
-const API_REQUEST_ID_ALLOWED_CHARACTERS = /^[A-Za-z0-9._:-]+$/;
+export const API_REQUEST_ID_MAX_LENGTH = 36;
+
+/**
+ * Sólo se preservan identificadores UUID v4.
+ *
+ * Una allowlist de caracteres no demuestra que el valor no sea una
+ * credencial, porque un token opaco puede estar compuesto únicamente por
+ * letras, números, guiones, puntos o underscores.
+ */
+const API_REQUEST_ID_UUID_V4_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
 export function isSafeRequestId(value: unknown): value is string {
   return (
     typeof value === "string" &&
-    value.length > 0 &&
-    value.length <= API_REQUEST_ID_MAX_LENGTH &&
-    API_REQUEST_ID_ALLOWED_CHARACTERS.test(value)
+    value.length === API_REQUEST_ID_MAX_LENGTH &&
+    API_REQUEST_ID_UUID_V4_PATTERN.test(value)
   );
 }
 
@@ -47,7 +55,11 @@ function setReplyHeaderIfUnset(
   }
 }
 
-function setReplyHeader(reply: FastifyReply, name: string, value: string) {
+function setReplyHeader(
+  reply: FastifyReply,
+  name: string,
+  value: string,
+) {
   reply.header(name, value);
   reply.raw.setHeader(name, value);
 }

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -230,15 +230,37 @@ export function redactLogValue(value: unknown): unknown {
   return redactValue(value, 0, new WeakSet<object>());
 }
 
-export function serializeError(error: unknown): unknown {
-  if (error instanceof Error) {
+const SAFE_ERROR_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,63}$/;
+
+export type SerializedError = {
+  name: string;
+  messageSanitized: typeof LOG_REDACTED_VALUE;
+};
+
+/**
+ * Envelope cerrado: nunca se exporta el mensaje libre de un error. Una regex de
+ * credenciales no puede demostrar que un mensaje arbitrario no contiene nombre
+ * de paciente, email, contenido clinico, SQL, parametros DB o paths internos,
+ * asi que el mensaje se elimina por diseno y solo sobrevive el nombre de la
+ * clase de error, validado contra una allowlist.
+ */
+export function serializeError(error: unknown): SerializedError {
+  if (!(error instanceof Error)) {
     return {
-      name: error.name,
-      messageSanitized: redactSensitiveText(error.message),
+      name: "UnknownError",
+      messageSanitized: LOG_REDACTED_VALUE,
     };
   }
 
-  return redactLogValue(error);
+  const name = error.name;
+
+  return {
+    name:
+      typeof name === "string" && SAFE_ERROR_NAME_PATTERN.test(name)
+        ? name
+        : "Error",
+    messageSanitized: LOG_REDACTED_VALUE,
+  };
 }
 
 function buildLogContext(args: unknown[]): Record<string, unknown> {

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -230,7 +230,22 @@ export function redactLogValue(value: unknown): unknown {
   return redactValue(value, 0, new WeakSet<object>());
 }
 
-const SAFE_ERROR_NAME_PATTERN = /^[A-Za-z][A-Za-z0-9_]{0,63}$/;
+/**
+ * Allowlist finita e inmutable de nombres de clases de Error nativas de
+ * JavaScript. Una regex sintactica (p. ej. "cualquier identificador") sigue
+ * aceptando nombres con forma de PII como "MariaGomez" o "Paciente_307": sólo
+ * una lista cerrada de valores conocidos elimina esa clase de fuga.
+ */
+const SAFE_ERROR_NAMES: ReadonlySet<string> = new Set([
+  "Error",
+  "TypeError",
+  "RangeError",
+  "ReferenceError",
+  "SyntaxError",
+  "URIError",
+  "EvalError",
+  "AggregateError",
+]);
 
 export type SerializedError = {
   name: string;
@@ -242,7 +257,7 @@ export type SerializedError = {
  * credenciales no puede demostrar que un mensaje arbitrario no contiene nombre
  * de paciente, email, contenido clinico, SQL, parametros DB o paths internos,
  * asi que el mensaje se elimina por diseno y solo sobrevive el nombre de la
- * clase de error, validado contra una allowlist.
+ * clase de error, validado contra la allowlist finita.
  */
 export function serializeError(error: unknown): SerializedError {
   if (!(error instanceof Error)) {
@@ -256,9 +271,7 @@ export function serializeError(error: unknown): SerializedError {
 
   return {
     name:
-      typeof name === "string" && SAFE_ERROR_NAME_PATTERN.test(name)
-        ? name
-        : "Error",
+      typeof name === "string" && SAFE_ERROR_NAMES.has(name) ? name : "Error",
     messageSanitized: LOG_REDACTED_VALUE,
   };
 }

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -55,18 +55,22 @@ function normalizeLogKey(key: string): string {
   return key.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
-function isSafeLogKey(normalizedKey: string): boolean {
-  return (
-    normalizedKey === "requestid" ||
-    normalizedKey.endsWith("tokenid") ||
-    normalizedKey.endsWith("count")
-  );
-}
-
+/**
+ * Las claves sensibles se evalúan sin excepciones amplias por sufijo.
+ *
+ * Un nombre como `sessionTokenId`, `reportAccessTokenId` o
+ * `refreshTokenCount` sigue describiendo material sensible aunque termine en
+ * `Id` o `Count`. La clave por sí sola no demuestra que su valor sea un
+ * identificador numérico inocuo.
+ *
+ * `requestId` no requiere una excepción: no contiene fragmentos sensibles y
+ * su valor se valida separadamente como UUID v4 antes de promoverse al nivel
+ * superior del evento.
+ */
 export function isSensitiveLogKey(key: string): boolean {
   const normalizedKey = normalizeLogKey(key);
 
-  if (!normalizedKey || isSafeLogKey(normalizedKey)) {
+  if (!normalizedKey) {
     return false;
   }
 

--- a/server/lib/logger.ts
+++ b/server/lib/logger.ts
@@ -1,22 +1,307 @@
-export function logInfo(...args: any[]) {
-  console.log('[INFO]', ...args);
+import { isSafeRequestId } from "./http/api-request-id.ts";
+
+export const LOG_REDACTED_VALUE = "[REDACTED]";
+
+export type LogLevel = "info" | "warn" | "error";
+
+export type StructuredLogEvent = {
+  timestamp: string;
+  level: LogLevel;
+  event: string;
+  requestId?: string;
+  context: Record<string, unknown>;
+};
+
+const DEFAULT_EVENT_BY_LEVEL: Record<LogLevel, string> = {
+  info: "LOG_INFO",
+  warn: "LOG_WARN",
+  error: "LOG_ERROR",
+};
+
+const EVENT_NAME_PATTERN = /^[A-Z][A-Z0-9_]*$/;
+
+const MAX_DEPTH = 6;
+const MAX_ARRAY_ITEMS = 50;
+const MAX_OBJECT_KEYS = 60;
+const MAX_STRING_LENGTH = 2048;
+
+const SENSITIVE_KEY_EXACT = new Set([
+  "pass",
+  "dsn",
+  "auth",
+  "key",
+]);
+
+const SENSITIVE_KEY_FRAGMENTS = [
+  "authorization",
+  "cookie",
+  "password",
+  "passphrase",
+  "secret",
+  "servicerole",
+  "apikey",
+  "token",
+  "session",
+  "signedurl",
+  "storagepath",
+  "databaseurl",
+  "connectionstring",
+  "credential",
+  "privatekey",
+  "bearer",
+];
+
+function normalizeLogKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
 }
 
-export function logWarn(...args: any[]) {
-  console.warn('[WARN]', ...args);
+function isSafeLogKey(normalizedKey: string): boolean {
+  return (
+    normalizedKey === "requestid" ||
+    normalizedKey.endsWith("tokenid") ||
+    normalizedKey.endsWith("count")
+  );
 }
 
-export function logError(...args: any[]) {
-  console.error('[ERROR]', ...args);
+export function isSensitiveLogKey(key: string): boolean {
+  const normalizedKey = normalizeLogKey(key);
+
+  if (!normalizedKey || isSafeLogKey(normalizedKey)) {
+    return false;
+  }
+
+  if (SENSITIVE_KEY_EXACT.has(normalizedKey)) {
+    return true;
+  }
+
+  return SENSITIVE_KEY_FRAGMENTS.some((fragment) =>
+    normalizedKey.includes(fragment),
+  );
 }
 
-export function serializeError(error: unknown) {
+const SIGNED_URL_PATTERN =
+  /\bhttps?:\/\/[^\s"']*(?:\/object\/sign\/|[?&](?:token|access_token|refresh_token|signature|X-Amz-Signature)=)[^\s"']*/gi;
+const CONNECTION_STRING_PATTERN =
+  /\b(?:postgres|postgresql|mysql|mongodb(?:\+srv)?|redis|amqp):\/\/[^\s"']+/gi;
+const BEARER_PATTERN = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]+/gi;
+const JWT_PATTERN = /\beyJ[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]{4,}\.[A-Za-z0-9_-]+/g;
+const SUPABASE_SECRET_PATTERN =
+  /\bsb_(?:secret|publishable)_[A-Za-z0-9_-]+/gi;
+const SENSITIVE_QUERY_PARAM_PATTERN =
+  /([?&](?:token|access_token|refresh_token|accessToken|refreshToken|reportAccessToken|signature|apikey|api_key)=)([^&#\s"']+)/gi;
+const SERIALIZED_COOKIE_PATTERN =
+  /(^|[;,\s])([A-Za-z0-9_.-]*(?:session|token|auth|secret|password)[A-Za-z0-9_.-]*)=([^;,\s]+)/gi;
+
+export function redactSensitiveText(value: string): string {
+  const redacted = value
+    .replace(SIGNED_URL_PATTERN, LOG_REDACTED_VALUE)
+    .replace(CONNECTION_STRING_PATTERN, LOG_REDACTED_VALUE)
+    .replace(JWT_PATTERN, LOG_REDACTED_VALUE)
+    .replace(SUPABASE_SECRET_PATTERN, LOG_REDACTED_VALUE)
+    .replace(BEARER_PATTERN, (_match, scheme: string) =>
+      `${scheme} ${LOG_REDACTED_VALUE}`,
+    )
+    .replace(
+      SENSITIVE_QUERY_PARAM_PATTERN,
+      (_match, prefix: string) => `${prefix}${LOG_REDACTED_VALUE}`,
+    )
+    .replace(
+      SERIALIZED_COOKIE_PATTERN,
+      (_match, lead: string, name: string) =>
+        `${lead}${name}=${LOG_REDACTED_VALUE}`,
+    );
+
+  return redacted.length > MAX_STRING_LENGTH
+    ? `${redacted.slice(0, MAX_STRING_LENGTH)}...[TRUNCATED]`
+    : redacted;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return (
+    value !== null && typeof value === "object" && !Array.isArray(value)
+  );
+}
+
+function redactValue(
+  value: unknown,
+  depth: number,
+  seen: WeakSet<object>,
+): unknown {
+  if (value === null) {
+    return null;
+  }
+
+  switch (typeof value) {
+    case "string":
+      return redactSensitiveText(value);
+    case "number":
+      return Number.isFinite(value) ? value : String(value);
+    case "boolean":
+      return value;
+    case "bigint":
+      return value.toString();
+    case "undefined":
+      return undefined;
+    case "function":
+      return "[Function]";
+    case "symbol":
+      return value.toString();
+    default:
+      break;
+  }
+
+  if (value instanceof Date) {
+    return Number.isNaN(value.getTime())
+      ? "[InvalidDate]"
+      : value.toISOString();
+  }
+
+  if (value instanceof Error) {
+    return serializeError(value);
+  }
+
+  const objectValue = value as object;
+
+  if (seen.has(objectValue)) {
+    return "[Circular]";
+  }
+
+  if (depth >= MAX_DEPTH) {
+    return "[MaxDepth]";
+  }
+
+  seen.add(objectValue);
+
+  try {
+    if (Array.isArray(value)) {
+      const items = value
+        .slice(0, MAX_ARRAY_ITEMS)
+        .map((item) => redactValue(item, depth + 1, seen));
+
+      if (value.length > MAX_ARRAY_ITEMS) {
+        items.push(`[+${value.length - MAX_ARRAY_ITEMS} more]`);
+      }
+
+      return items;
+    }
+
+    if (value instanceof Map || value instanceof Set) {
+      return `[${value.constructor.name}]`;
+    }
+
+    if (!isPlainObject(value)) {
+      return redactSensitiveText(String(value));
+    }
+
+    const result: Record<string, unknown> = {};
+    let keyCount = 0;
+
+    for (const [key, entryValue] of Object.entries(value)) {
+      if (keyCount >= MAX_OBJECT_KEYS) {
+        result["[truncated]"] = true;
+        break;
+      }
+
+      if (entryValue === undefined) {
+        continue;
+      }
+
+      keyCount += 1;
+
+      if (isSensitiveLogKey(key)) {
+        result[key] = LOG_REDACTED_VALUE;
+        continue;
+      }
+
+      const redacted = redactValue(entryValue, depth + 1, seen);
+
+      if (redacted !== undefined) {
+        result[key] = redacted;
+      }
+    }
+
+    return result;
+  } finally {
+    seen.delete(objectValue);
+  }
+}
+
+export function redactLogValue(value: unknown): unknown {
+  return redactValue(value, 0, new WeakSet<object>());
+}
+
+export function serializeError(error: unknown): unknown {
   if (error instanceof Error) {
     return {
-      message: error.message,
-      stack: error.stack,
-      name: error.name
+      name: error.name,
+      messageSanitized: redactSensitiveText(error.message),
     };
   }
-  return error;
+
+  return redactLogValue(error);
+}
+
+function buildLogContext(args: unknown[]): Record<string, unknown> {
+  if (args.length === 0) {
+    return {};
+  }
+
+  if (args.length === 1 && isPlainObject(args[0])) {
+    return redactLogValue(args[0]) as Record<string, unknown>;
+  }
+
+  return {
+    args: redactLogValue(args) as unknown[],
+  };
+}
+
+export function buildStructuredLogEvent(
+  level: LogLevel,
+  args: unknown[],
+): StructuredLogEvent {
+  const [first, ...rest] = args;
+  const hasEventName = typeof first === "string" && EVENT_NAME_PATTERN.test(first);
+
+  const event = hasEventName ? first : DEFAULT_EVENT_BY_LEVEL[level];
+  const context = buildLogContext(hasEventName ? rest : args);
+
+  const requestId = context.requestId;
+
+  if ("requestId" in context) {
+    delete context.requestId;
+  }
+
+  return {
+    timestamp: new Date().toISOString(),
+    level,
+    event,
+    ...(isSafeRequestId(requestId) ? { requestId } : {}),
+    context,
+  };
+}
+
+function stringifyLogEvent(logEvent: StructuredLogEvent): string {
+  try {
+    return JSON.stringify(logEvent);
+  } catch {
+    return JSON.stringify({
+      timestamp: logEvent.timestamp,
+      level: logEvent.level,
+      event: logEvent.event,
+      ...(logEvent.requestId ? { requestId: logEvent.requestId } : {}),
+      context: { serialization: "failed" },
+    });
+  }
+}
+
+export function logInfo(...args: unknown[]) {
+  console.log(stringifyLogEvent(buildStructuredLogEvent("info", args)));
+}
+
+export function logWarn(...args: unknown[]) {
+  console.warn(stringifyLogEvent(buildStructuredLogEvent("warn", args)));
+}
+
+export function logError(...args: unknown[]) {
+  console.error(stringifyLogEvent(buildStructuredLogEvent("error", args)));
 }

--- a/server/lib/observability-metrics.ts
+++ b/server/lib/observability-metrics.ts
@@ -65,9 +65,59 @@ export type ObservabilityMetricsSnapshot = {
 export type ObservabilityMetricsRegistry = {
   recordRequestStarted: () => void;
   recordRequestCompleted: (input: RecordRequestCompletedInput) => void;
+  recordRequestAborted: () => void;
   getSnapshot: () => ObservabilityMetricsSnapshot;
   reset: () => void;
 };
+
+/**
+ * Finaliza un request exactamente una vez. Un aborto sin respuesta no es una
+ * respuesta completada: sólo libera el contador in-flight.
+ */
+export type ObservabilityRequestFinalizer = {
+  recordCompleted: (input: RecordRequestCompletedInput) => boolean;
+  recordAborted: () => boolean;
+};
+
+export function createObservabilityRequestFinalizer(
+  registry: ObservabilityMetricsRegistry,
+): ObservabilityRequestFinalizer {
+  let finalized = false;
+
+  // Se marca antes de invocar la registry: si la implementacion inyectada
+  // lanza, el request ya no puede volver a finalizarse y contar dos veces.
+  function claim(): boolean {
+    if (finalized) {
+      return false;
+    }
+
+    finalized = true;
+
+    return true;
+  }
+
+  return {
+    recordCompleted(input) {
+      if (!claim()) {
+        return false;
+      }
+
+      registry.recordRequestCompleted(input);
+
+      return true;
+    },
+
+    recordAborted() {
+      if (!claim()) {
+        return false;
+      }
+
+      registry.recordRequestAborted();
+
+      return true;
+    },
+  };
+}
 
 const HTTP_METHOD_PATTERN = /^[A-Z]{3,10}$/;
 const ROUTE_TEMPLATE_PATTERN = /^[A-Za-z0-9/_:*.-]+$/;
@@ -262,6 +312,12 @@ export function createObservabilityMetricsRegistry(
     recordRequestStarted() {
       requestsStartedTotal += 1;
       inFlightRequests += 1;
+    },
+
+    recordRequestAborted() {
+      // Un aborto libera el in-flight pero no produce respuesta: no alimenta
+      // completadas, status classes, 5xx, rate limit, latencias ni rutas.
+      inFlightRequests = Math.max(0, inFlightRequests - 1);
     },
 
     recordRequestCompleted(input) {

--- a/server/lib/observability-metrics.ts
+++ b/server/lib/observability-metrics.ts
@@ -1,0 +1,373 @@
+export const OBSERVABILITY_STATUS_CLASSES = [
+  "1xx",
+  "2xx",
+  "3xx",
+  "4xx",
+  "5xx",
+] as const;
+
+export type ObservabilityStatusClass =
+  (typeof OBSERVABILITY_STATUS_CLASSES)[number];
+
+export const DEFAULT_LATENCY_SAMPLE_LIMIT = 1024;
+export const DEFAULT_ROUTE_KEY_LIMIT = 128;
+export const OVERFLOW_ROUTE_KEY = "OTHER";
+export const UNMATCHED_ROUTE_TEMPLATE = "UNMATCHED_ROUTE";
+
+export type ObservabilityMetricsRegistryOptions = {
+  latencySampleLimit?: number;
+  routeKeyLimit?: number;
+  now?: () => number;
+};
+
+export type RecordRequestCompletedInput = {
+  method: string;
+  routeTemplate: string;
+  statusCode: number;
+  durationMs: number;
+};
+
+export type LatencySummary = {
+  count: number;
+  min: number | null;
+  max: number | null;
+  average: number | null;
+  p50: number | null;
+  p95: number | null;
+  p99: number | null;
+};
+
+export type RouteMetricsSummary = {
+  route: string;
+  count: number;
+  serverErrors5xx: number;
+  p50: number | null;
+  p95: number | null;
+};
+
+export type ObservabilityMetricsSnapshot = {
+  startedAt: string;
+  uptimeSeconds: number;
+  requestsStartedTotal: number;
+  requestsCompletedTotal: number;
+  inFlightRequests: number;
+  responsesByStatusClass: Record<ObservabilityStatusClass, number>;
+  serverErrors5xxTotal: number;
+  serverErrorRate: number | null;
+  rateLimitedResponsesTotal: number;
+  latencyMs: LatencySummary;
+  routes: RouteMetricsSummary[];
+  routeKeysTracked: number;
+  routeKeyLimitReached: boolean;
+  latencySampleLimit: number;
+};
+
+export type ObservabilityMetricsRegistry = {
+  recordRequestStarted: () => void;
+  recordRequestCompleted: (input: RecordRequestCompletedInput) => void;
+  getSnapshot: () => ObservabilityMetricsSnapshot;
+  reset: () => void;
+};
+
+const HTTP_METHOD_PATTERN = /^[A-Z]{3,10}$/;
+const ROUTE_TEMPLATE_PATTERN = /^[A-Za-z0-9/_:*.-]+$/;
+const MAX_ROUTE_TEMPLATE_LENGTH = 120;
+const MAX_ROUTE_SUMMARY_ENTRIES = 50;
+
+type RouteBucket = {
+  count: number;
+  serverErrors5xx: number;
+  latencies: number[];
+};
+
+export function getStatusClass(statusCode: number): ObservabilityStatusClass {
+  if (!Number.isFinite(statusCode)) {
+    return "5xx";
+  }
+
+  if (statusCode >= 500) {
+    return "5xx";
+  }
+
+  if (statusCode >= 400) {
+    return "4xx";
+  }
+
+  if (statusCode >= 300) {
+    return "3xx";
+  }
+
+  if (statusCode >= 200) {
+    return "2xx";
+  }
+
+  return "1xx";
+}
+
+function normalizeMethod(method: unknown): string {
+  const value = typeof method === "string" ? method.toUpperCase() : "";
+
+  return HTTP_METHOD_PATTERN.test(value) ? value : "UNKNOWN";
+}
+
+function normalizeRoute(routeTemplate: unknown): string {
+  const value = typeof routeTemplate === "string" ? routeTemplate.trim() : "";
+
+  if (
+    !value ||
+    value.length > MAX_ROUTE_TEMPLATE_LENGTH ||
+    !ROUTE_TEMPLATE_PATTERN.test(value)
+  ) {
+    return UNMATCHED_ROUTE_TEMPLATE;
+  }
+
+  return value;
+}
+
+export function buildRouteMetricsKey(
+  method: unknown,
+  routeTemplate: unknown,
+): string {
+  return `${normalizeMethod(method)} ${normalizeRoute(routeTemplate)}`;
+}
+
+export function computePercentile(
+  sortedSamples: readonly number[],
+  percentile: number,
+): number | null {
+  if (sortedSamples.length === 0) {
+    return null;
+  }
+
+  if (sortedSamples.length === 1) {
+    return sortedSamples[0]!;
+  }
+
+  const rank = Math.ceil((percentile / 100) * sortedSamples.length);
+  const index = Math.min(Math.max(rank, 1), sortedSamples.length) - 1;
+
+  return sortedSamples[index]!;
+}
+
+function roundMs(value: number | null): number | null {
+  return value === null ? null : Math.round(value * 100) / 100;
+}
+
+function summarizeLatencies(samples: readonly number[]): LatencySummary {
+  if (samples.length === 0) {
+    return {
+      count: 0,
+      min: null,
+      max: null,
+      average: null,
+      p50: null,
+      p95: null,
+      p99: null,
+    };
+  }
+
+  const sorted = [...samples].sort((left, right) => left - right);
+  const total = sorted.reduce((sum, value) => sum + value, 0);
+
+  return {
+    count: sorted.length,
+    min: roundMs(sorted[0]!),
+    max: roundMs(sorted[sorted.length - 1]!),
+    average: roundMs(total / sorted.length),
+    p50: roundMs(computePercentile(sorted, 50)),
+    p95: roundMs(computePercentile(sorted, 95)),
+    p99: roundMs(computePercentile(sorted, 99)),
+  };
+}
+
+function createStatusClassCounters(): Record<ObservabilityStatusClass, number> {
+  return {
+    "1xx": 0,
+    "2xx": 0,
+    "3xx": 0,
+    "4xx": 0,
+    "5xx": 0,
+  };
+}
+
+function pushBoundedSample(
+  samples: number[],
+  value: number,
+  limit: number,
+) {
+  if (samples.length >= limit) {
+    samples.shift();
+  }
+
+  samples.push(value);
+}
+
+export function createObservabilityMetricsRegistry(
+  options: ObservabilityMetricsRegistryOptions = {},
+): ObservabilityMetricsRegistry {
+  const latencySampleLimit =
+    Number.isInteger(options.latencySampleLimit) &&
+    (options.latencySampleLimit as number) > 0
+      ? (options.latencySampleLimit as number)
+      : DEFAULT_LATENCY_SAMPLE_LIMIT;
+  const routeKeyLimit =
+    Number.isInteger(options.routeKeyLimit) &&
+    (options.routeKeyLimit as number) > 0
+      ? (options.routeKeyLimit as number)
+      : DEFAULT_ROUTE_KEY_LIMIT;
+  const now = options.now ?? (() => Date.now());
+
+  let startedAtMs = now();
+  let requestsStartedTotal = 0;
+  let requestsCompletedTotal = 0;
+  let inFlightRequests = 0;
+  let serverErrors5xxTotal = 0;
+  let rateLimitedResponsesTotal = 0;
+  let routeKeyLimitReached = false;
+  let latencies: number[] = [];
+  let responsesByStatusClass = createStatusClassCounters();
+  let routes = new Map<string, RouteBucket>();
+
+  function createRouteBucket(key: string): RouteBucket {
+    const bucket: RouteBucket = {
+      count: 0,
+      serverErrors5xx: 0,
+      latencies: [],
+    };
+
+    routes.set(key, bucket);
+
+    return bucket;
+  }
+
+  function resolveRouteBucket(key: string): RouteBucket {
+    const existing = routes.get(key);
+
+    if (existing) {
+      return existing;
+    }
+
+    if (routes.size >= routeKeyLimit) {
+      routeKeyLimitReached = true;
+
+      return (
+        routes.get(OVERFLOW_ROUTE_KEY) ?? createRouteBucket(OVERFLOW_ROUTE_KEY)
+      );
+    }
+
+    return createRouteBucket(key);
+  }
+
+  return {
+    recordRequestStarted() {
+      requestsStartedTotal += 1;
+      inFlightRequests += 1;
+    },
+
+    recordRequestCompleted(input) {
+      requestsCompletedTotal += 1;
+      inFlightRequests = Math.max(0, inFlightRequests - 1);
+
+      const statusCode = Number.isFinite(input.statusCode)
+        ? Math.trunc(input.statusCode)
+        : 500;
+      const statusClass = getStatusClass(statusCode);
+
+      responsesByStatusClass[statusClass] += 1;
+
+      if (statusClass === "5xx") {
+        serverErrors5xxTotal += 1;
+      }
+
+      if (statusCode === 429) {
+        rateLimitedResponsesTotal += 1;
+      }
+
+      const durationMs =
+        Number.isFinite(input.durationMs) && input.durationMs >= 0
+          ? input.durationMs
+          : 0;
+
+      pushBoundedSample(latencies, durationMs, latencySampleLimit);
+
+      const key = buildRouteMetricsKey(input.method, input.routeTemplate);
+      const bucket = resolveRouteBucket(key);
+
+      bucket.count += 1;
+
+      if (statusClass === "5xx") {
+        bucket.serverErrors5xx += 1;
+      }
+
+      pushBoundedSample(bucket.latencies, durationMs, latencySampleLimit);
+    },
+
+    getSnapshot() {
+      const routeSummaries: RouteMetricsSummary[] = Array.from(routes.entries())
+        .map(([route, bucket]) => {
+          const sorted = [...bucket.latencies].sort(
+            (left, right) => left - right,
+          );
+
+          return {
+            route,
+            count: bucket.count,
+            serverErrors5xx: bucket.serverErrors5xx,
+            p50: roundMs(computePercentile(sorted, 50)),
+            p95: roundMs(computePercentile(sorted, 95)),
+          };
+        })
+        .sort((left, right) => right.count - left.count)
+        .slice(0, MAX_ROUTE_SUMMARY_ENTRIES);
+
+      return {
+        startedAt: new Date(startedAtMs).toISOString(),
+        uptimeSeconds: Math.max(0, Math.round((now() - startedAtMs) / 1000)),
+        requestsStartedTotal,
+        requestsCompletedTotal,
+        inFlightRequests,
+        responsesByStatusClass: { ...responsesByStatusClass },
+        serverErrors5xxTotal,
+        serverErrorRate:
+          requestsCompletedTotal === 0
+            ? null
+            : Math.round(
+                (serverErrors5xxTotal / requestsCompletedTotal) * 10000,
+              ) / 10000,
+        rateLimitedResponsesTotal,
+        latencyMs: summarizeLatencies(latencies),
+        routes: routeSummaries,
+        routeKeysTracked: routes.size,
+        routeKeyLimitReached,
+        latencySampleLimit,
+      };
+    },
+
+    reset() {
+      startedAtMs = now();
+      requestsStartedTotal = 0;
+      requestsCompletedTotal = 0;
+      inFlightRequests = 0;
+      serverErrors5xxTotal = 0;
+      rateLimitedResponsesTotal = 0;
+      routeKeyLimitReached = false;
+      latencies = [];
+      responsesByStatusClass = createStatusClassCounters();
+      routes = new Map<string, RouteBucket>();
+    },
+  };
+}
+
+let processRegistry: ObservabilityMetricsRegistry | undefined;
+
+export function getObservabilityMetricsRegistry(): ObservabilityMetricsRegistry {
+  if (!processRegistry) {
+    processRegistry = createObservabilityMetricsRegistry();
+  }
+
+  return processRegistry;
+}
+
+export function getObservabilityMetricsSnapshot(): ObservabilityMetricsSnapshot {
+  return getObservabilityMetricsRegistry().getSnapshot();
+}

--- a/server/middlewares/request-logger.ts
+++ b/server/middlewares/request-logger.ts
@@ -1,13 +1,31 @@
 import type { NextFunction, Request, Response } from "../lib/http-types.ts";
+import {
+  getSafeIncomingRequestId,
+  isSafeRequestId,
+} from "../lib/http/api-request-id.ts";
+import { logInfo } from "../lib/logger.ts";
+import {
+  getStatusClass,
+  UNMATCHED_ROUTE_TEMPLATE,
+} from "../lib/observability-metrics.ts";
 import { createRuntimeTimer } from "../lib/runtime-timing.ts";
+
+export const HTTP_REQUEST_COMPLETED_EVENT = "HTTP_REQUEST_COMPLETED";
+
+const SIGNED_URL_IN_LOG_PATTERN =
+  /\bhttps?:\/\/[^\s"']*(?:\/object\/sign\/|[?&](?:token|access_token|refresh_token|signature|X-Amz-Signature)=)[^\s"']*/gi;
 
 export function sanitizeUrlForLogs(url: string): string {
   return url
+    .replace(SIGNED_URL_IN_LOG_PATTERN, "[REDACTED]")
     .replace(
       /(\/api\/public\/report-access\/)([^/?#]+)/gi,
       "$1[REDACTED]",
     )
-    .replace(/([?&](?:token|reportAccessToken)=)([^&#]+)/gi, "$1[REDACTED]");
+    .replace(
+      /([?&](?:token|reportAccessToken|access_token|refresh_token|accessToken|refreshToken|signature)=)([^&#]+)/gi,
+      "$1[REDACTED]",
+    );
 }
 
 export function buildRequestLogLine(input: {
@@ -28,24 +46,92 @@ export function buildRequestLogLine(input: {
   return baseLine;
 }
 
+const ROUTE_TEMPLATE_PATTERN = /^[A-Za-z0-9/_:*.-]+$/;
+const MAX_ROUTE_TEMPLATE_LENGTH = 120;
+
+/**
+ * Normaliza el template de ruta de Fastify (no la URL real) para usarlo como
+ * dimension acotada en logs y metricas. Cualquier valor con IDs concretos o
+ * caracteres fuera del template cae a UNMATCHED_ROUTE.
+ */
+export function normalizeRouteTemplate(value: unknown): string {
+  if (typeof value !== "string") {
+    return UNMATCHED_ROUTE_TEMPLATE;
+  }
+
+  const trimmed = value.trim();
+
+  if (
+    !trimmed ||
+    trimmed.length > MAX_ROUTE_TEMPLATE_LENGTH ||
+    !ROUTE_TEMPLATE_PATTERN.test(trimmed)
+  ) {
+    return UNMATCHED_ROUTE_TEMPLATE;
+  }
+
+  return trimmed;
+}
+
+/**
+ * Contexto cerrado del access log. No incluye path, url, pathname ni query:
+ * la unica dimension de ruta es el template Fastify normalizado, porque la URL
+ * real puede conservar reportId, clinicId, trackingCaseId u otros IDs aun
+ * despues de redactar tokens.
+ */
+export type RequestCompletionLogContext = {
+  method: string;
+  routeTemplate: string;
+  statusCode: number;
+  statusClass: string;
+  durationMs: number;
+  rateLimited: boolean;
+};
+
+export function buildRequestCompletionLogContext(input: {
+  method: string;
+  routeTemplate: unknown;
+  statusCode: number;
+  durationMs: number;
+}): RequestCompletionLogContext {
+  return {
+    method: input.method,
+    routeTemplate: normalizeRouteTemplate(input.routeTemplate),
+    statusCode: input.statusCode,
+    statusClass: getStatusClass(input.statusCode),
+    durationMs: Math.round(input.durationMs * 100) / 100,
+    rateLimited: input.statusCode === 429,
+  };
+}
+
+export function logRequestCompletion(input: {
+  method: string;
+  routeTemplate: unknown;
+  statusCode: number;
+  durationMs: number;
+  requestId?: unknown;
+}) {
+  const context = buildRequestCompletionLogContext(input);
+
+  logInfo(HTTP_REQUEST_COMPLETED_EVENT, {
+    ...(isSafeRequestId(input.requestId) ? { requestId: input.requestId } : {}),
+    ...context,
+  });
+}
+
 export function requestLogger(req: Request, res: Response, next: NextFunction) {
   const timer = createRuntimeTimer();
 
   res.on("finish", () => {
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(req.originalUrl);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: req.method,
-        url: safeUrl,
-        statusCode: res.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: req.method,
+      routeTemplate: (req as { route?: { path?: string } }).route?.path,
+      statusCode: res.statusCode,
+      durationMs,
+      requestId: req.requestId ?? getSafeIncomingRequestId(req.headers ?? {}),
+    });
   });
 
   next();
 }
-

--- a/server/routes/admin-audit.fastify.ts
+++ b/server/routes/admin-audit.fastify.ts
@@ -18,10 +18,7 @@ import {
   type AdminAuditListFilters,
   type AuditLogListItem,
 } from "../lib/admin-audit.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -116,7 +113,6 @@ async function loadDefaultDeps(): Promise<NativeAdminAuditDeps> {
 
   return defaultDepsPromise!;
 }
-
 
 async function authenticateAdminUser(
   request: FastifyRequest,
@@ -237,17 +233,14 @@ export const adminAuditNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   app.get<{

--- a/server/routes/admin-auth.fastify.ts
+++ b/server/routes/admin-auth.fastify.ts
@@ -36,10 +36,7 @@ import {
   type RateLimitEntry,
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -345,8 +342,6 @@ function createMissingAdminPasswordChangeDep(name: string) {
   };
 }
 
-
-
 function getUserAgent(request: FastifyRequest) {
   const value = request.headers["user-agent"];
 
@@ -476,17 +471,14 @@ export const adminAuthNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/admin-particular-tokens.fastify.ts
+++ b/server/routes/admin-particular-tokens.fastify.ts
@@ -28,10 +28,7 @@ import {
   serializeParticularTokenDetail,
   updateParticularTokenReportSchema,
 } from "../features/particular-access/index.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -363,17 +360,14 @@ export const adminParticularTokensNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/admin-pricing.fastify.ts
+++ b/server/routes/admin-pricing.fastify.ts
@@ -12,6 +12,8 @@ import {
 } from "../lib/cors-headers.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
+import { logError } from "../lib/logger.ts";
+import { normalizeRouteTemplate } from "../middlewares/request-logger.ts";
 import {
   invalidatePublicPricingCache,
   listAdminPricingCategories,
@@ -43,6 +45,12 @@ type AuthenticatedAdminUser = {
 type AdminPricingRequestParams = {
   id?: unknown;
 };
+
+function getSafeErrorName(error: unknown) {
+  return error instanceof Error && error.name.trim()
+    ? error.name
+    : "unknown_error";
+}
 
 type AdminPricingPatchBody = {
   priceLabel?: unknown;
@@ -345,9 +353,9 @@ export const adminPricingNativeRoutes: FastifyPluginAsync<
         categories,
       });
     } catch (error) {
-      console.error("[ADMIN_PRICING_LIST_ERROR]", {
-        path: request.url,
-        error,
+      logError("ADMIN_PRICING_LIST_ERROR", {
+        routeTemplate: normalizeRouteTemplate(request.routeOptions?.url),
+        errorName: getSafeErrorName(error),
       });
 
       return reply.code(500).send({
@@ -437,9 +445,9 @@ export const adminPricingNativeRoutes: FastifyPluginAsync<
         pricingItem: serializeAdminPricingItem(updated),
       });
     } catch (error) {
-      console.error("[ADMIN_PRICING_PATCH_ERROR]", {
-        path: request.url,
-        error,
+      logError("ADMIN_PRICING_PATCH_ERROR", {
+        routeTemplate: normalizeRouteTemplate(request.routeOptions?.url),
+        errorName: getSafeErrorName(error),
       });
 
       return reply.code(500).send({

--- a/server/routes/admin-pricing.fastify.ts
+++ b/server/routes/admin-pricing.fastify.ts
@@ -12,7 +12,7 @@ import {
 } from "../lib/cors-headers.ts";
 import { AUDIT_EVENTS, type AuditWriteInput } from "../lib/audit.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
-import { logError } from "../lib/logger.ts";
+import { logError, serializeError } from "../lib/logger.ts";
 import { normalizeRouteTemplate } from "../middlewares/request-logger.ts";
 import {
   invalidatePublicPricingCache,
@@ -45,12 +45,6 @@ type AuthenticatedAdminUser = {
 type AdminPricingRequestParams = {
   id?: unknown;
 };
-
-function getSafeErrorName(error: unknown) {
-  return error instanceof Error && error.name.trim()
-    ? error.name
-    : "unknown_error";
-}
 
 type AdminPricingPatchBody = {
   priceLabel?: unknown;
@@ -354,8 +348,9 @@ export const adminPricingNativeRoutes: FastifyPluginAsync<
       });
     } catch (error) {
       logError("ADMIN_PRICING_LIST_ERROR", {
+        requestId: request.id,
         routeTemplate: normalizeRouteTemplate(request.routeOptions?.url),
-        errorName: getSafeErrorName(error),
+        errorName: serializeError(error).name,
       });
 
       return reply.code(500).send({
@@ -446,8 +441,9 @@ export const adminPricingNativeRoutes: FastifyPluginAsync<
       });
     } catch (error) {
       logError("ADMIN_PRICING_PATCH_ERROR", {
+        requestId: request.id,
         routeTemplate: normalizeRouteTemplate(request.routeOptions?.url),
-        errorName: getSafeErrorName(error),
+        errorName: serializeError(error).name,
       });
 
       return reply.code(500).send({

--- a/server/routes/admin-report-access-tokens.fastify.ts
+++ b/server/routes/admin-report-access-tokens.fastify.ts
@@ -36,10 +36,7 @@ import {
   serializeReportAccessToken,
   serializeReportAccessTokenDetail,
 } from "../features/report-access/index.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -233,8 +230,6 @@ function setMutationRateLimitHeaders(
   );
 }
 
-
-
 function createAuditRequestLike(
   request: FastifyRequest,
   admin?: Pick<AuthenticatedAdminUser, "id" | "username">,
@@ -344,17 +339,14 @@ export const adminReportAccessTokensNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/admin-reports.fastify.ts
+++ b/server/routes/admin-reports.fastify.ts
@@ -25,10 +25,7 @@ import {
   parseReportId,
   serializeSafeReport,
 } from "../features/reports/domain/index.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -200,7 +197,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
 }
 
-
 async function authenticateAdminUser(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -299,17 +295,14 @@ export const adminReportsNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/admin-study-tracking.fastify.ts
+++ b/server/routes/admin-study-tracking.fastify.ts
@@ -31,10 +31,7 @@ import {
   serializeStudyTrackingNotification,
   updateStudyTrackingSchema,
 } from "../features/study-tracking/domain/index.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -255,7 +252,6 @@ function applyCorsHeaders(
   reply.header("access-control-allow-credentials", "true");
 }
 
-
 async function authenticateAdminUser(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -425,17 +421,14 @@ export const adminStudyTrackingNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/admin-system-health.fastify.ts
+++ b/server/routes/admin-system-health.fastify.ts
@@ -11,6 +11,10 @@ import {
   getRequestOrigin,
 } from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
+import {
+  getObservabilityMetricsSnapshot as getProcessObservabilityMetricsSnapshot,
+  type ObservabilityMetricsSnapshot,
+} from "../lib/observability-metrics.ts";
 
 type AdminSessionRecord = {
   adminUserId: number;
@@ -46,6 +50,7 @@ export type AdminSystemHealthNativeRoutesOptions = {
   hashSessionToken?: (token: string) => string;
   getSystemHealthSnapshot?: () => Promise<SystemHealthSnapshot>;
   getBackendVersion?: () => string;
+  getObservabilityMetricsSnapshot?: () => ObservabilityMetricsSnapshot;
   now?: () => number;
 };
 
@@ -314,7 +319,25 @@ export const adminSystemHealthNativeRoutes: FastifyPluginAsync<
     return reply.code(204).send();
   };
 
+  const getObservabilityMetrics =
+    options.getObservabilityMetricsSnapshot ??
+    getProcessObservabilityMetricsSnapshot;
+
   app.options("/", optionsHandler);
+  app.options("/metrics", optionsHandler);
+
+  app.get("/metrics", async (request, reply) => {
+    const admin = await authenticateAdminUser(request, reply, deps, now);
+
+    if (!admin) {
+      return reply;
+    }
+
+    return reply.code(200).send({
+      success: true,
+      metrics: getObservabilityMetrics(),
+    });
+  });
 
   app.get("/", async (request, reply) => {
     const admin = await authenticateAdminUser(request, reply, deps, now);

--- a/server/routes/auth.fastify.ts
+++ b/server/routes/auth.fastify.ts
@@ -34,10 +34,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -920,17 +917,14 @@ export const clinicAuthNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (request: FastifyRequest, reply: FastifyReply) => {

--- a/server/routes/clinic-audit.fastify.ts
+++ b/server/routes/clinic-audit.fastify.ts
@@ -12,10 +12,7 @@ import {
   type AuditLogListItem,
 } from "../lib/clinic-audit.ts";
 import { ENV } from "../lib/env.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -211,7 +208,6 @@ function buildClearSessionCookie() {
   });
 }
 
-
 async function authenticateClinicUser(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -332,17 +328,14 @@ export const clinicAuditNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   app.get<{

--- a/server/routes/clinic-public-profile.fastify.ts
+++ b/server/routes/clinic-public-profile.fastify.ts
@@ -15,10 +15,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -536,17 +533,14 @@ export const clinicPublicProfileNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/particular-audit.fastify.ts
+++ b/server/routes/particular-audit.fastify.ts
@@ -12,10 +12,7 @@ import {
   type AuditLogListItem,
 } from "../lib/particular-audit.ts";
 import { ENV } from "../lib/env.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -209,7 +206,6 @@ function buildClearParticularSessionCookie() {
   });
 }
 
-
 async function authenticateParticularUser(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -331,17 +327,14 @@ export const particularAuditNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   app.get<{

--- a/server/routes/particular-auth.fastify.ts
+++ b/server/routes/particular-auth.fastify.ts
@@ -31,10 +31,7 @@ import {
   type RateLimitStore,
 } from "../lib/rate-limit-store.ts";
 import { serializeParticularTokenDetail } from "../features/particular-access/index.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -509,17 +506,14 @@ export const particularAuthNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/particular-study-tracking.fastify.ts
+++ b/server/routes/particular-study-tracking.fastify.ts
@@ -27,10 +27,7 @@ import {
   serializeStudyTrackingCase,
   serializeStudyTrackingNotification,
 } from "../features/study-tracking/domain/index.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -391,17 +388,14 @@ export const particularStudyTrackingNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/particular-tokens.fastify.ts
+++ b/server/routes/particular-tokens.fastify.ts
@@ -26,10 +26,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -505,17 +502,14 @@ export const particularTokensNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/public-pricing.fastify.ts
+++ b/server/routes/public-pricing.fastify.ts
@@ -5,6 +5,14 @@ import {
   type ListPublicPricingItemsFn,
   type PublicPricingCacheStatus,
 } from "../features/pricing/public-pricing-service.ts";
+import { logError } from "../lib/logger.ts";
+import { normalizeRouteTemplate } from "../middlewares/request-logger.ts";
+
+function getSafeErrorName(error: unknown) {
+  return error instanceof Error && error.name.trim()
+    ? error.name
+    : "unknown_error";
+}
 
 export type PublicPricingNativeRoutesOptions = {
   listPublicPricingItems?: ListPublicPricingItemsFn;
@@ -34,9 +42,9 @@ export const publicPricingNativeRoutes: FastifyPluginAsync<
 
       return reply.code(200).send(snapshot);
     } catch (error) {
-      console.error("[PUBLIC_PRICING_LIST_ERROR]", {
-        path: request.url,
-        error,
+      logError("PUBLIC_PRICING_LIST_ERROR", {
+        routeTemplate: normalizeRouteTemplate(request.routeOptions?.url),
+        errorName: getSafeErrorName(error),
       });
 
       return reply.code(500).send({

--- a/server/routes/public-pricing.fastify.ts
+++ b/server/routes/public-pricing.fastify.ts
@@ -5,14 +5,8 @@ import {
   type ListPublicPricingItemsFn,
   type PublicPricingCacheStatus,
 } from "../features/pricing/public-pricing-service.ts";
-import { logError } from "../lib/logger.ts";
+import { logError, serializeError } from "../lib/logger.ts";
 import { normalizeRouteTemplate } from "../middlewares/request-logger.ts";
-
-function getSafeErrorName(error: unknown) {
-  return error instanceof Error && error.name.trim()
-    ? error.name
-    : "unknown_error";
-}
 
 export type PublicPricingNativeRoutesOptions = {
   listPublicPricingItems?: ListPublicPricingItemsFn;
@@ -43,8 +37,9 @@ export const publicPricingNativeRoutes: FastifyPluginAsync<
       return reply.code(200).send(snapshot);
     } catch (error) {
       logError("PUBLIC_PRICING_LIST_ERROR", {
+        requestId: request.id,
         routeTemplate: normalizeRouteTemplate(request.routeOptions?.url),
-        errorName: getSafeErrorName(error),
+        errorName: serializeError(error).name,
       });
 
       return reply.code(500).send({

--- a/server/routes/public-professionals.fastify.ts
+++ b/server/routes/public-professionals.fastify.ts
@@ -28,10 +28,7 @@ import {
   createRuntimeTimer,
   type RuntimeTimer,
 } from "../lib/runtime-timing.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 
 type PublicProfessionalRow = {
   clinicId: number;
@@ -263,7 +260,6 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
     createSignedStorageUrl: options.createSignedStorageUrl,
   });
 
-
   const allowedOrigins = new Set(getAllowedOrigins());
 
   const searchRateLimit = createFixedWindowRateLimit({
@@ -309,17 +305,14 @@ export const publicProfessionalsNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   app.get<{

--- a/server/routes/public-report-access.fastify.ts
+++ b/server/routes/public-report-access.fastify.ts
@@ -33,10 +33,7 @@ import {
   getAllowedOrigins,
   getAllowedOriginForCors,
 } from "../lib/cors-headers.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -174,7 +171,6 @@ function setRateLimitHeaders(
   );
 }
 
-
 export const publicReportAccessNativeRoutes: FastifyPluginAsync<
   PublicReportAccessNativeRoutesOptions
 > = async (app, options) => {
@@ -234,17 +230,14 @@ export const publicReportAccessNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   app.options("/:token", async (request, reply) => {

--- a/server/routes/report-access-tokens.fastify.ts
+++ b/server/routes/report-access-tokens.fastify.ts
@@ -39,10 +39,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -352,8 +349,6 @@ function setMutationRateLimitHeaders(
   );
 }
 
-
-
 function createAuditRequestLike(
   request: FastifyRequest,
   auth?: Pick<
@@ -549,17 +544,14 @@ export const reportAccessTokensNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/reports-status.fastify.ts
+++ b/server/routes/reports-status.fastify.ts
@@ -24,10 +24,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -221,7 +218,6 @@ function buildClearSessionCookie() {
   });
 }
 
-
 function createAuditRequestLike(
   request: FastifyRequest,
   auth: AuthenticatedClinicUser,
@@ -350,17 +346,14 @@ export const reportsStatusNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/server/routes/reports.fastify.ts
+++ b/server/routes/reports.fastify.ts
@@ -23,10 +23,7 @@ import {
 } from "../features/reports/domain/index.ts";
 import { createClinicReportsRouteComposition } from "../features/reports/composition/index.ts";
 import { normalizeClinicUserRole } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -224,7 +221,6 @@ function buildClearSessionCookie() {
   });
 }
 
-
 async function authenticateClinicUser(
   request: FastifyRequest,
   reply: FastifyReply,
@@ -315,17 +311,14 @@ export const reportsNativeRoutes: FastifyPluginAsync<ReportsNativeRoutesOptions>
         createRuntimeTimer();
 
       const durationMs = timer.elapsedMs();
-      const safeUrl = sanitizeUrlForLogs(request.url);
 
-      console.log(
-        buildRequestLogLine({
-          timestamp: new Date().toISOString(),
-          method: request.method,
-          url: safeUrl,
-          statusCode: reply.statusCode,
-          durationMs,
-        }),
-      );
+      logRequestCompletion({
+        method: request.method,
+        routeTemplate: request.routeOptions?.url,
+        statusCode: reply.statusCode,
+        durationMs,
+        requestId: request.id,
+      });
     });
 
     const optionsHandler = async (

--- a/server/routes/study-tracking.fastify.ts
+++ b/server/routes/study-tracking.fastify.ts
@@ -35,10 +35,7 @@ import {
   getClinicPermissions,
   normalizeClinicUserRole,
 } from "../lib/permissions.ts";
-import {
-  buildRequestLogLine,
-  sanitizeUrlForLogs,
-} from "../middlewares/request-logger.ts";
+import { logRequestCompletion } from "../middlewares/request-logger.ts";
 import {
   createRuntimeTimer,
   type RuntimeTimer,
@@ -565,17 +562,14 @@ export const studyTrackingNativeRoutes: FastifyPluginAsync<
       createRuntimeTimer();
 
     const durationMs = timer.elapsedMs();
-    const safeUrl = sanitizeUrlForLogs(request.url);
 
-    console.log(
-      buildRequestLogLine({
-        timestamp: new Date().toISOString(),
-        method: request.method,
-        url: safeUrl,
-        statusCode: reply.statusCode,
-        durationMs,
-      }),
-    );
+    logRequestCompletion({
+      method: request.method,
+      routeTemplate: request.routeOptions?.url,
+      statusCode: reply.statusCode,
+      durationMs,
+      requestId: request.id,
+    });
   });
 
   const optionsHandler = async (

--- a/test/architecture/backend-modularization-m46-http-lib-reclassification.test.ts
+++ b/test/architecture/backend-modularization-m46-http-lib-reclassification.test.ts
@@ -92,6 +92,7 @@ const expectedConsumerKeys = [
   "server/middlewares/request-logger.ts|static|runtime|../lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
   "test/helpers/api-request-id-contract.ts|dynamic|runtime|../../server/lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
   "test/integration/adapters/controllers/api-request-id-observability-contract.test.ts|dynamic|runtime|../../../../server/lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
+  "test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts|static|runtime|../../../../server/lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
   "test/integration/app/fastify-app.test.ts|dynamic|runtime|../../../server/lib/http/api-response-security.ts|server/lib/http/api-response-security.ts",
   "test/security/backend-api-no-store-cache-contract.test.ts|dynamic|runtime|../../server/lib/http/sensitive-response-cache.ts|server/lib/http/sensitive-response-cache.ts",
   "test/unit/infrastructure/backend-api-nosniff-responses-contract.test.ts|dynamic|runtime|../../../server/lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",

--- a/test/architecture/backend-modularization-m46-http-lib-reclassification.test.ts
+++ b/test/architecture/backend-modularization-m46-http-lib-reclassification.test.ts
@@ -88,6 +88,8 @@ const expectedConsumerKeys = [
   "server/fastify-app.ts|static|runtime|./lib/http/api-response-security.ts|server/lib/http/api-response-security.ts",
   "server/fastify-app.ts|static|runtime|./lib/http/sensitive-response-cache.ts|server/lib/http/sensitive-response-cache.ts",
   "server/lib/http/api-request-id.ts|static|runtime|./api-response-security.ts|server/lib/http/api-response-security.ts",
+  "server/lib/logger.ts|static|runtime|./http/api-request-id.ts|server/lib/http/api-request-id.ts",
+  "server/middlewares/request-logger.ts|static|runtime|../lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
   "test/helpers/api-request-id-contract.ts|dynamic|runtime|../../server/lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
   "test/integration/adapters/controllers/api-request-id-observability-contract.test.ts|dynamic|runtime|../../../../server/lib/http/api-request-id.ts|server/lib/http/api-request-id.ts",
   "test/integration/app/fastify-app.test.ts|dynamic|runtime|../../../server/lib/http/api-response-security.ts|server/lib/http/api-response-security.ts",

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -85,7 +85,7 @@ const expectedAreaCensus = {
   "server/routes": { files: 35, loc: 22_934 },
   "server/lib": { files: 28, loc: 4_612 },
   "server/middlewares": { files: 7, loc: 947 },
-  "server root": { files: 9, loc: 2_390 },
+  "server root": { files: 9, loc: 2_371 },
   other: { files: 0, loc: 0 },
 } as const;
 
@@ -268,7 +268,7 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_863,
+    47_844,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 228, loc: 47_863 }],
+    ["Total server", { files: 228, loc: 47_844 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -83,7 +83,7 @@ const m47KeepPaths = [
 const expectedAreaCensus = {
   "server/features": { files: 149, loc: 16_980 },
   "server/routes": { files: 35, loc: 22_934 },
-  "server/lib": { files: 28, loc: 4_612 },
+  "server/lib": { files: 28, loc: 4_628 },
   "server/middlewares": { files: 7, loc: 947 },
   "server root": { files: 9, loc: 2_371 },
   other: { files: 0, loc: 0 },
@@ -268,7 +268,7 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_844,
+    47_860,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 228, loc: 47_844 }],
+    ["Total server", { files: 228, loc: 47_860 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -83,9 +83,9 @@ const m47KeepPaths = [
 const expectedAreaCensus = {
   "server/features": { files: 149, loc: 16_980 },
   "server/routes": { files: 35, loc: 22_934 },
-  "server/lib": { files: 28, loc: 4_599 },
+  "server/lib": { files: 28, loc: 4_612 },
   "server/middlewares": { files: 7, loc: 947 },
-  "server root": { files: 9, loc: 2_397 },
+  "server root": { files: 9, loc: 2_390 },
   other: { files: 0, loc: 0 },
 } as const;
 
@@ -268,7 +268,7 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_857,
+    47_863,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 228, loc: 47_857 }],
+    ["Total server", { files: 228, loc: 47_863 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -82,10 +82,10 @@ const m47KeepPaths = [
 
 const expectedAreaCensus = {
   "server/features": { files: 149, loc: 16_980 },
-  "server/routes": { files: 35, loc: 23_033 },
-  "server/lib": { files: 27, loc: 3_863 },
-  "server/middlewares": { files: 7, loc: 861 },
-  "server root": { files: 9, loc: 2_278 },
+  "server/routes": { files: 35, loc: 22_943 },
+  "server/lib": { files: 28, loc: 4_521 },
+  "server/middlewares": { files: 7, loc: 947 },
+  "server root": { files: 9, loc: 2_367 },
   other: { files: 0, loc: 0 },
 } as const;
 
@@ -268,14 +268,14 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_015,
+    47_758,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
       (total, area) => total + area.files,
       0,
     ),
-    227,
+    228,
   );
 
   const actualFeatureCensus = Object.fromEntries(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 227, loc: 47_015 }],
+    ["Total server", { files: 228, loc: 47_758 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -82,10 +82,10 @@ const m47KeepPaths = [
 
 const expectedAreaCensus = {
   "server/features": { files: 149, loc: 16_980 },
-  "server/routes": { files: 35, loc: 22_943 },
-  "server/lib": { files: 28, loc: 4_521 },
+  "server/routes": { files: 35, loc: 22_934 },
+  "server/lib": { files: 28, loc: 4_599 },
   "server/middlewares": { files: 7, loc: 947 },
-  "server root": { files: 9, loc: 2_367 },
+  "server root": { files: 9, loc: 2_397 },
   other: { files: 0, loc: 0 },
 } as const;
 
@@ -268,7 +268,7 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_758,
+    47_857,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 228, loc: 47_758 }],
+    ["Total server", { files: 228, loc: 47_857 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/architecture/particular-access-m33-closeout.test.ts
+++ b/test/architecture/particular-access-m33-closeout.test.ts
@@ -366,7 +366,7 @@ test("M44 retira paths legacy y realinea los ocho consumidores externos", () => 
 test("Auth preserva contrato y Reports usa composition M41", () => {
   assert.equal(
     digest("server/routes/particular-auth.fastify.ts"),
-    "33ffa0c6da11304dbeb8c000b9ec0b55d03781b90fd2980a76365bdfaeed049f",
+    "8aa9bdd2539bbbbbc40a98965c89144ba11c9b36018168664985d3bb686c9706",
   );
   assert.equal(
     digest("server/middlewares/particular-auth.ts"),

--- a/test/architecture/security/security-production-invariants.test.ts
+++ b/test/architecture/security/security-production-invariants.test.ts
@@ -477,7 +477,7 @@ test("errores internos se loguean, pero la respuesta 500 no expone detalles", ()
 
   assertContains(source, "app.setErrorHandler((error, request, reply) => {", file);
   assertContains(source, 'logError("API_ERROR", {', file);
-  assertContains(source, "errorName: getFastifyErrorName(error)", file);
+  assertContains(source, "errorName: serializeError(error).name", file);
   assertNotContains(source, 'console.error("[API ERROR]"', file);
   assertNotContains(source, "\n      error,\n", file);
   assertContains(

--- a/test/architecture/security/security-production-invariants.test.ts
+++ b/test/architecture/security/security-production-invariants.test.ts
@@ -476,7 +476,10 @@ test("errores internos se loguean, pero la respuesta 500 no expone detalles", ()
   const source = read(file);
 
   assertContains(source, "app.setErrorHandler((error, request, reply) => {", file);
-  assertContains(source, 'console.error("[API ERROR]"', file);
+  assertContains(source, 'logError("API_ERROR", {', file);
+  assertContains(source, "errorName: getFastifyErrorName(error)", file);
+  assertNotContains(source, 'console.error("[API ERROR]"', file);
+  assertNotContains(source, "\n      error,\n", file);
   assertContains(
     source,
     'error: status >= 500 ? "Error interno del servidor" : message',
@@ -500,13 +503,19 @@ test("logs de request sanitizan tokens y accesos públicos antes de escribir con
   assertContains(loggerSource, "[REDACTED]", loggerFile);
   assertContains(loggerSource, "token|reportAccessToken", loggerFile);
   assertContains(loggerSource, "RATE_LIMITED", loggerFile);
+  assertContains(loggerSource, "HTTP_REQUEST_COMPLETED", loggerFile);
 
+  // El access log ya no deriva ninguna dimension de la URL real: la unica
+  // dimension de ruta es el template Fastify normalizado.
   for (const file of authRouteFiles) {
     const source = read(file);
 
-    assertContains(source, "sanitizeUrlForLogs(request.url)", file);
-    assertContains(source, "url: safeUrl", file);
-    assertContains(source, "buildRequestLogLine({", file);
+    assertContains(source, "logRequestCompletion({", file);
+    assertContains(source, "routeTemplate: request.routeOptions?.url", file);
+    assertContains(source, "requestId: request.id", file);
+    assertNotContains(source, "console.log(", file);
+    assertNotContains(source, "sanitizeUrlForLogs", file);
+    assertNotContains(source, "url: safeUrl", file);
   }
 });
 

--- a/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
@@ -348,10 +348,14 @@ test("los handlers globales no registran el objeto Error crudo", () => {
   );
   assertContains(
     fastifyApp,
+    "...(requestId ? { requestId } : {}),",
+    "fastify error handler keeps requestId correlation",
+  );
+  assertContains(
+    fastifyApp,
     "routeTemplate: getFastifyRouteTemplate(request)",
     "fastify error handler route template",
   );
-  assertContains(fastifyApp, "getFastifyErrorSafeCode", "fastify safe code allowlist");
   assertNotContains(
     fastifyApp,
     "getFastifyErrorName",
@@ -374,14 +378,22 @@ test("los handlers globales no registran el objeto Error crudo", () => {
     "fastify error response path contract",
   );
 
-  // SAFE_ERROR_CODE_PATTERN es una regex sintactica para `code` (p. ej.
-  // SQLSTATE), deliberadamente distinta de la allowlist finita de nombres de
-  // Error: un `code` corto no es un nombre de clase y no exige lista cerrada.
-  assertContains(
+  // `error.code` se omite del todo del log: una regex sintactica sobre un
+  // `code` acepta identificadores con forma de PII (p. ej. "Paciente_307"), y
+  // no existe una allowlist cerrada de SQLSTATE/codigos de libreria que
+  // justifique mantener el campo. El contrato es ausencia total, no una lista
+  // parcial de valores "tecnicos" aceptados.
+  assertNotContains(
     fastifyApp,
     "SAFE_ERROR_CODE_PATTERN",
-    "fastify safe code pattern is distinct from error names",
+    "fastify must not keep a syntactic error-code pattern",
   );
+  assertNotContains(
+    fastifyApp,
+    "getFastifyErrorSafeCode",
+    "fastify must not derive a safeCode from error.code",
+  );
+  assertNotContains(fastifyApp, "safeCode", "fastify API_ERROR must omit safeCode");
   assertNotContains(
     fastifyApp,
     "SAFE_ERROR_NAME_PATTERN",
@@ -406,6 +418,7 @@ test("los handlers globales no registran el objeto Error crudo", () => {
     );
     assertNotContains(source, "path: request.url", `${file} raw url dimension`);
     assertNotContains(source, "sanitizeUrlForLogs", `${file} url log derivation`);
+    assertNotContains(source, "safeCode", `${file} must not derive safeCode`);
     assertNotContains(source, "error.name", `${file} direct error.name usage`);
   }
 });

--- a/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
@@ -11,6 +11,20 @@ const SENSITIVE_LOG_REDACTION_BOUNDARIES = {
     middleware: "server/middlewares/request-logger.ts",
     redactionMarker: "[REDACTED]",
   },
+  structuredLogger: {
+    module: "server/lib/logger.ts",
+    redactionEntrypoint: "redactLogValue",
+    textRedactionEntrypoint: "redactSensitiveText",
+    errorSerializer: "serializeError",
+  },
+  observabilityMetrics: {
+    module: "server/lib/observability-metrics.ts",
+    routeDimension: "buildRouteMetricsKey",
+  },
+  globalErrorHandlers: {
+    fastifyApp: "server/fastify-app.ts",
+    event: "API_ERROR",
+  },
   authSecrets: {
     sessionHash: "hashSessionToken",
     passwordVerifier: "verifyPassword",
@@ -83,6 +97,20 @@ test("sensitive log redaction matrix documents protected boundaries", () => {
       middleware: "server/middlewares/request-logger.ts",
       redactionMarker: "[REDACTED]",
     },
+    structuredLogger: {
+      module: "server/lib/logger.ts",
+      redactionEntrypoint: "redactLogValue",
+      textRedactionEntrypoint: "redactSensitiveText",
+      errorSerializer: "serializeError",
+    },
+    observabilityMetrics: {
+      module: "server/lib/observability-metrics.ts",
+      routeDimension: "buildRouteMetricsKey",
+    },
+    globalErrorHandlers: {
+      fastifyApp: "server/fastify-app.ts",
+      event: "API_ERROR",
+    },
     authSecrets: {
       sessionHash: "hashSessionToken",
       passwordVerifier: "verifyPassword",
@@ -108,8 +136,198 @@ test("request logger keeps token and query redaction centralized", () => {
   assertContains(requestLogger, "method", "request logger method");
   assertContains(requestLogger, "statusCode", "request logger status code");
   assertContains(logger, "console", "central logger console boundary");
+  assertContains(
+    requestLogger,
+    "logRequestCompletion",
+    "request logger structured emitter",
+  );
+  assertNotContains(requestLogger, "console.", "request logger console boundary");
+
+  // El contexto del access log es cerrado: sin path, url ni pathname reales.
+  const contextTypeStart = requestLogger.indexOf(
+    "export type RequestCompletionLogContext = {",
+  );
+
+  assert.notEqual(contextTypeStart, -1, "request logger context type");
+
+  const contextType = requestLogger.slice(
+    contextTypeStart,
+    requestLogger.indexOf("};", contextTypeStart),
+  );
+
+  assert.deepEqual(
+    contextType
+      .split("\n")
+      .map((line) => line.trim().split(":")[0])
+      .filter((name) => /^[a-zA-Z]+$/.test(name))
+      .sort(),
+    [
+      "durationMs",
+      "method",
+      "rateLimited",
+      "routeTemplate",
+      "statusClass",
+      "statusCode",
+    ],
+  );
+
+  assertNotContains(
+    requestLogger,
+    "sanitizeUrlForLogs(input.url",
+    "request logger url dimension",
+  );
+  assertContains(requestLogger, "UNMATCHED_ROUTE", "request logger route fallback");
+  assertContains(
+    requestLogger,
+    "routeTemplate: normalizeRouteTemplate(input.routeTemplate)",
+    "request logger route template normalization",
+  );
+
+  for (const file of [
+    "server/routes/admin-auth.fastify.ts",
+    "server/routes/auth.fastify.ts",
+    "server/routes/particular-auth.fastify.ts",
+    "server/routes/public-report-access.fastify.ts",
+    "server/routes/reports.fastify.ts",
+    "server/routes/study-tracking.fastify.ts",
+  ] as const) {
+    const source = readSource(file);
+
+    assertContains(source, "logRequestCompletion({", `${file} structured access log`);
+    assertContains(
+      source,
+      "routeTemplate: request.routeOptions?.url",
+      `${file} route template dimension`,
+    );
+    assertNotContains(source, "url: safeUrl", `${file} url dimension`);
+    assertNotContains(source, "sanitizeUrlForLogs", `${file} url log derivation`);
+  }
 
   assertNoDirectSecretLogging(requestLogger, "request logger middleware");
+});
+
+test("structured logger centraliza la redaccion y es el unico boundary de console migrado", () => {
+  const logger = readSource("server/lib/logger.ts");
+
+  for (const marker of [
+    "export function redactLogValue",
+    "export function redactSensitiveText",
+    "export function serializeError",
+    "export function isSensitiveLogKey",
+    "isSafeRequestId",
+    "[REDACTED]",
+  ]) {
+    assertContains(logger, marker, "structured logger redaction boundary");
+  }
+
+  for (const fragment of [
+    "authorization",
+    "cookie",
+    "password",
+    "secret",
+    "servicerole",
+    "apikey",
+    "token",
+    "session",
+    "signedurl",
+    "storagepath",
+    "databaseurl",
+    "connectionstring",
+  ]) {
+    assertContains(logger, `"${fragment}"`, "structured logger key matrix");
+  }
+
+  assertNotContains(logger, "error.stack", "structured logger stack export");
+  assertNoDirectSecretLogging(logger, "structured logger");
+
+  // Las rutas migradas emiten via logInfo/logError, no via console directo.
+  for (const file of [
+    "server/routes/admin-pricing.fastify.ts",
+    "server/routes/public-pricing.fastify.ts",
+  ] as const) {
+    const source = readSource(file);
+
+    assertContains(source, "logError(", `${file} structured error logging`);
+    assertContains(source, "errorName:", `${file} allowlisted error metadata`);
+    assertNotContains(source, "console.", `${file} console boundary`);
+    assertNotContains(source, "\n        error,\n", `${file} raw error payload`);
+  }
+});
+
+test("los handlers globales no registran el objeto Error crudo", () => {
+  const fastifyApp = readSource("server/fastify-app.ts");
+
+  assertContains(fastifyApp, 'logError("API_ERROR", {', "fastify error handler event");
+  assertContains(
+    fastifyApp,
+    "errorName: getFastifyErrorName(error)",
+    "fastify error handler allowlist",
+  );
+  assertContains(
+    fastifyApp,
+    "routeTemplate: getFastifyRouteTemplate(request)",
+    "fastify error handler route template",
+  );
+  assertContains(fastifyApp, "getFastifyErrorSafeCode", "fastify safe code allowlist");
+  assertNotContains(fastifyApp, "\n      error,\n", "fastify raw error payload");
+  assertNotContains(fastifyApp, "error.stack", "fastify stack export");
+  assertNotContains(fastifyApp, "console.", "fastify console boundary");
+  assertNotContains(
+    fastifyApp,
+    "path: getFastifyErrorResponsePath(request),\n      routeTemplate",
+    "fastify error log path dimension",
+  );
+  assertNoDirectSecretLogging(fastifyApp, "fastify app");
+
+  // El path sanitizado sigue siendo parte del body publico, no del log.
+  assertContains(
+    fastifyApp,
+    "path: getFastifyErrorResponsePath(request),",
+    "fastify error response path contract",
+  );
+
+  for (const file of [
+    "server/routes/admin-pricing.fastify.ts",
+    "server/routes/public-pricing.fastify.ts",
+  ] as const) {
+    const source = readSource(file);
+
+    assertContains(
+      source,
+      "routeTemplate: normalizeRouteTemplate(request.routeOptions?.url)",
+      `${file} route template dimension`,
+    );
+    assertNotContains(source, "path: request.url", `${file} raw url dimension`);
+    assertNotContains(source, "sanitizeUrlForLogs", `${file} url log derivation`);
+  }
+});
+
+test("las metricas de observabilidad no admiten labels prohibidas", () => {
+  const metrics = readSource("server/lib/observability-metrics.ts");
+
+  assertContains(metrics, "export function buildRouteMetricsKey", "metrics route key boundary");
+  assertContains(metrics, "UNMATCHED_ROUTE", "metrics unmatched route fallback");
+  assertContains(metrics, "MAX_ROUTE_TEMPLATE_LENGTH", "metrics route length bound");
+  assertContains(metrics, "routeKeyLimit", "metrics cardinality bound");
+  assertContains(metrics, "latencySampleLimit", "metrics latency buffer bound");
+
+  for (const forbidden of [
+    "clinicId",
+    "reportId",
+    "patientId",
+    "tutorId",
+    "email",
+    "sessionId",
+    "cookie",
+    "token",
+    "tenant",
+    "username",
+    "process.env",
+  ]) {
+    assertNotContains(metrics, forbidden, "metrics forbidden dimension");
+  }
+
+  assertNoDirectSecretLogging(metrics, "observability metrics");
 });
 
 test("auth routes hash session tokens and avoid logging raw credentials", () => {

--- a/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
@@ -240,6 +240,16 @@ test("structured logger centraliza la redaccion y es el unico boundary de consol
   assertNotContains(logger, "error.stack", "structured logger stack export");
   assertNoDirectSecretLogging(logger, "structured logger");
 
+  // El mensaje libre de un error nunca se exporta: una regex de credenciales no
+  // puede demostrar que no contiene datos clinicos, SQL o PII.
+  assertNotContains(logger, "error.message", "structured logger free-form message");
+  assertContains(
+    logger,
+    "messageSanitized: LOG_REDACTED_VALUE",
+    "structured logger closed error envelope",
+  );
+  assertContains(logger, "UnknownError", "structured logger non-Error envelope");
+
   // Las rutas migradas emiten via logInfo/logError, no via console directo.
   for (const file of [
     "server/routes/admin-pricing.fastify.ts",
@@ -248,9 +258,82 @@ test("structured logger centraliza la redaccion y es el unico boundary de consol
     const source = readSource(file);
 
     assertContains(source, "logError(", `${file} structured error logging`);
-    assertContains(source, "errorName:", `${file} allowlisted error metadata`);
+    assertContains(source, "requestId: request.id", `${file} error correlation`);
     assertNotContains(source, "console.", `${file} console boundary`);
     assertNotContains(source, "\n        error,\n", `${file} raw error payload`);
+
+    // El nombre del error pasa por la allowlist central del logger: un `name`
+    // manipulado no puede exportar PII, email ni SQL a traves del log.
+    assertContains(source, "serializeError", `${file} central error envelope`);
+    assertContains(
+      source,
+      "errorName: serializeError(error).name,",
+      `${file} allowlisted error name`,
+    );
+    assertNotContains(source, "getSafeErrorName", `${file} local error name helper`);
+    assertNotContains(source, "error.message", `${file} free-form error message`);
+    assertNotContains(source, "messageSanitized", `${file} error message export`);
+  }
+});
+
+test("las metricas finalizan cada request exactamente una vez", () => {
+  const metrics = readSource("server/lib/observability-metrics.ts");
+  const fastifyApp = readSource("server/fastify-app.ts");
+
+  for (const marker of [
+    "recordRequestAborted",
+    "createObservabilityRequestFinalizer",
+  ] as const) {
+    assertContains(metrics, marker, "metrics finalization boundary");
+  }
+
+  assertContains(
+    fastifyApp,
+    "createObservabilityRequestFinalizer",
+    "fastify finalization boundary",
+  );
+  assertContains(fastifyApp, "onRequestAbort", "fastify abort hook");
+  assertContains(
+    fastifyApp,
+    "finalizer.recordAborted()",
+    "fastify abort finalization",
+  );
+  assertNotContains(
+    fastifyApp,
+    "metricsRegistry.recordRequestAborted(",
+    "fastify direct abort bypassing the finalizer",
+  );
+  assertContains(
+    fastifyApp,
+    "state.finalizer.recordCompleted({",
+    "fastify once-only completion",
+  );
+  assertNotContains(
+    fastifyApp,
+    "metricsRegistry.recordRequestCompleted(",
+    "fastify direct completion bypassing the finalizer",
+  );
+
+  // Un aborto libera in-flight sin inventar un status code ni una latencia.
+  const abortedStart = metrics.indexOf("recordRequestAborted() {");
+
+  assert.notEqual(abortedStart, -1, "metrics aborted recorder");
+
+  const abortedBody = metrics.slice(
+    abortedStart,
+    metrics.indexOf("},", abortedStart),
+  );
+
+  for (const forbidden of [
+    "requestsCompletedTotal",
+    "responsesByStatusClass",
+    "serverErrors5xxTotal",
+    "rateLimitedResponsesTotal",
+    "pushBoundedSample",
+    "resolveRouteBucket",
+    "499",
+  ]) {
+    assertNotContains(abortedBody, forbidden, "metrics aborted recorder scope");
   }
 });
 

--- a/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
@@ -343,8 +343,8 @@ test("los handlers globales no registran el objeto Error crudo", () => {
   assertContains(fastifyApp, 'logError("API_ERROR", {', "fastify error handler event");
   assertContains(
     fastifyApp,
-    "errorName: getFastifyErrorName(error)",
-    "fastify error handler allowlist",
+    "errorName: serializeError(error).name",
+    "fastify error handler central allowlist",
   );
   assertContains(
     fastifyApp,
@@ -352,6 +352,11 @@ test("los handlers globales no registran el objeto Error crudo", () => {
     "fastify error handler route template",
   );
   assertContains(fastifyApp, "getFastifyErrorSafeCode", "fastify safe code allowlist");
+  assertNotContains(
+    fastifyApp,
+    "getFastifyErrorName",
+    "fastify local error name helper",
+  );
   assertNotContains(fastifyApp, "\n      error,\n", "fastify raw error payload");
   assertNotContains(fastifyApp, "error.stack", "fastify stack export");
   assertNotContains(fastifyApp, "console.", "fastify console boundary");
@@ -369,6 +374,20 @@ test("los handlers globales no registran el objeto Error crudo", () => {
     "fastify error response path contract",
   );
 
+  // SAFE_ERROR_CODE_PATTERN es una regex sintactica para `code` (p. ej.
+  // SQLSTATE), deliberadamente distinta de la allowlist finita de nombres de
+  // Error: un `code` corto no es un nombre de clase y no exige lista cerrada.
+  assertContains(
+    fastifyApp,
+    "SAFE_ERROR_CODE_PATTERN",
+    "fastify safe code pattern is distinct from error names",
+  );
+  assertNotContains(
+    fastifyApp,
+    "SAFE_ERROR_NAME_PATTERN",
+    "fastify must not keep a syntactic error-name pattern",
+  );
+
   for (const file of [
     "server/routes/admin-pricing.fastify.ts",
     "server/routes/public-pricing.fastify.ts",
@@ -380,8 +399,57 @@ test("los handlers globales no registran el objeto Error crudo", () => {
       "routeTemplate: normalizeRouteTemplate(request.routeOptions?.url)",
       `${file} route template dimension`,
     );
+    assertContains(
+      source,
+      "errorName: serializeError(error).name,",
+      `${file} allowlisted error name`,
+    );
     assertNotContains(source, "path: request.url", `${file} raw url dimension`);
     assertNotContains(source, "sanitizeUrlForLogs", `${file} url log derivation`);
+    assertNotContains(source, "error.name", `${file} direct error.name usage`);
+  }
+});
+
+test("serializeError usa una allowlist finita de nombres, no una regex sintactica", () => {
+  const logger = readSource("server/lib/logger.ts");
+
+  assertNotContains(
+    logger,
+    "SAFE_ERROR_NAME_PATTERN",
+    "logger must not keep the syntactic error-name pattern",
+  );
+  assertContains(logger, "SAFE_ERROR_NAMES", "logger finite error-name allowlist");
+
+  for (const builtin of [
+    "Error",
+    "TypeError",
+    "RangeError",
+    "ReferenceError",
+    "SyntaxError",
+    "URIError",
+    "EvalError",
+    "AggregateError",
+  ] as const) {
+    assertContains(
+      logger,
+      `"${builtin}"`,
+      `logger allowlist must include native error class ${builtin}`,
+    );
+  }
+
+  // Nombres custom de librerias/frameworks nunca deben sumarse a la allowlist:
+  // deben degradar a "Error" via serializeError, no listarse como seguros.
+  for (const disallowed of [
+    "ZodError",
+    "PostgresError",
+    "FastifyError",
+    "ValidationError",
+  ] as const) {
+    assertNotContains(
+      logger,
+      `"${disallowed}"`,
+      `logger allowlist must not include library-specific name ${disallowed}`,
+    );
   }
 });
 

--- a/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
+++ b/test/architecture/security/security-sensitive-log-redaction-boundaries.test.ts
@@ -679,3 +679,62 @@ test("sensitive log redaction guardrail source stays ascii only", () => {
     );
   }
 });
+
+test("request ids solo aceptan UUID v4 antes de llegar a logs", () => {
+  const requestIdSource = readSource(
+    "server/lib/http/api-request-id.ts",
+  );
+  const loggerSource = readSource("server/lib/logger.ts");
+
+  assertContains(
+    requestIdSource,
+    "API_REQUEST_ID_UUID_V4_PATTERN",
+    "request id UUID v4 boundary",
+  );
+  assertContains(
+    requestIdSource,
+    "value.length === API_REQUEST_ID_MAX_LENGTH",
+    "request id exact UUID length",
+  );
+  assertContains(
+    requestIdSource,
+    "randomUUID()",
+    "server-generated request id",
+  );
+  assertNotContains(
+    requestIdSource,
+    "API_REQUEST_ID_ALLOWED_CHARACTERS",
+    "request id character-only allowlist",
+  );
+
+  assertContains(
+    loggerSource,
+    "isSafeRequestId(requestId)",
+    "logger request id promotion boundary",
+  );
+});
+
+test("sensitive log keys no permiten bypass por sufijos Id o Count", () => {
+  const logger = readSource("server/lib/logger.ts");
+
+  assertNotContains(
+    logger,
+    'endsWith("tokenid")',
+    "logger tokenId suffix bypass",
+  );
+  assertNotContains(
+    logger,
+    'endsWith("count")',
+    "logger count suffix bypass",
+  );
+  assertNotContains(
+    logger,
+    "function isSafeLogKey",
+    "logger broad safe-key bypass",
+  );
+  assertContains(
+    logger,
+    "SENSITIVE_KEY_FRAGMENTS.some",
+    "logger sensitive fragment boundary",
+  );
+});

--- a/test/architecture/study-tracking-admin-thin-route.test.ts
+++ b/test/architecture/study-tracking-admin-thin-route.test.ts
@@ -375,11 +375,11 @@ test("M32b composición admin selecciona sólo el barrel de infrastructure", () 
 test("M44 preserva rutas M32 y realinea sólo el specifier Particular Access", () => {
   assert.equal(
     digest(clinicRouteFile),
-    "aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7",
+    "f417f341b488cf0fc15a7e932defcc28be4fdcb0ab13659aadaf4cae226382a8",
   );
   assert.equal(
     digest(particularRouteFile),
-    "88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa",
+    "24c6fa65a94def117e8e155ef1d14672409ac42ed2452e62667763b79ce5cc72",
   );
 });
 

--- a/test/architecture/study-tracking-clinic-particular-thin-routes.test.ts
+++ b/test/architecture/study-tracking-clinic-particular-thin-routes.test.ts
@@ -257,12 +257,12 @@ test("M44 preserva rutas M32 y realinea sólo el specifier Particular Access", (
     createHash("sha256")
       .update(readFileSync(resolve(repoRoot, clinicRoute)))
       .digest("hex"),
-    "aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7",
+    "f417f341b488cf0fc15a7e932defcc28be4fdcb0ab13659aadaf4cae226382a8",
   );
   assert.equal(
     createHash("sha256")
       .update(readFileSync(resolve(repoRoot, particularRoute)))
       .digest("hex"),
-    "88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa",
+    "24c6fa65a94def117e8e155ef1d14672409ac42ed2452e62667763b79ce5cc72",
   );
 });

--- a/test/architecture/study-tracking-phase-closeout.test.ts
+++ b/test/architecture/study-tracking-phase-closeout.test.ts
@@ -22,9 +22,9 @@ const routes = {
 } as const;
 
 const routeHashes = new Map<string, string>([
-  [routes.clinic, "aeacf4866ffa9a70d1ee867cd652f49e35b5bb86709fa4b3003d95c178078ae7"],
-  [routes.particular, "88d6cd63bb808fbb6d613aea60fcf9fae25c2681f8679c3acc3c3d3ad16501aa"],
-  [routes.admin, "4454a06d394f6d377eedfb1420bc2e3a6e8e651096d3a230c2cd809db0dcb6de"],
+  [routes.clinic, "f417f341b488cf0fc15a7e932defcc28be4fdcb0ab13659aadaf4cae226382a8"],
+  [routes.particular, "24c6fa65a94def117e8e155ef1d14672409ac42ed2452e62667763b79ce5cc72"],
+  [routes.admin, "eb11f9b1508edd16d5ec3b7353dcfc29ca70963ee9427735eef40857bd0dac79"],
 ]);
 
 const expectedFeatureFiles = [

--- a/test/helpers/api-request-id-contract.ts
+++ b/test/helpers/api-request-id-contract.ts
@@ -167,6 +167,8 @@ export function assertApiErrorLogRequestId(
     "detail",
     "cookie",
     "message",
+    "code",
+    "safeCode",
   ]) {
     assert.equal(
       forbiddenKey in loggedContext,
@@ -180,7 +182,6 @@ export function assertApiErrorLogRequestId(
     "routeTemplate",
     "status",
     "errorName",
-    "safeCode",
   ]);
 
   for (const key of Object.keys(loggedContext)) {

--- a/test/helpers/api-request-id-contract.ts
+++ b/test/helpers/api-request-id-contract.ts
@@ -115,28 +115,84 @@ export function assertApiErrorLogRequestId(
   const call = consoleCalls[index];
 
   assert.ok(call, `${label} debe registrar log de error API`);
-  assert.equal(call[0], "[API ERROR]");
-
-  const payload = call[1];
-
   assert.equal(
-    payload !== null && typeof payload === "object" && !Array.isArray(payload),
-    true,
-    `${label} debe registrar payload de log estructurado`,
+    call.length,
+    1,
+    `${label} debe registrar una sola linea JSON estructurada`,
   );
+  assert.equal(typeof call[0], "string");
 
-  const loggedPayload = payload as Record<string, unknown>;
+  let logEvent: Record<string, unknown>;
+
+  try {
+    logEvent = JSON.parse(call[0] as string) as Record<string, unknown>;
+  } catch {
+    throw new Error(`${label} debe registrar JSON parseable`);
+  }
+
+  assert.equal(logEvent.event, "API_ERROR");
+  assert.equal(logEvent.level, "error");
+  assert.equal(typeof logEvent.timestamp, "string");
 
   assert.equal(
-    loggedPayload.requestId,
+    logEvent.requestId,
     expectedRequestId,
     `${label} debe registrar el mismo requestId del header/body`,
   );
   assert.equal(
-    isSafeRequestId(loggedPayload.requestId),
+    isSafeRequestId(logEvent.requestId),
     true,
     `${label} debe registrar requestId seguro`,
   );
 
-  return loggedPayload;
+  const context = logEvent.context;
+
+  assert.equal(
+    context !== null && typeof context === "object" && !Array.isArray(context),
+    true,
+    `${label} debe registrar contexto estructurado`,
+  );
+
+  const loggedContext = context as Record<string, unknown>;
+
+  for (const forbiddenKey of [
+    "stack",
+    "error",
+    "path",
+    "url",
+    "originalUrl",
+    "rawUrl",
+    "pathname",
+    "query",
+    "detail",
+    "cookie",
+    "message",
+  ]) {
+    assert.equal(
+      forbiddenKey in loggedContext,
+      false,
+      `${label} no debe registrar ${forbiddenKey} en API_ERROR`,
+    );
+  }
+
+  const allowedKeys = new Set([
+    "method",
+    "routeTemplate",
+    "status",
+    "errorName",
+    "safeCode",
+  ]);
+
+  for (const key of Object.keys(loggedContext)) {
+    assert.equal(
+      allowedKeys.has(key),
+      true,
+      `${label} registró metadata fuera de la allowlist: ${key}`,
+    );
+  }
+
+  return {
+    ...loggedContext,
+    requestId: logEvent.requestId,
+  } as Record<string, unknown>;
 }

--- a/test/integration/adapters/controllers/admin-system-health.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-system-health.fastify.test.ts
@@ -340,3 +340,226 @@ test("CORS: origin no permitido en system-health no recibe access-control-allow-
     await app.close();
   }
 });
+
+const METRICS_SNAPSHOT_FIXTURE = {
+  startedAt: "2026-07-31T00:00:00.000Z",
+  uptimeSeconds: 3600,
+  requestsStartedTotal: 12,
+  requestsCompletedTotal: 12,
+  inFlightRequests: 0,
+  responsesByStatusClass: {
+    "1xx": 0,
+    "2xx": 9,
+    "3xx": 0,
+    "4xx": 2,
+    "5xx": 1,
+  },
+  serverErrors5xxTotal: 1,
+  serverErrorRate: 0.0833,
+  rateLimitedResponsesTotal: 1,
+  latencyMs: {
+    count: 12,
+    min: 1,
+    max: 120,
+    average: 22.5,
+    p50: 15,
+    p95: 110,
+    p99: 120,
+  },
+  routes: [
+    {
+      route: "GET /api/admin/system/health",
+      count: 6,
+      serverErrors5xx: 0,
+      p50: 12,
+      p95: 30,
+    },
+  ],
+  routeKeysTracked: 1,
+  routeKeyLimitReached: false,
+  latencySampleLimit: 1024,
+} as const;
+
+function buildMetricsDeps(overrides: Record<string, unknown> = {}) {
+  return buildHealthDeps({
+    getObservabilityMetricsSnapshot: () => METRICS_SNAPSHOT_FIXTURE,
+    ...overrides,
+  });
+}
+
+test("admin metrics requiere sesión admin", async () => {
+  const app = Fastify();
+
+  await app.register(
+    adminSystemHealthNativeRoutes,
+    buildMetricsDeps({ getAdminSessionByToken: async () => null }),
+  );
+
+  try {
+    const response = await app.inject({ method: "GET", url: "/metrics" });
+
+    assert.equal(response.statusCode, 401);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: false,
+      error: "Admin no autenticado",
+    });
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin metrics devuelve el snapshot sanitizado para admin autenticado", async () => {
+  const app = Fastify();
+
+  await app.register(adminSystemHealthNativeRoutes, buildMetricsDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/metrics",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      metrics: METRICS_SNAPSHOT_FIXTURE,
+    });
+
+    for (const forbidden of [
+      "admin-session-token",
+      "hash:",
+      "cookie",
+      "password",
+      "clinicId",
+      "reportId",
+      "@",
+      "VETNEB",
+      "SUPABASE",
+      "postgres",
+      "C:\\",
+    ]) {
+      assert.equal(
+        response.body.includes(forbidden),
+        false,
+        `metrics no debe exponer ${forbidden}`,
+      );
+    }
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin metrics sólo acepta GET y OPTIONS", async () => {
+  const app = Fastify();
+
+  await app.register(adminSystemHealthNativeRoutes, buildMetricsDeps());
+
+  try {
+    const postResponse = await app.inject({
+      method: "POST",
+      url: "/metrics",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(postResponse.statusCode, 404);
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: preflight OPTIONS /metrics devuelve 204 con la política de system-health", async () => {
+  const app = Fastify();
+
+  await app.register(adminSystemHealthNativeRoutes, buildMetricsDeps());
+
+  try {
+    const response = await app.inject({
+      method: "OPTIONS",
+      url: "/metrics",
+      headers: {
+        origin: STAGING_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "content-type",
+      },
+    });
+
+    assert.equal(response.statusCode, 204);
+    assert.equal(response.body, "");
+    assert.equal(
+      response.headers["access-control-allow-origin"],
+      STAGING_ORIGIN,
+    );
+    assert.equal(response.headers["access-control-allow-credentials"], "true");
+    assert.equal(
+      response.headers["access-control-allow-methods"],
+      "GET,OPTIONS",
+    );
+  } finally {
+    await app.close();
+  }
+});
+
+test("CORS: origin no permitido en /metrics no recibe access-control-allow-origin", async () => {
+  const app = Fastify();
+
+  await app.register(adminSystemHealthNativeRoutes, buildMetricsDeps());
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/metrics",
+      headers: {
+        origin: "https://atacante.example",
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.equal(response.headers["access-control-allow-origin"], undefined);
+
+    const preflight = await app.inject({
+      method: "OPTIONS",
+      url: "/metrics",
+      headers: {
+        origin: "https://atacante.example",
+        "access-control-request-method": "GET",
+      },
+    });
+
+    assert.equal(preflight.statusCode, 403);
+    assert.equal(preflight.headers["access-control-allow-origin"], undefined);
+  } finally {
+    await app.close();
+  }
+});
+
+test("admin metrics hereda no-store en la app integrada", async () => {
+  const { createFastifyApp } = await import("../../../../server/fastify-app.ts");
+  const app = await createFastifyApp({
+    adminSystemHealthRoutes: buildMetricsDeps(),
+  });
+
+  try {
+    const response = await app.inject({
+      method: "GET",
+      url: "/api/admin/system/health/metrics",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+    assert.match(String(response.headers["cache-control"]), /no-store/);
+    assert.deepEqual(JSON.parse(response.body), {
+      success: true,
+      metrics: METRICS_SNAPSHOT_FIXTURE,
+    });
+  } finally {
+    await app.close();
+  }
+});

--- a/test/integration/adapters/controllers/api-request-id-observability-contract.test.ts
+++ b/test/integration/adapters/controllers/api-request-id-observability-contract.test.ts
@@ -224,8 +224,13 @@ test(
         "genericError",
       );
       assert.equal(genericLogPayload.method, "POST");
-      assert.equal(genericLogPayload.path, "/api/__contract/internal-error");
+      assert.equal(
+        genericLogPayload.routeTemplate,
+        "/api/__contract/internal-error",
+      );
       assert.equal(genericLogPayload.status, 500);
+      assert.equal("path" in genericLogPayload, false);
+      assert.equal("url" in genericLogPayload, false);
 
       const validIncomingRequestId = "client-req_123.abc:456";
       const validIncomingError = await app.inject({

--- a/test/integration/adapters/controllers/api-request-id-observability-contract.test.ts
+++ b/test/integration/adapters/controllers/api-request-id-observability-contract.test.ts
@@ -232,7 +232,8 @@ test(
       assert.equal("path" in genericLogPayload, false);
       assert.equal("url" in genericLogPayload, false);
 
-      const validIncomingRequestId = "client-req_123.abc:456";
+      const validIncomingRequestId =
+        "123e4567-e89b-42d3-a456-426614174000";
       const validIncomingError = await app.inject({
         method: "GET",
         url: "/api/__contract/internal-error",
@@ -255,8 +256,12 @@ test(
         "validIncomingError",
       );
 
-      const invalidIncomingRequestId =
-        "bad id;Authorization=Bearer secret-dangerous-token";
+      const invalidIncomingRequestId = [
+        "sess",
+        "opaque",
+        "fixture",
+        "abc123",
+      ].join("_");
       const invalidIncomingError = await app.inject({
         method: "GET",
         url: "/api/__contract/internal-error",
@@ -272,6 +277,10 @@ test(
 
       assert.notEqual(invalidIncomingHeaderId, invalidIncomingRequestId);
       assert.equal(invalidIncomingBody.requestId, invalidIncomingHeaderId);
+      assert.match(
+        invalidIncomingHeaderId,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
       assertApiErrorLogRequestId(
         consoleErrorCalls,
         2,

--- a/test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts
+++ b/test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts
@@ -70,24 +70,52 @@ function assertSingleLogLine(logs: string[]) {
   return logs[0];
 }
 
+function parseRequestLogEvent(line: string) {
+  const logEvent = JSON.parse(line) as {
+    timestamp: string;
+    level: string;
+    event: string;
+    requestId?: string;
+    context: Record<string, unknown>;
+  };
+
+  assert.equal(logEvent.event, "HTTP_REQUEST_COMPLETED");
+  assert.equal(logEvent.level, "info");
+  assert.match(logEvent.timestamp, /^\d{4}-\d{2}-\d{2}T.*Z$/);
+
+  return logEvent;
+}
+
 function assertRequestLogShape(
   line: string,
   expected: {
     method: string;
-    path: string;
+    routeTemplate: string;
     status: number;
     rateLimited?: boolean;
   },
 ) {
-  assert.match(
-    line,
-    new RegExp(
-      String.raw`^\[\d{4}-\d{2}-\d{2}T.*Z\] ${expected.method} ${expected.path.replace(
-        /[.*+?^${}()|[\]\\]/g,
-        "\\$&",
-      )} ${expected.status} \d+\.\dms${expected.rateLimited ? " RATE_LIMITED" : ""}$`,
-    ),
-  );
+  const { context } = parseRequestLogEvent(line);
+
+  assert.equal(context.method, expected.method);
+  assert.equal(context.routeTemplate, expected.routeTemplate);
+  assert.equal(context.statusCode, expected.status);
+  assert.equal(context.rateLimited, expected.rateLimited ?? false);
+  assert.equal(typeof context.durationMs, "number");
+
+  // Contexto cerrado: ninguna dimension derivada de la URL real.
+  assert.deepEqual(Object.keys(context).sort(), [
+    "durationMs",
+    "method",
+    "rateLimited",
+    "routeTemplate",
+    "statusClass",
+    "statusCode",
+  ]);
+  assert.equal("path" in context, false);
+  assert.equal("url" in context, false);
+
+  return context;
 }
 
 test("public professionals logging registra search y detail con método path status y duración", async () => {
@@ -113,16 +141,27 @@ test("public professionals logging registra search y detail con método path sta
     assert.equal(searchCapture.result.statusCode, 200);
     assertRequestLogShape(assertSingleLogLine(searchCapture.logs), {
       method: "GET",
-      path: "/api/public/professionals/search?q=histo",
+      routeTemplate: "/api/public/professionals/search",
       status: 200,
     });
 
     assert.equal(detailCapture.result.statusCode, 200);
-    assertRequestLogShape(assertSingleLogLine(detailCapture.logs), {
+    const detailLine = assertSingleLogLine(detailCapture.logs);
+    const detailContext = assertRequestLogShape(detailLine, {
       method: "GET",
-      path: "/api/public/professionals/130",
+      routeTemplate: "/api/public/professionals/:clinicId",
       status: 200,
     });
+
+    // El clinicId real (130) nunca entra al log: sólo el template.
+    assert.equal(detailLine.includes("130"), false);
+    assert.equal(JSON.stringify(detailContext).includes("130"), false);
+
+    // El evento siempre lleva un requestId para correlacionar.
+    assert.equal(
+      typeof parseRequestLogEvent(detailLine).requestId,
+      "string",
+    );
   } finally {
     await app.close();
   }
@@ -144,10 +183,13 @@ test("public professionals logging sanitiza token y reportAccessToken en query p
 
     const line = assertSingleLogLine(capture.logs);
 
-    assert.match(
-      line,
-      /^\[\d{4}-\d{2}-\d{2}T.*Z\] GET \/api\/public\/professionals\/search\?q=histo&token=\[REDACTED\]&reportAccessToken=\[REDACTED\] 200 \d+\.\dms$/,
-    );
+    assertRequestLogShape(line, {
+      method: "GET",
+      routeTemplate: "/api/public/professionals/search",
+      status: 200,
+    });
+    assert.equal(line.includes("q=histo"), false);
+    assert.equal(line.includes("REDACTED"), false);
     assert.equal(line.includes("super-secret-token"), false);
     assert.equal(line.includes("another-secret"), false);
   } finally {
@@ -194,7 +236,7 @@ test("public professionals logging marca RATE_LIMITED en respuestas 429 de searc
     assert.equal(searchLimitedCapture.result.statusCode, 429);
     assertRequestLogShape(assertSingleLogLine(searchLimitedCapture.logs), {
       method: "GET",
-      path: "/api/public/professionals/search",
+      routeTemplate: "/api/public/professionals/search",
       status: 429,
       rateLimited: true,
     });
@@ -202,7 +244,7 @@ test("public professionals logging marca RATE_LIMITED en respuestas 429 de searc
     assert.equal(detailLimitedCapture.result.statusCode, 429);
     assertRequestLogShape(assertSingleLogLine(detailLimitedCapture.logs), {
       method: "GET",
-      path: "/api/public/professionals/130",
+      routeTemplate: "/api/public/professionals/:clinicId",
       status: 429,
       rateLimited: true,
     });
@@ -233,10 +275,11 @@ test("public professionals logging no expone datos internos de helpers en errore
 
     const line = assertSingleLogLine(capture.logs);
 
-    assert.match(
-      line,
-      /^\[\d{4}-\d{2}-\d{2}T.*Z\] GET \/api\/public\/professionals\/search\?token=\[REDACTED\] 500 \d+\.\dms$/,
-    );
+    assertRequestLogShape(line, {
+      method: "GET",
+      routeTemplate: "/api/public/professionals/search",
+      status: 500,
+    });
     assert.equal(line.includes("db-password"), false);
     assert.equal(line.includes("very-secret"), false);
     assert.equal(line.includes("raw-secret"), false);
@@ -265,10 +308,11 @@ test("public professionals logging registra CORS bloqueado sin headers ni payloa
 
     const line = assertSingleLogLine(capture.logs);
 
-    assert.match(
-      line,
-      /^\[\d{4}-\d{2}-\d{2}T.*Z\] GET \/api\/public\/professionals\/search\?token=\[REDACTED\] 403 \d+\.\dms$/,
-    );
+    assertRequestLogShape(line, {
+      method: "GET",
+      routeTemplate: "/api/public/professionals/search",
+      status: 403,
+    });
     assert.equal(line.includes("blocked-origin-secret"), false);
     assert.equal(line.includes("https://blocked.example"), false);
     assert.equal(line.includes("Origin no permitido"), false);

--- a/test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts
+++ b/test/integration/adapters/controllers/public-professionals-logging-invariants.test.ts
@@ -8,6 +8,7 @@ import {
   buildPublicProfessionalsRouteFixtureStubs,
   type PublicProfessionalsRouteFixtureStubs,
 } from "../../../mocks/public-professionals-route.ts";
+import { generateFastifyRequestId } from "../../../../server/lib/http/api-request-id.ts";
 
 process.env.NODE_ENV ??= "development";
 process.env.SUPABASE_URL ??= "https://example.supabase.co";
@@ -25,6 +26,7 @@ async function buildLoggingApp(
 ) {
   const app = Fastify({
     logger: false,
+    genReqId: generateFastifyRequestId,
   });
 
   await app.register(publicProfessionalsNativeRoutes, {

--- a/test/integration/app/fastify-app.test.ts
+++ b/test/integration/app/fastify-app.test.ts
@@ -1685,7 +1685,7 @@ test(
       assert.equal("path" in genericLogPayload, false);
       assert.equal("url" in genericLogPayload, false);
 
-      const validIncomingRequestId = "client-req_123.abc:456";
+      const validIncomingRequestId = "123e4567-e89b-42d3-a456-426614174000";
       const validIncomingError = await app.inject({
         method: "GET",
         url: "/api/__test/internal-error",
@@ -1708,7 +1708,12 @@ test(
         "validIncomingError",
       );
 
-      const invalidIncomingRequestId = "client request id";
+      const invalidIncomingRequestId = [
+        "sess",
+        "opaque",
+        "fixture",
+        "abc123",
+      ].join("_");
       const invalidIncomingError = await app.inject({
         method: "GET",
         url: "/api/__test/internal-error",
@@ -1724,6 +1729,10 @@ test(
 
       assert.notEqual(invalidRequestId, invalidIncomingRequestId);
       assert.equal(invalidIncomingBody.requestId, invalidRequestId);
+      assert.match(
+        invalidRequestId,
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i,
+      );
       assertApiErrorLogRequestId(
         consoleErrorCalls,
         2,
@@ -2116,7 +2125,7 @@ test(
         method: "GET",
         url: "/api/health",
         headers: {
-          "x-request-id": "client-req_123.abc:456",
+          "x-request-id": "123e4567-e89b-42d3-a456-426614174000",
         },
       });
 
@@ -2161,7 +2170,7 @@ test(
 
       assert.equal(
         apiHealthWithValidRequestId.headers["x-request-id"],
-        "client-req_123.abc:456",
+        "123e4567-e89b-42d3-a456-426614174000",
       );
       const replacementRequestId = assertRequestIdHeader(
         apiHealthWithInvalidRequestId,
@@ -2777,7 +2786,7 @@ test(
     };
 
     try {
-      const incomingRequestId = "client-req_correlation.1:2";
+      const incomingRequestId = "423e4567-e89b-42d3-a456-426614174003";
       const response = await app.inject({
         method: "GET",
         url: "/api/admin/audit-log?limit=25&token=raw-secret",

--- a/test/integration/app/fastify-app.test.ts
+++ b/test/integration/app/fastify-app.test.ts
@@ -2432,6 +2432,9 @@ test(
       recordRequestCompleted() {
         throw new Error("metrics complete failure");
       },
+      recordRequestAborted() {
+        throw new Error("metrics abort failure");
+      },
       getSnapshot() {
         throw new Error("metrics snapshot failure");
       },
@@ -2512,8 +2515,19 @@ test(
 
       assertRequestIdHeader(ok, "okConIds");
 
-      const serializedLogs = consoleLogCalls
+      // Se inspeccionan las dimensiones string deterministas: requestId es un
+      // UUID y durationMs un float, de modo que incluirlos en un scan de
+      // substrings volveria el assert dependiente del azar.
+      const loggedDimensions = consoleLogCalls
         .map((call) => String(call[0]))
+        .map((line) => JSON.parse(line) as { context: Record<string, unknown> })
+        .map(({ context }) =>
+          JSON.stringify({
+            method: context.method,
+            routeTemplate: context.routeTemplate,
+            statusClass: context.statusClass,
+          }),
+        )
         .join("\n");
 
       for (const leaked of [
@@ -2523,9 +2537,11 @@ test(
         "raw-secret",
         "no-existe",
         "REDACTED",
+        "path",
+        "url",
       ]) {
         assert.equal(
-          serializedLogs.includes(leaked),
+          loggedDimensions.includes(leaked),
           false,
           `los access logs no deben conservar ${leaked}`,
         );
@@ -2541,7 +2557,9 @@ test(
         "GET UNMATCHED_ROUTE",
       ]);
 
-      const serializedSnapshot = JSON.stringify(snapshot);
+      // Las route keys son la unica dimension libre del snapshot; el resto son
+      // contadores y latencias numericas.
+      const serializedRouteKeys = JSON.stringify(routeKeys);
 
       for (const leaked of [
         "307",
@@ -2554,7 +2572,7 @@ test(
         "?",
       ]) {
         assert.equal(
-          serializedSnapshot.includes(leaked),
+          serializedRouteKeys.includes(leaked),
           false,
           `las metricas no deben conservar ${leaked}`,
         );
@@ -2568,10 +2586,11 @@ test(
       );
 
       assert.equal(errorLog.routeTemplate, "/api/__ids/clinics/:clinicId/boom");
-      assert.equal(
-        serializeConsoleCalls(consoleErrorCalls).includes("307"),
-        false,
-      );
+
+      const { requestId: loggedRequestId, ...errorLogDimensions } = errorLog;
+
+      assert.equal(typeof loggedRequestId, "string");
+      assert.equal(JSON.stringify(errorLogDimensions).includes("307"), false);
       assert.equal(
         serializeConsoleCalls(consoleErrorCalls).includes(
           "detalle interno sensible",
@@ -2640,6 +2659,278 @@ test(
       assert.equal((accessLogLine as string).includes("REDACTED"), false);
     } finally {
       console.log = originalConsoleLog;
+      await app.close();
+    }
+  },
+);
+
+test(
+  "los errores de pricing se correlacionan con X-Request-ID sin metadata extra",
+  async () => {
+    // El name viene manipulado a proposito: sin allowlist, un Error construido
+    // por una libreria o por datos externos filtraria PII al log.
+    const sensitiveErrorMessage =
+      "Paciente Maria Gomez biopsia con celulas atipicas tutor@example.com";
+    const listFailure = () => {
+      const failure = new Error(sensitiveErrorMessage);
+
+      failure.name = "Postgres Error usuario@example.com";
+
+      throw failure;
+    };
+
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      adminPricingRoutes: {
+        deleteAdminSession: async () => {},
+        getAdminSessionByToken: async () => ({
+          id: 1,
+          adminUserId: 1,
+          expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+        }),
+        getAdminUserById: async () => ({ id: 1, username: "VETNEB" }),
+        updateAdminSessionLastAccess: async () => {},
+        hashSessionToken: (token: string) => `hash:${token}`,
+        listAdminPricingItems: listFailure,
+        updatePricingItem: listFailure,
+        writeAuditLog: async () => {},
+      },
+      publicPricingRoutes: {
+        listPublicPricingItems: listFailure,
+      },
+    });
+
+    const { invalidatePublicPricingCache } = await import(
+      "../../../server/features/pricing/admin-pricing-service.ts"
+    );
+
+    // El listado publico se sirve con read-through cache: sin invalidarla, una
+    // suite previa del mismo proceso puede devolver 200 desde memoria.
+    invalidatePublicPricingCache();
+
+    const originalConsoleError = console.error;
+    const consoleErrorCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
+
+    try {
+      const adminCookie = `${ENV.adminCookieName}=admin-session-value`;
+      const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
+
+      const cases = [
+        {
+          label: "ADMIN_PRICING_LIST_ERROR",
+          routeTemplate: "/api/admin/pricing",
+          response: await app.inject({
+            method: "GET",
+            url: "/api/admin/pricing",
+            headers: { cookie: adminCookie },
+          }),
+          expectedBody: {
+            success: false,
+            error: "No se pudieron cargar los precios administrables.",
+          },
+        },
+        {
+          label: "ADMIN_PRICING_PATCH_ERROR",
+          routeTemplate: "/api/admin/pricing/:id",
+          response: await app.inject({
+            method: "PATCH",
+            url: "/api/admin/pricing/4821",
+            headers: { cookie: adminCookie, origin: allowedOrigin },
+            payload: { isActive: false },
+          }),
+          expectedBody: {
+            success: false,
+            error: "No se pudieron guardar los cambios de precio.",
+          },
+        },
+        {
+          label: "PUBLIC_PRICING_LIST_ERROR",
+          routeTemplate: "/api/public/pricing",
+          response: await app.inject({
+            method: "GET",
+            url: "/api/public/pricing",
+          }),
+          expectedBody: {
+            success: false,
+            error: "Error interno del servidor",
+          },
+        },
+      ];
+
+      const logLines = consoleErrorCalls.map((call) => String(call[0]));
+
+      for (const testCase of cases) {
+        assert.equal(testCase.response.statusCode, 500, testCase.label);
+
+        const headerRequestId = assertRequestIdHeader(
+          testCase.response,
+          testCase.label,
+        );
+
+        assert.deepEqual(JSON.parse(testCase.response.body), {
+          ...testCase.expectedBody,
+          requestId: headerRequestId,
+        });
+
+        const logLine = logLines.find((line) =>
+          line.includes(`"event":"${testCase.label}"`),
+        );
+
+        assert.equal(typeof logLine, "string", testCase.label);
+
+        const logEvent = JSON.parse(logLine as string) as {
+          level: string;
+          event: string;
+          requestId?: string;
+          context: Record<string, unknown>;
+        };
+
+        assert.equal(logEvent.event, testCase.label);
+        assert.equal(logEvent.level, "error");
+
+        // requestId se promueve al nivel superior y no queda duplicado.
+        assert.equal(logEvent.requestId, headerRequestId);
+        assert.equal("requestId" in logEvent.context, false);
+
+        // El name manipulado se degrada a la allowlist del logger.
+        assert.deepEqual(logEvent.context, {
+          routeTemplate: testCase.routeTemplate,
+          errorName: "Error",
+        });
+        assert.deepEqual(Object.keys(logEvent.context).sort(), [
+          "errorName",
+          "routeTemplate",
+        ]);
+
+        for (const forbidden of [
+          sensitiveErrorMessage,
+          "Maria",
+          "Gomez",
+          "biopsia",
+          "atipicas",
+          "tutor@example.com",
+          "usuario@example.com",
+          "Postgres Error",
+          "admin-session-value",
+          "hash:",
+          "VETNEB",
+          "4821",
+          "isActive",
+          "cookie",
+          "session",
+          "message",
+          "stack",
+          "path",
+          "url",
+          "body",
+        ]) {
+          assert.equal(
+            (logLine as string).includes(forbidden),
+            false,
+            `${testCase.label} no debe registrar ${forbidden}`,
+          );
+        }
+
+        // "error" se verifica contra el context porque el nivel del evento es
+        // literalmente "error" en el nivel superior del JSON.
+        const serializedContext = JSON.stringify(logEvent.context);
+
+        for (const forbiddenKey of [
+          "error",
+          "message",
+          "stack",
+          "path",
+          "url",
+          "body",
+          "cookie",
+          "session",
+          "messageSanitized",
+          "code",
+          "params",
+        ]) {
+          assert.equal(
+            forbiddenKey in (logEvent.context as Record<string, unknown>),
+            false,
+            `${testCase.label} no debe registrar la clave ${forbiddenKey}`,
+          );
+          assert.equal(
+            serializedContext.includes(`"${forbiddenKey}"`),
+            false,
+            `${testCase.label} no debe serializar ${forbiddenKey}`,
+          );
+        }
+      }
+    } finally {
+      console.error = originalConsoleError;
+      invalidatePublicPricingCache();
+      await app.close();
+    }
+  },
+);
+
+test(
+  "un request finalizado por la app no vuelve a finalizarse ante un aborto",
+  async () => {
+    const {
+      createObservabilityMetricsRegistry,
+      createObservabilityRequestFinalizer,
+    } = await import("../../../server/lib/observability-metrics.ts");
+    const observabilityMetricsRegistry = createObservabilityMetricsRegistry();
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      observabilityMetricsRegistry,
+    });
+
+    try {
+      app.get("/api/__finalize/ok", async () => ({ success: true }));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/__finalize/ok",
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      const afterResponse = observabilityMetricsRegistry.getSnapshot();
+
+      assert.equal(afterResponse.requestsStartedTotal, 1);
+      assert.equal(afterResponse.requestsCompletedTotal, 1);
+      assert.equal(afterResponse.inFlightRequests, 0);
+      assert.equal(afterResponse.responsesByStatusClass["2xx"], 1);
+      assert.equal(afterResponse.latencyMs.count, 1);
+
+      // Contrato de finalizacion once-only: el mismo finalizer que ya cerro el
+      // request no puede volver a tocar la registry por la via de aborto.
+      const finalizer = createObservabilityRequestFinalizer(
+        observabilityMetricsRegistry,
+      );
+
+      assert.equal(
+        finalizer.recordCompleted({
+          method: "GET",
+          routeTemplate: "/api/__finalize/ok",
+          statusCode: 200,
+          durationMs: 1,
+        }),
+        true,
+      );
+      assert.equal(finalizer.recordAborted(), false);
+      assert.equal(finalizer.recordCompleted({
+        method: "GET",
+        routeTemplate: "/api/__finalize/ok",
+        statusCode: 200,
+        durationMs: 1,
+      }), false);
+
+      const afterFinalizer = observabilityMetricsRegistry.getSnapshot();
+
+      assert.equal(afterFinalizer.requestsCompletedTotal, 2);
+      assert.equal(afterFinalizer.inFlightRequests, 0);
+    } finally {
       await app.close();
     }
   },

--- a/test/integration/app/fastify-app.test.ts
+++ b/test/integration/app/fastify-app.test.ts
@@ -1609,8 +1609,19 @@ test(
       };
       const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
 
+      // "Paciente_307" pasaria una regex sintactica de identificador; sólo la
+      // allowlist finita de nombres de Error nativos lo rechaza.
+      const manipulatedNameThrow = async () => {
+        const failure = new Error("historia clinica confidencial del paciente");
+
+        failure.name = "Paciente_307";
+
+        throw failure;
+      };
+
       app.get("/api/__test/internal-error", throwInternalError);
       app.post("/api/__test/internal-error", throwInternalError);
+      app.get("/api/__test/manipulated-error-name", manipulatedNameThrow);
 
       const genericError = await app.inject({
         method: "POST",
@@ -1697,6 +1708,57 @@ test(
         "invalidIncomingError",
       );
 
+      const manipulatedNameError = await app.inject({
+        method: "GET",
+        url: "/api/__test/manipulated-error-name",
+      });
+
+      assert.equal(manipulatedNameError.statusCode, 500);
+      const {
+        body: manipulatedNameBody,
+        requestId: manipulatedNameRequestId,
+      } = assertBodyRequestIdMatchesHeader(
+        manipulatedNameError,
+        "manipulatedNameError",
+      );
+      assert.deepEqual(manipulatedNameBody, {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__test/manipulated-error-name",
+        requestId: manipulatedNameRequestId,
+      });
+      assert.doesNotMatch(
+        manipulatedNameError.body,
+        /historia clinica confidencial/,
+      );
+      assert.doesNotMatch(manipulatedNameError.body, /Paciente_307/);
+
+      const manipulatedNameLogPayload = assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        3,
+        manipulatedNameRequestId,
+        "manipulatedNameError",
+      );
+
+      assert.equal(manipulatedNameLogPayload.errorName, "Error");
+      assert.equal(
+        manipulatedNameLogPayload.routeTemplate,
+        "/api/__test/manipulated-error-name",
+      );
+
+      const manipulatedNameLogLine = serializeConsoleCalls([
+        consoleErrorCalls[3] ?? [],
+      ]);
+
+      assert.equal(
+        manipulatedNameLogLine.includes("Paciente_307"),
+        false,
+      );
+      assert.equal(
+        manipulatedNameLogLine.includes("historia clinica confidencial"),
+        false,
+      );
+
       const publicApiNotFound = await app.inject({
         method: "GET",
         url: "/api/public/no-existe",
@@ -1725,7 +1787,7 @@ test(
       assertBodyDoesNotIncludeRequestId(apiHealth, "apiHealth");
       assert.equal(
         consoleErrorCalls.length,
-        3,
+        4,
         "respuesta API exitosa no debe registrar log de error nuevo",
       );
 
@@ -2667,14 +2729,17 @@ test(
 test(
   "los errores de pricing se correlacionan con X-Request-ID sin metadata extra",
   async () => {
-    // El name viene manipulado a proposito: sin allowlist, un Error construido
-    // por una libreria o por datos externos filtraria PII al log.
+    // El name viene manipulado a proposito con forma de identificador valido
+    // ("MariaGomez" pasaria una regex sintactica de tipo /^[A-Za-z][\w]*$/):
+    // sólo una allowlist finita de nombres de Error nativos lo rechaza. Sin
+    // esa allowlist, un Error construido por una libreria o por datos
+    // externos filtraria PII al log a traves del nombre de la clase.
     const sensitiveErrorMessage =
       "Paciente Maria Gomez biopsia con celulas atipicas tutor@example.com";
     const listFailure = () => {
       const failure = new Error(sensitiveErrorMessage);
 
-      failure.name = "Postgres Error usuario@example.com";
+      failure.name = "MariaGomez";
 
       throw failure;
     };
@@ -2813,8 +2878,7 @@ test(
           "biopsia",
           "atipicas",
           "tutor@example.com",
-          "usuario@example.com",
-          "Postgres Error",
+          "MariaGomez",
           "admin-session-value",
           "hash:",
           "VETNEB",
@@ -2930,6 +2994,195 @@ test(
 
       assert.equal(afterFinalizer.requestsCompletedTotal, 2);
       assert.equal(afterFinalizer.inFlightRequests, 0);
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+function buildAuthenticatedAdminSystemHealthStubs(
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    ...fastifyAppHelpers.buildAdminSystemHealthRouteStubs(),
+    getAdminSessionByToken: async () => ({
+      adminUserId: 1,
+      expiresAt: new Date("2099-01-01T00:00:00.000Z"),
+      lastAccess: new Date("2026-07-31T00:00:00.000Z"),
+    }),
+    getAdminUserById: async () => ({ id: 1, username: "VETNEB" }),
+    ...overrides,
+  };
+}
+
+test(
+  "el endpoint privado de metricas lee la registry instrumentada por createFastifyApp",
+  async () => {
+    const { createObservabilityMetricsRegistry } = await import(
+      "../../../server/lib/observability-metrics.ts"
+    );
+    const observabilityMetricsRegistry = createObservabilityMetricsRegistry();
+    const sentinelRoute = "/api/__injected-registry-sentinel";
+
+    // La sentinel se siembra directamente en la registry inyectada: no es
+    // alcanzable por HTTP, asi que su presencia prueba que el endpoint consulta
+    // esta instancia y no otra.
+    observabilityMetricsRegistry.recordRequestStarted();
+    observabilityMetricsRegistry.recordRequestCompleted({
+      method: "GET",
+      routeTemplate: sentinelRoute,
+      statusCode: 200,
+      durationMs: 17,
+    });
+
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      observabilityMetricsRegistry,
+      adminSystemHealthRoutes: buildAuthenticatedAdminSystemHealthStubs(),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/system/health/metrics",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-value`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      const body = JSON.parse(response.body) as {
+        success: boolean;
+        metrics: {
+          routes: Array<{ route: string; count: number; p50: number | null }>;
+          requestsStartedTotal: number;
+          inFlightRequests: number;
+          requestsCompletedTotal: number;
+          latencyMs: { count: number };
+        };
+      };
+
+      assert.equal(body.success, true);
+
+      const sentinelEntry = body.metrics.routes.find(
+        (route) => route.route === `GET ${sentinelRoute}`,
+      );
+
+      assert.ok(
+        sentinelEntry,
+        "el endpoint debe exponer la ruta sembrada en la registry inyectada",
+      );
+      assert.equal(sentinelEntry.count, 1);
+      assert.equal(sentinelEntry.p50, 17);
+
+      // El propio GET /metrics ya esta iniciado y en vuelo cuando el handler
+      // toma el snapshot: se afirma la semantica, no un conteo cerrado.
+      assert.equal(body.metrics.requestsStartedTotal >= 2, true);
+      assert.equal(body.metrics.inFlightRequests >= 1, true);
+      assert.equal(body.metrics.requestsCompletedTotal >= 1, true);
+      assert.equal(body.metrics.latencyMs.count >= 1, true);
+
+      // No es una fixture estatica: la registry sigue viva y acumula.
+      const afterResponse = observabilityMetricsRegistry.getSnapshot();
+
+      assert.equal(afterResponse.inFlightRequests, 0);
+      assert.equal(
+        afterResponse.routes.some(
+          (route) => route.route === "GET /api/admin/system/health/metrics",
+        ),
+        true,
+      );
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "adminSystemHealthRoutes puede sobrescribir el getter de metricas inyectado",
+  async () => {
+    const { createObservabilityMetricsRegistry } = await import(
+      "../../../server/lib/observability-metrics.ts"
+    );
+    const observabilityMetricsRegistry = createObservabilityMetricsRegistry();
+
+    observabilityMetricsRegistry.recordRequestStarted();
+    observabilityMetricsRegistry.recordRequestCompleted({
+      method: "GET",
+      routeTemplate: "/api/__injected-registry-sentinel",
+      statusCode: 200,
+      durationMs: 17,
+    });
+
+    const overrideSnapshot = {
+      startedAt: "2026-07-31T00:00:00.000Z",
+      uptimeSeconds: 42,
+      requestsStartedTotal: 7,
+      requestsCompletedTotal: 7,
+      inFlightRequests: 0,
+      responsesByStatusClass: {
+        "1xx": 0,
+        "2xx": 7,
+        "3xx": 0,
+        "4xx": 0,
+        "5xx": 0,
+      },
+      serverErrors5xxTotal: 0,
+      serverErrorRate: 0,
+      rateLimitedResponsesTotal: 0,
+      latencyMs: {
+        count: 7,
+        min: 1,
+        max: 9,
+        average: 4,
+        p50: 4,
+        p95: 9,
+        p99: 9,
+      },
+      routes: [
+        {
+          route: "GET /api/__override-snapshot-sentinel",
+          count: 7,
+          serverErrors5xx: 0,
+          p50: 4,
+          p95: 9,
+        },
+      ],
+      routeKeysTracked: 1,
+      routeKeyLimitReached: false,
+      latencySampleLimit: 1024,
+    } as const;
+
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      observabilityMetricsRegistry,
+      adminSystemHealthRoutes: buildAuthenticatedAdminSystemHealthStubs({
+        getObservabilityMetricsSnapshot: () => overrideSnapshot,
+      }),
+    });
+
+    try {
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/system/health/metrics",
+        headers: {
+          cookie: `${ENV.adminCookieName}=admin-session-value`,
+        },
+      });
+
+      assert.equal(response.statusCode, 200);
+
+      // El spread de options va despues del getter por defecto: un override
+      // explicito sigue ganando.
+      assert.deepEqual(JSON.parse(response.body), {
+        success: true,
+        metrics: overrideSnapshot,
+      });
+      assert.equal(
+        response.body.includes("__injected-registry-sentinel"),
+        false,
+      );
     } finally {
       await app.close();
     }

--- a/test/integration/app/fastify-app.test.ts
+++ b/test/integration/app/fastify-app.test.ts
@@ -1643,8 +1643,13 @@ test(
         "genericError",
       );
       assert.equal(genericLogPayload.method, "POST");
-      assert.equal(genericLogPayload.path, "/api/__test/internal-error");
+      assert.equal(
+        genericLogPayload.routeTemplate,
+        "/api/__test/internal-error",
+      );
       assert.equal(genericLogPayload.status, 500);
+      assert.equal("path" in genericLogPayload, false);
+      assert.equal("url" in genericLogPayload, false);
 
       const validIncomingRequestId = "client-req_123.abc:456";
       const validIncomingError = await app.inject({
@@ -2313,6 +2318,328 @@ test(
       assert.equal(response.body.includes("password"), false);
       assert.equal(response.body.includes("cookie"), false);
     } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp instrumenta metricas in-process sin alterar el contrato HTTP",
+  async () => {
+    const { createObservabilityMetricsRegistry } = await import(
+      "../../../server/lib/observability-metrics.ts"
+    );
+    const observabilityMetricsRegistry = createObservabilityMetricsRegistry();
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      observabilityMetricsRegistry,
+    });
+
+    const originalConsoleError = console.error;
+    const consoleErrorCalls: unknown[][] = [];
+
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
+
+    try {
+      app.get("/api/__metrics/boom", async () => {
+        throw new Error("detalle interno sensible");
+      });
+      app.get("/api/__metrics/ok", async () => ({ success: true }));
+
+      const health = await app.inject({
+        method: "GET",
+        url: "/api/__metrics/ok",
+      });
+      const notFound = await app.inject({
+        method: "GET",
+        url: "/api/__metrics/no-existe",
+      });
+      const failure = await app.inject({
+        method: "GET",
+        url: "/api/__metrics/boom",
+      });
+
+      assert.equal(health.statusCode, 200);
+      assert.equal(notFound.statusCode, 404);
+      assert.equal(failure.statusCode, 500);
+      assert.deepEqual(JSON.parse(failure.body), {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__metrics/boom",
+        requestId: assertRequestIdHeader(failure, "failure"),
+      });
+
+      const snapshot = observabilityMetricsRegistry.getSnapshot();
+
+      assert.equal(snapshot.requestsStartedTotal, 3);
+      assert.equal(snapshot.requestsCompletedTotal, 3);
+      assert.equal(snapshot.inFlightRequests, 0);
+      assert.equal(snapshot.responsesByStatusClass["2xx"], 1);
+      assert.equal(snapshot.responsesByStatusClass["4xx"], 1);
+      assert.equal(snapshot.responsesByStatusClass["5xx"], 1);
+      assert.equal(snapshot.serverErrors5xxTotal, 1);
+      assert.equal(snapshot.serverErrorRate, 0.3333);
+      assert.equal(snapshot.latencyMs.count, 3);
+      assert.equal(typeof snapshot.latencyMs.p95, "number");
+
+      const routeKeys = snapshot.routes.map((route) => route.route).sort();
+
+      assert.deepEqual(routeKeys, [
+        "GET /api/__metrics/boom",
+        "GET /api/__metrics/ok",
+        "GET UNMATCHED_ROUTE",
+      ]);
+
+      const serializedRoutes = JSON.stringify(snapshot.routes);
+
+      assert.equal(serializedRoutes.includes("no-existe"), false);
+      assert.equal(serializedRoutes.includes("?"), false);
+
+      const errorLog = assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        0,
+        assertRequestIdHeader(failure, "failure"),
+        "metricsFailure",
+      );
+
+      assert.equal(errorLog.status, 500);
+      assert.equal(errorLog.errorName, "Error");
+      assert.equal(errorLog.routeTemplate, "/api/__metrics/boom");
+      assert.equal("path" in errorLog, false);
+      assert.equal("url" in errorLog, false);
+      assert.equal(
+        serializeConsoleCalls(consoleErrorCalls).includes(
+          "detalle interno sensible",
+        ),
+        false,
+      );
+    } finally {
+      console.error = originalConsoleError;
+      await app.close();
+    }
+  },
+);
+
+test(
+  "createFastifyApp mantiene la respuesta cuando la instrumentacion de metricas falla",
+  async () => {
+    const failingRegistry = {
+      recordRequestStarted() {
+        throw new Error("metrics start failure");
+      },
+      recordRequestCompleted() {
+        throw new Error("metrics complete failure");
+      },
+      getSnapshot() {
+        throw new Error("metrics snapshot failure");
+      },
+      reset() {},
+    };
+
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      observabilityMetricsRegistry: failingRegistry as never,
+    });
+
+    try {
+      app.get("/api/__metrics/resilient", async () => ({ success: true }));
+
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/__metrics/resilient",
+      });
+
+      assert.equal(response.statusCode, 200);
+      assert.deepEqual(JSON.parse(response.body), { success: true });
+      assertRequestIdHeader(response, "respuestaConMetricasRotas");
+    } finally {
+      await app.close();
+    }
+  },
+);
+
+test(
+  "logs y metricas de rutas con IDs reales sólo conservan el route template",
+  async () => {
+    const { createObservabilityMetricsRegistry } = await import(
+      "../../../server/lib/observability-metrics.ts"
+    );
+    const observabilityMetricsRegistry = createObservabilityMetricsRegistry();
+    const app = await createFastifyApp({
+      ...fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+      observabilityMetricsRegistry,
+    });
+
+    const originalConsoleLog = console.log;
+    const originalConsoleError = console.error;
+    const consoleLogCalls: unknown[][] = [];
+    const consoleErrorCalls: unknown[][] = [];
+
+    console.log = (...args: unknown[]) => {
+      consoleLogCalls.push(args);
+    };
+    console.error = (...args: unknown[]) => {
+      consoleErrorCalls.push(args);
+    };
+
+    try {
+      app.get(
+        "/api/__ids/clinics/:clinicId/reports/:reportId",
+        async () => ({ success: true }),
+      );
+      app.get("/api/__ids/clinics/:clinicId/boom", async () => {
+        throw new Error("detalle interno sensible");
+      });
+
+      const ok = await app.inject({
+        method: "GET",
+        url: "/api/__ids/clinics/307/reports/4821?trackingCaseId=99&token=raw-secret",
+      });
+      const unmatched = await app.inject({
+        method: "GET",
+        url: "/api/__ids/clinics/307/no-existe",
+      });
+      const failure = await app.inject({
+        method: "GET",
+        url: "/api/__ids/clinics/307/boom",
+      });
+
+      assert.equal(ok.statusCode, 200);
+      assert.equal(unmatched.statusCode, 404);
+      assert.equal(failure.statusCode, 500);
+
+      assertRequestIdHeader(ok, "okConIds");
+
+      const serializedLogs = consoleLogCalls
+        .map((call) => String(call[0]))
+        .join("\n");
+
+      for (const leaked of [
+        "307",
+        "4821",
+        "trackingCaseId",
+        "raw-secret",
+        "no-existe",
+        "REDACTED",
+      ]) {
+        assert.equal(
+          serializedLogs.includes(leaked),
+          false,
+          `los access logs no deben conservar ${leaked}`,
+        );
+      }
+
+      // El 404 se agrega bajo UNMATCHED_ROUTE, sin el pathname original.
+      const snapshot = observabilityMetricsRegistry.getSnapshot();
+      const routeKeys = snapshot.routes.map((route) => route.route).sort();
+
+      assert.deepEqual(routeKeys, [
+        "GET /api/__ids/clinics/:clinicId/boom",
+        "GET /api/__ids/clinics/:clinicId/reports/:reportId",
+        "GET UNMATCHED_ROUTE",
+      ]);
+
+      const serializedSnapshot = JSON.stringify(snapshot);
+
+      for (const leaked of [
+        "307",
+        "4821",
+        "clinicId=",
+        "reportId=",
+        "trackingCaseId",
+        "raw-secret",
+        "no-existe",
+        "?",
+      ]) {
+        assert.equal(
+          serializedSnapshot.includes(leaked),
+          false,
+          `las metricas no deben conservar ${leaked}`,
+        );
+      }
+
+      const errorLog = assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        0,
+        assertRequestIdHeader(failure, "failureConIds"),
+        "failureConIds",
+      );
+
+      assert.equal(errorLog.routeTemplate, "/api/__ids/clinics/:clinicId/boom");
+      assert.equal(
+        serializeConsoleCalls(consoleErrorCalls).includes("307"),
+        false,
+      );
+      assert.equal(
+        serializeConsoleCalls(consoleErrorCalls).includes(
+          "detalle interno sensible",
+        ),
+        false,
+      );
+    } finally {
+      console.log = originalConsoleLog;
+      console.error = originalConsoleError;
+      await app.close();
+    }
+  },
+);
+
+test(
+  "el access log estructurado correlaciona con X-Request-ID en la app integrada",
+  async () => {
+    const app = await createFastifyApp(
+      fastifyAppHelpers.buildFastifyDispatchRouteStubs(),
+    );
+
+    const originalConsoleLog = console.log;
+    const consoleLogCalls: unknown[][] = [];
+
+    console.log = (...args: unknown[]) => {
+      consoleLogCalls.push(args);
+    };
+
+    try {
+      const incomingRequestId = "client-req_correlation.1:2";
+      const response = await app.inject({
+        method: "GET",
+        url: "/api/admin/audit-log?limit=25&token=raw-secret",
+        headers: {
+          "x-request-id": incomingRequestId,
+        },
+      });
+
+      const headerRequestId = assertRequestIdHeader(response, "accessLog");
+
+      assert.equal(headerRequestId, incomingRequestId);
+
+      const accessLogLine = consoleLogCalls
+        .map((call) => String(call[0]))
+        .find((line) => line.includes("HTTP_REQUEST_COMPLETED"));
+
+      assert.equal(typeof accessLogLine, "string");
+
+      const logEvent = JSON.parse(accessLogLine as string) as {
+        requestId?: string;
+        context: Record<string, unknown>;
+      };
+
+      assert.equal(logEvent.requestId, headerRequestId);
+      assert.equal(logEvent.context.routeTemplate, "/api/admin/audit-log");
+      assert.deepEqual(Object.keys(logEvent.context).sort(), [
+        "durationMs",
+        "method",
+        "rateLimited",
+        "routeTemplate",
+        "statusClass",
+        "statusCode",
+      ]);
+      assert.equal((accessLogLine as string).includes("raw-secret"), false);
+      assert.equal((accessLogLine as string).includes("limit=25"), false);
+      assert.equal((accessLogLine as string).includes("REDACTED"), false);
+    } finally {
+      console.log = originalConsoleLog;
       await app.close();
     }
   },

--- a/test/integration/app/fastify-app.test.ts
+++ b/test/integration/app/fastify-app.test.ts
@@ -1610,11 +1610,33 @@ test(
       const allowedOrigin = ENV.corsOrigins[0] ?? "http://localhost:3000";
 
       // "Paciente_307" pasaria una regex sintactica de identificador; sólo la
-      // allowlist finita de nombres de Error nativos lo rechaza.
+      // allowlist finita de nombres de Error nativos lo rechaza. El mismo
+      // valor se reutiliza como `code` para probar que el campo no existe en
+      // absoluto: no hay una allowlist parcial de codigos permitidos.
       const manipulatedNameThrow = async () => {
-        const failure = new Error("historia clinica confidencial del paciente");
+        const failure = new Error(
+          "historia clinica confidencial del paciente",
+        ) as Error & { code?: string };
 
         failure.name = "Paciente_307";
+        failure.code = "Paciente_307";
+
+        throw failure;
+      };
+
+      // Un codigo con forma de SQLSTATE tambien debe omitirse por completo:
+      // el contrato es ausencia total de `code`/`safeCode`, no una lista
+      // parcial de valores "tecnicos" aceptados. "40001" (serialization
+      // failure) se elige porque, a diferencia de 23505/23503/22P02/42703,
+      // no dispara el mapeo especial preexistente de getFastifyErrorStatus a
+      // 400: este test aisla el hallazgo (ausencia del campo en el log) sin
+      // interferir con esa logica de status ya existente.
+      const technicalCodeThrow = async () => {
+        const failure = new Error(
+          "could not serialize access due to concurrent update",
+        ) as Error & { code?: string };
+
+        failure.code = "40001";
 
         throw failure;
       };
@@ -1622,6 +1644,7 @@ test(
       app.get("/api/__test/internal-error", throwInternalError);
       app.post("/api/__test/internal-error", throwInternalError);
       app.get("/api/__test/manipulated-error-name", manipulatedNameThrow);
+      app.get("/api/__test/technical-error-code", technicalCodeThrow);
 
       const genericError = await app.inject({
         method: "POST",
@@ -1745,6 +1768,21 @@ test(
         manipulatedNameLogPayload.routeTemplate,
         "/api/__test/manipulated-error-name",
       );
+      assert.equal(manipulatedNameLogPayload.method, "GET");
+      assert.equal(manipulatedNameLogPayload.status, 500);
+
+      // El contexto de API_ERROR es cerrado: exactamente method, routeTemplate,
+      // status y errorName, con requestId promovido al nivel superior. Nunca
+      // safeCode ni code, sin importar que el error los traiga adjuntos.
+      assert.deepEqual(Object.keys(manipulatedNameLogPayload).sort(), [
+        "errorName",
+        "method",
+        "requestId",
+        "routeTemplate",
+        "status",
+      ]);
+      assert.equal("safeCode" in manipulatedNameLogPayload, false);
+      assert.equal("code" in manipulatedNameLogPayload, false);
 
       const manipulatedNameLogLine = serializeConsoleCalls([
         consoleErrorCalls[3] ?? [],
@@ -1758,6 +1796,63 @@ test(
         manipulatedNameLogLine.includes("historia clinica confidencial"),
         false,
       );
+      assert.equal(manipulatedNameLogLine.includes("safeCode"), false);
+      assert.equal(manipulatedNameLogLine.includes('"code"'), false);
+
+      const technicalCodeError = await app.inject({
+        method: "GET",
+        url: "/api/__test/technical-error-code",
+      });
+
+      assert.equal(technicalCodeError.statusCode, 500);
+      const {
+        body: technicalCodeBody,
+        requestId: technicalCodeRequestId,
+      } = assertBodyRequestIdMatchesHeader(
+        technicalCodeError,
+        "technicalCodeError",
+      );
+      assert.deepEqual(technicalCodeBody, {
+        success: false,
+        error: "Error interno del servidor",
+        path: "/api/__test/technical-error-code",
+        requestId: technicalCodeRequestId,
+      });
+      assert.doesNotMatch(
+        technicalCodeError.body,
+        /could not serialize access/,
+      );
+      assert.doesNotMatch(technicalCodeError.body, /40001/);
+
+      const technicalCodeLogPayload = assertApiErrorLogRequestId(
+        consoleErrorCalls,
+        4,
+        technicalCodeRequestId,
+        "technicalCodeError",
+      );
+
+      assert.equal(technicalCodeLogPayload.errorName, "Error");
+      assert.deepEqual(Object.keys(technicalCodeLogPayload).sort(), [
+        "errorName",
+        "method",
+        "requestId",
+        "routeTemplate",
+        "status",
+      ]);
+      assert.equal("safeCode" in technicalCodeLogPayload, false);
+      assert.equal("code" in technicalCodeLogPayload, false);
+
+      const technicalCodeLogLine = serializeConsoleCalls([
+        consoleErrorCalls[4] ?? [],
+      ]);
+
+      assert.equal(technicalCodeLogLine.includes("40001"), false);
+      assert.equal(
+        technicalCodeLogLine.includes("could not serialize access"),
+        false,
+      );
+      assert.equal(technicalCodeLogLine.includes("safeCode"), false);
+      assert.equal(technicalCodeLogLine.includes('"code"'), false);
 
       const publicApiNotFound = await app.inject({
         method: "GET",
@@ -1787,7 +1882,7 @@ test(
       assertBodyDoesNotIncludeRequestId(apiHealth, "apiHealth");
       assert.equal(
         consoleErrorCalls.length,
-        4,
+        5,
         "respuesta API exitosa no debe registrar log de error nuevo",
       );
 

--- a/test/unit/infrastructure/backend-api-nosniff-responses-contract.test.ts
+++ b/test/unit/infrastructure/backend-api-nosniff-responses-contract.test.ts
@@ -32,7 +32,7 @@ test("api security headers helper clasifica solo superficie API", () => {
   assert.equal(API_REFERRER_POLICY_HEADER_VALUE, "no-referrer");
   assert.equal(API_REQUEST_ID_HEADER_NAME, "X-Request-ID");
   assert.equal(API_REQUEST_ID_HEADER_KEY, "x-request-id");
-  assert.equal(API_REQUEST_ID_MAX_LENGTH, 128);
+  assert.equal(API_REQUEST_ID_MAX_LENGTH, 36);
   assert.equal(shouldApplyApiSecurityHeaders("/api"), true);
   assert.equal(shouldApplyApiSecurityHeaders("/api/health"), true);
   assert.equal(shouldApplyApiSecurityHeaders("/api/admin/system/health"), true);
@@ -46,21 +46,46 @@ test("api security headers helper clasifica solo superficie API", () => {
   assert.equal(shouldApplyApiSecurityHeaders("/"), false);
 });
 
-test("api request id helper valida formato seguro y genera fallback", () => {
-  const validRequestId = "client-req_123.abc:456";
-  const invalidRequestId = "client request id";
+test("api request id helper acepta UUID v4 y reemplaza identificadores opacos", () => {
+  const validRequestId = "123e4567-e89b-42d3-a456-426614174000";
+  const credentialShapedRequestId = [
+    "sess",
+    "opaque",
+    "fixture",
+    "abc123",
+  ].join("_");
+
   const generatedWithoutHeader = generateFastifyRequestId({
     headers: {},
   } as any);
-  const generatedFromInvalidHeader = generateFastifyRequestId({
+
+  const generatedFromCredentialShapedHeader = generateFastifyRequestId({
     headers: {
-      [API_REQUEST_ID_HEADER_KEY]: invalidRequestId,
+      [API_REQUEST_ID_HEADER_KEY]: credentialShapedRequestId,
     },
   } as any);
 
+  assert.equal(API_REQUEST_ID_MAX_LENGTH, 36);
+
   assert.equal(isSafeRequestId(validRequestId), true);
-  assert.equal(isSafeRequestId(invalidRequestId), false);
-  assert.equal(isSafeRequestId(`req-${"a".repeat(129)}`), false);
+  assert.equal(isSafeRequestId(validRequestId.toUpperCase()), true);
+
+  assert.equal(isSafeRequestId(credentialShapedRequestId), false);
+  assert.equal(isSafeRequestId("client-req_123.abc:456"), false);
+  assert.equal(isSafeRequestId("client request id"), false);
+  assert.equal(
+    isSafeRequestId("123e4567-e89b-12d3-a456-426614174000"),
+    false,
+  );
+  assert.equal(
+    isSafeRequestId("123e4567-e89b-42d3-7456-426614174000"),
+    false,
+  );
+  assert.equal(
+    isSafeRequestId("123e4567-e89b-42d3-a456-42661417400"),
+    false,
+  );
+
   assert.equal(
     generateFastifyRequestId({
       headers: {
@@ -69,9 +94,17 @@ test("api request id helper valida formato seguro y genera fallback", () => {
     } as any),
     validRequestId,
   );
+
   assert.equal(isSafeRequestId(generatedWithoutHeader), true);
-  assert.equal(isSafeRequestId(generatedFromInvalidHeader), true);
-  assert.notEqual(generatedFromInvalidHeader, invalidRequestId);
+  assert.equal(
+    isSafeRequestId(generatedFromCredentialShapedHeader),
+    true,
+  );
+
+  assert.notEqual(
+    generatedFromCredentialShapedHeader,
+    credentialShapedRequestId,
+  );
 });
 
 test("fastify-app registra hook central de security headers antes de cortes tempranos", () => {

--- a/test/unit/infrastructure/logger-and-email.test.ts
+++ b/test/unit/infrastructure/logger-and-email.test.ts
@@ -19,76 +19,81 @@ process.env.SUPABASE_DB_URL ??= process.env.DATABASE_URL;
 const { ENV } = await import("../../../server/lib/env.ts");
 const { sendContactMessageEmail, sendSpecialStainRequiredEmail } = await import("../../../server/lib/email.ts");
 
-test("logInfo agrega prefijo [INFO]", () => {
-  const original = console.log;
+function captureSingleJsonLine(
+  channel: "log" | "warn" | "error",
+  run: () => void,
+) {
+  const original = console[channel];
   const calls: unknown[][] = [];
 
-  console.log = (...args: unknown[]) => {
+  console[channel] = (...args: unknown[]) => {
     calls.push(args);
   };
 
   try {
-    logInfo("hola", { ok: true });
+    run();
   } finally {
-    console.log = original;
+    console[channel] = original;
   }
 
   assert.equal(calls.length, 1);
-  assert.deepEqual(calls[0], ["[INFO]", "hola", { ok: true }]);
+  assert.equal(calls[0].length, 1);
+  assert.equal(typeof calls[0][0], "string");
+
+  return JSON.parse(calls[0][0] as string) as Record<string, unknown>;
+}
+
+test("logInfo emite una linea JSON estructurada con nivel info", () => {
+  const logEvent = captureSingleJsonLine("log", () => {
+    logInfo("HOLA_EVENTO", { ok: true });
+  });
+
+  assert.equal(logEvent.level, "info");
+  assert.equal(logEvent.event, "HOLA_EVENTO");
+  assert.deepEqual(logEvent.context, { ok: true });
+  assert.equal(typeof logEvent.timestamp, "string");
 });
 
-test("logWarn agrega prefijo [WARN]", () => {
-  const original = console.warn;
-  const calls: unknown[][] = [];
-
-  console.warn = (...args: unknown[]) => {
-    calls.push(args);
-  };
-
-  try {
+test("logWarn emite una linea JSON estructurada con nivel warn", () => {
+  const logEvent = captureSingleJsonLine("warn", () => {
     logWarn("atención", 123);
-  } finally {
-    console.warn = original;
-  }
+  });
 
-  assert.equal(calls.length, 1);
-  assert.deepEqual(calls[0], ["[WARN]", "atención", 123]);
+  assert.equal(logEvent.level, "warn");
+  assert.equal(logEvent.event, "LOG_WARN");
+  assert.deepEqual(logEvent.context, { args: ["atención", 123] });
 });
 
-test("logError agrega prefijo [ERROR]", () => {
-  const original = console.error;
-  const calls: unknown[][] = [];
+test("logError emite una linea JSON estructurada con nivel error", () => {
+  const logEvent = captureSingleJsonLine("error", () => {
+    logError("FALLO_EVENTO", { code: "E_TEST" });
+  });
 
-  console.error = (...args: unknown[]) => {
-    calls.push(args);
-  };
-
-  try {
-    logError("falló", { code: "E_TEST" });
-  } finally {
-    console.error = original;
-  }
-
-  assert.equal(calls.length, 1);
-  assert.deepEqual(calls[0], ["[ERROR]", "falló", { code: "E_TEST" }]);
+  assert.equal(logEvent.level, "error");
+  assert.equal(logEvent.event, "FALLO_EVENTO");
+  assert.deepEqual(logEvent.context, { code: "E_TEST" });
 });
 
-test("serializeError serializa instancias de Error", () => {
+test("serializeError expone allowlist sin stack", () => {
   const error = new TypeError("mensaje de prueba");
-  const serialized = serializeError(error) as {
-    message: string;
-    name: string;
-    stack?: string;
-  };
+  const serialized = serializeError(error) as Record<string, unknown>;
 
-  assert.equal(serialized.message, "mensaje de prueba");
-  assert.equal(serialized.name, "TypeError");
-  assert.equal(typeof serialized.stack, "string");
+  assert.deepEqual(serialized, {
+    name: "TypeError",
+    messageSanitized: "mensaje de prueba",
+  });
+  assert.equal("stack" in serialized, false);
 });
 
-test("serializeError deja intactos valores no Error", () => {
-  const payload = { ok: false, code: "X" };
-  assert.equal(serializeError(payload), payload);
+test("serializeError redacta valores no Error sin mutar el original", () => {
+  const payload = { ok: false, code: "X", sessionToken: "raw-secret" };
+
+  assert.deepEqual(serializeError(payload), {
+    ok: false,
+    code: "X",
+    sessionToken: "[REDACTED]",
+  });
+  assert.equal(payload.sessionToken, "raw-secret");
   assert.equal(serializeError("texto"), "texto");
   assert.equal(serializeError(null), null);
 });

--- a/test/unit/infrastructure/logger-and-email.test.ts
+++ b/test/unit/infrastructure/logger-and-email.test.ts
@@ -74,28 +74,29 @@ test("logError emite una linea JSON estructurada con nivel error", () => {
   assert.deepEqual(logEvent.context, { code: "E_TEST" });
 });
 
-test("serializeError expone allowlist sin stack", () => {
+test("serializeError expone sólo el nombre, nunca el mensaje libre", () => {
   const error = new TypeError("mensaje de prueba");
   const serialized = serializeError(error) as Record<string, unknown>;
 
   assert.deepEqual(serialized, {
     name: "TypeError",
-    messageSanitized: "mensaje de prueba",
+    messageSanitized: "[REDACTED]",
   });
   assert.equal("stack" in serialized, false);
+  assert.equal(JSON.stringify(serialized).includes("mensaje de prueba"), false);
 });
 
-test("serializeError redacta valores no Error sin mutar el original", () => {
-  const payload = { ok: false, code: "X", sessionToken: "raw-secret" };
+test("serializeError encapsula valores no Error sin mutar el original", () => {
+  const payload = { ok: false, code: "X", sessionToken: "raw-value" };
+  const expected = {
+    name: "UnknownError",
+    messageSanitized: "[REDACTED]",
+  };
 
-  assert.deepEqual(serializeError(payload), {
-    ok: false,
-    code: "X",
-    sessionToken: "[REDACTED]",
-  });
-  assert.equal(payload.sessionToken, "raw-secret");
-  assert.equal(serializeError("texto"), "texto");
-  assert.equal(serializeError(null), null);
+  assert.deepEqual(serializeError(payload), expected);
+  assert.deepEqual(payload, { ok: false, code: "X", sessionToken: "raw-value" });
+  assert.deepEqual(serializeError("texto"), expected);
+  assert.deepEqual(serializeError(null), expected);
 });
 
 test("sendContactMessageEmail usa CONTACT_TO y fallback SMTP_FROM sin loguear secretos", async () => {

--- a/test/unit/infrastructure/observability-metrics.test.ts
+++ b/test/unit/infrastructure/observability-metrics.test.ts
@@ -4,6 +4,7 @@ import {
   buildRouteMetricsKey,
   computePercentile,
   createObservabilityMetricsRegistry,
+  createObservabilityRequestFinalizer,
   getStatusClass,
   OVERFLOW_ROUTE_KEY,
   UNMATCHED_ROUTE_TEMPLATE,
@@ -234,4 +235,165 @@ test("el snapshot reporta startedAt y uptime a partir del reloj inyectado", () =
 
   assert.equal(snapshot.startedAt, new Date(1_800_000_000_000).toISOString());
   assert.equal(snapshot.uptimeSeconds, 90);
+});
+
+test("recordRequestAborted libera in-flight sin contar una respuesta", () => {
+  const registry = createObservabilityMetricsRegistry();
+
+  registry.recordRequestStarted();
+  registry.recordRequestStarted();
+  registry.recordRequestAborted();
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.requestsStartedTotal, 2);
+  assert.equal(snapshot.inFlightRequests, 1);
+  assert.equal(snapshot.requestsCompletedTotal, 0);
+  assert.deepEqual(snapshot.responsesByStatusClass, {
+    "1xx": 0,
+    "2xx": 0,
+    "3xx": 0,
+    "4xx": 0,
+    "5xx": 0,
+  });
+  assert.equal(snapshot.serverErrors5xxTotal, 0);
+  assert.equal(snapshot.serverErrorRate, null);
+  assert.equal(snapshot.rateLimitedResponsesTotal, 0);
+  assert.equal(snapshot.latencyMs.count, 0);
+  assert.deepEqual(snapshot.routes, []);
+});
+
+test("múltiples abortos nunca dejan in-flight negativo", () => {
+  const registry = createObservabilityMetricsRegistry();
+
+  registry.recordRequestStarted();
+  registry.recordRequestAborted();
+  registry.recordRequestAborted();
+  registry.recordRequestAborted();
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.inFlightRequests, 0);
+  assert.equal(snapshot.requestsCompletedTotal, 0);
+});
+
+test("el finalizer ejecuta abort una sola vez y bloquea el complete posterior", () => {
+  const registry = createObservabilityMetricsRegistry();
+  const finalizer = createObservabilityRequestFinalizer(registry);
+
+  registry.recordRequestStarted();
+
+  assert.equal(finalizer.recordAborted(), true);
+  assert.equal(finalizer.recordAborted(), false);
+  assert.equal(
+    finalizer.recordCompleted({
+      method: "GET",
+      routeTemplate: "/api/health",
+      statusCode: 200,
+      durationMs: 10,
+    }),
+    false,
+  );
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.inFlightRequests, 0);
+  assert.equal(snapshot.requestsCompletedTotal, 0);
+  assert.equal(snapshot.responsesByStatusClass["2xx"], 0);
+  assert.equal(snapshot.latencyMs.count, 0);
+  assert.deepEqual(snapshot.routes, []);
+});
+
+test("el finalizer ejecuta complete una sola vez y bloquea el abort posterior", () => {
+  const registry = createObservabilityMetricsRegistry();
+  const finalizer = createObservabilityRequestFinalizer(registry);
+  const completedInput = {
+    method: "GET",
+    routeTemplate: "/api/health",
+    statusCode: 200,
+    durationMs: 10,
+  };
+
+  registry.recordRequestStarted();
+
+  assert.equal(finalizer.recordCompleted(completedInput), true);
+  assert.equal(finalizer.recordCompleted(completedInput), false);
+  assert.equal(finalizer.recordAborted(), false);
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.inFlightRequests, 0);
+  assert.equal(snapshot.requestsCompletedTotal, 1);
+  assert.equal(snapshot.responsesByStatusClass["2xx"], 1);
+  assert.equal(snapshot.latencyMs.count, 1);
+  assert.deepEqual(snapshot.routes, [
+    {
+      route: "GET /api/health",
+      count: 1,
+      serverErrors5xx: 0,
+      p50: 10,
+      p95: 10,
+    },
+  ]);
+});
+
+test("el finalizer queda consumido aunque la registry inyectada lance", () => {
+  const calls: string[] = [];
+  const throwingRegistry = {
+    recordRequestStarted() {
+      calls.push("started");
+    },
+    recordRequestCompleted() {
+      calls.push("completed");
+      throw new Error("registry failure");
+    },
+    recordRequestAborted() {
+      calls.push("aborted");
+    },
+    getSnapshot() {
+      throw new Error("snapshot failure");
+    },
+    reset() {},
+  };
+
+  const finalizer = createObservabilityRequestFinalizer(throwingRegistry);
+
+  assert.throws(() =>
+    finalizer.recordCompleted({
+      method: "GET",
+      routeTemplate: "/api/health",
+      statusCode: 200,
+      durationMs: 10,
+    }),
+  );
+
+  // La finalización ya fue reclamada: no puede volver a contarse.
+  assert.equal(finalizer.recordAborted(), false);
+  assert.deepEqual(calls, ["completed"]);
+});
+
+test("cada finalizer es independiente por request", () => {
+  const registry = createObservabilityMetricsRegistry();
+  const first = createObservabilityRequestFinalizer(registry);
+  const second = createObservabilityRequestFinalizer(registry);
+
+  registry.recordRequestStarted();
+  registry.recordRequestStarted();
+
+  assert.equal(first.recordAborted(), true);
+  assert.equal(
+    second.recordCompleted({
+      method: "GET",
+      routeTemplate: "/api/health",
+      statusCode: 500,
+      durationMs: 5,
+    }),
+    true,
+  );
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.inFlightRequests, 0);
+  assert.equal(snapshot.requestsCompletedTotal, 1);
+  assert.equal(snapshot.serverErrors5xxTotal, 1);
 });

--- a/test/unit/infrastructure/observability-metrics.test.ts
+++ b/test/unit/infrastructure/observability-metrics.test.ts
@@ -1,0 +1,237 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildRouteMetricsKey,
+  computePercentile,
+  createObservabilityMetricsRegistry,
+  getStatusClass,
+  OVERFLOW_ROUTE_KEY,
+  UNMATCHED_ROUTE_TEMPLATE,
+} from "../../../server/lib/observability-metrics.ts";
+
+function completeRequest(
+  registry: ReturnType<typeof createObservabilityMetricsRegistry>,
+  input: {
+    method?: string;
+    routeTemplate?: string;
+    statusCode: number;
+    durationMs?: number;
+  },
+) {
+  registry.recordRequestStarted();
+  registry.recordRequestCompleted({
+    method: input.method ?? "GET",
+    routeTemplate: input.routeTemplate ?? "/api/health",
+    statusCode: input.statusCode,
+    durationMs: input.durationMs ?? 10,
+  });
+}
+
+test("la registry cuenta requests iniciadas, completadas y en vuelo", () => {
+  const registry = createObservabilityMetricsRegistry();
+
+  registry.recordRequestStarted();
+  registry.recordRequestStarted();
+
+  let snapshot = registry.getSnapshot();
+  assert.equal(snapshot.requestsStartedTotal, 2);
+  assert.equal(snapshot.requestsCompletedTotal, 0);
+  assert.equal(snapshot.inFlightRequests, 2);
+
+  registry.recordRequestCompleted({
+    method: "GET",
+    routeTemplate: "/api/health",
+    statusCode: 200,
+    durationMs: 5,
+  });
+
+  snapshot = registry.getSnapshot();
+  assert.equal(snapshot.requestsCompletedTotal, 1);
+  assert.equal(snapshot.inFlightRequests, 1);
+});
+
+test("in-flight nunca queda negativo aunque falte el inicio", () => {
+  const registry = createObservabilityMetricsRegistry();
+
+  registry.recordRequestCompleted({
+    method: "GET",
+    routeTemplate: "/api/health",
+    statusCode: 200,
+    durationMs: 1,
+  });
+
+  assert.equal(registry.getSnapshot().inFlightRequests, 0);
+});
+
+test("las respuestas se agrupan por status class y alimentan el error rate 5xx", () => {
+  const registry = createObservabilityMetricsRegistry();
+
+  completeRequest(registry, { statusCode: 200 });
+  completeRequest(registry, { statusCode: 204 });
+  completeRequest(registry, { statusCode: 302 });
+  completeRequest(registry, { statusCode: 404 });
+  completeRequest(registry, { statusCode: 429 });
+  completeRequest(registry, { statusCode: 500 });
+  completeRequest(registry, { statusCode: 503 });
+
+  const snapshot = registry.getSnapshot();
+
+  assert.deepEqual(snapshot.responsesByStatusClass, {
+    "1xx": 0,
+    "2xx": 2,
+    "3xx": 1,
+    "4xx": 2,
+    "5xx": 2,
+  });
+  assert.equal(snapshot.serverErrors5xxTotal, 2);
+  assert.equal(snapshot.rateLimitedResponsesTotal, 1);
+  assert.equal(snapshot.serverErrorRate, 0.2857);
+  assert.equal(getStatusClass(199), "1xx");
+});
+
+test("sin muestras los percentiles y el error rate son null", () => {
+  const snapshot = createObservabilityMetricsRegistry().getSnapshot();
+
+  assert.equal(snapshot.serverErrorRate, null);
+  assert.deepEqual(snapshot.latencyMs, {
+    count: 0,
+    min: null,
+    max: null,
+    average: null,
+    p50: null,
+    p95: null,
+    p99: null,
+  });
+  assert.deepEqual(snapshot.routes, []);
+});
+
+test("los percentiles son deterministas y toleran una sola muestra", () => {
+  assert.equal(computePercentile([], 95), null);
+  assert.equal(computePercentile([7], 95), 7);
+  assert.equal(computePercentile([1, 2, 3, 4], 50), 2);
+
+  const registry = createObservabilityMetricsRegistry();
+
+  for (let index = 1; index <= 100; index += 1) {
+    completeRequest(registry, { statusCode: 200, durationMs: index });
+  }
+
+  const latency = registry.getSnapshot().latencyMs;
+
+  assert.equal(latency.count, 100);
+  assert.equal(latency.min, 1);
+  assert.equal(latency.max, 100);
+  assert.equal(latency.average, 50.5);
+  assert.equal(latency.p50, 50);
+  assert.equal(latency.p95, 95);
+  assert.equal(latency.p99, 99);
+});
+
+test("el buffer de latencias queda acotado al limite configurado", () => {
+  const registry = createObservabilityMetricsRegistry({
+    latencySampleLimit: 4,
+  });
+
+  for (const durationMs of [1, 2, 3, 4, 5, 6]) {
+    completeRequest(registry, { statusCode: 200, durationMs });
+  }
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.latencySampleLimit, 4);
+  assert.equal(snapshot.latencyMs.count, 4);
+  assert.equal(snapshot.latencyMs.min, 3);
+  assert.equal(snapshot.latencyMs.max, 6);
+  assert.equal(snapshot.requestsCompletedTotal, 6);
+});
+
+test("las route keys quedan acotadas y desbordan a una key fija", () => {
+  const registry = createObservabilityMetricsRegistry({ routeKeyLimit: 2 });
+
+  completeRequest(registry, { routeTemplate: "/api/a", statusCode: 200 });
+  completeRequest(registry, { routeTemplate: "/api/b", statusCode: 200 });
+  completeRequest(registry, { routeTemplate: "/api/c", statusCode: 500 });
+  completeRequest(registry, { routeTemplate: "/api/d", statusCode: 500 });
+
+  const snapshot = registry.getSnapshot();
+  const routeNames = snapshot.routes.map((route) => route.route);
+
+  assert.equal(snapshot.routeKeyLimitReached, true);
+  assert.deepEqual(routeNames.sort(), [
+    "GET /api/a",
+    "GET /api/b",
+    OVERFLOW_ROUTE_KEY,
+  ]);
+
+  const overflow = snapshot.routes.find(
+    (route) => route.route === OVERFLOW_ROUTE_KEY,
+  );
+
+  assert.equal(overflow?.count, 2);
+  assert.equal(overflow?.serverErrors5xx, 2);
+});
+
+test("las route keys sólo combinan método y route template normalizado", () => {
+  assert.equal(
+    buildRouteMetricsKey("get", "/api/reports/:id"),
+    "GET /api/reports/:id",
+  );
+  assert.equal(
+    buildRouteMetricsKey("GET", "/api/reports/42?token=abc"),
+    `GET ${UNMATCHED_ROUTE_TEMPLATE}`,
+  );
+  assert.equal(
+    buildRouteMetricsKey("GET", "usuario@example.com"),
+    `GET ${UNMATCHED_ROUTE_TEMPLATE}`,
+  );
+  assert.equal(
+    buildRouteMetricsKey("BADMETHOD-1", "/api/x"),
+    "UNKNOWN /api/x",
+  );
+  assert.equal(
+    buildRouteMetricsKey("GET", `/api/${"a".repeat(200)}`),
+    `GET ${UNMATCHED_ROUTE_TEMPLATE}`,
+  );
+});
+
+test("el snapshot no permite mutar el estado interno de la registry", () => {
+  const registry = createObservabilityMetricsRegistry();
+
+  completeRequest(registry, { statusCode: 500 });
+
+  const snapshot = registry.getSnapshot();
+  snapshot.responsesByStatusClass["5xx"] = 999;
+  snapshot.routes.length = 0;
+
+  const fresh = registry.getSnapshot();
+
+  assert.equal(fresh.responsesByStatusClass["5xx"], 1);
+  assert.equal(fresh.routes.length, 1);
+});
+
+test("reset limpia la instancia sin afectar a otras registries", () => {
+  const first = createObservabilityMetricsRegistry();
+  const second = createObservabilityMetricsRegistry();
+
+  completeRequest(first, { statusCode: 200 });
+  completeRequest(second, { statusCode: 500 });
+
+  first.reset();
+
+  assert.equal(first.getSnapshot().requestsCompletedTotal, 0);
+  assert.equal(first.getSnapshot().serverErrors5xxTotal, 0);
+  assert.equal(second.getSnapshot().requestsCompletedTotal, 1);
+  assert.equal(second.getSnapshot().serverErrors5xxTotal, 1);
+});
+
+test("el snapshot reporta startedAt y uptime a partir del reloj inyectado", () => {
+  let clock = 1_800_000_000_000;
+  const registry = createObservabilityMetricsRegistry({ now: () => clock });
+
+  clock += 90_000;
+
+  const snapshot = registry.getSnapshot();
+
+  assert.equal(snapshot.startedAt, new Date(1_800_000_000_000).toISOString());
+  assert.equal(snapshot.uptimeSeconds, 90);
+});

--- a/test/unit/infrastructure/request-logger-edge.test.ts
+++ b/test/unit/infrastructure/request-logger-edge.test.ts
@@ -98,7 +98,7 @@ test("buildRequestLogLine redondea duraciones muy pequeñas y no agrega RATE_LIM
   );
 });
 
-test("requestLogger registra url sanitizada y no agrega RATE_LIMITED para status no 429", () => {
+test("requestLogger registra evento estructurado sin marcar rateLimited fuera de 429", () => {
   const req = {
     method: "DELETE",
     originalUrl: "/api/reports/12?reportAccessToken=secret-token&foo=1",
@@ -124,9 +124,37 @@ test("requestLogger registra url sanitizada y no agrega RATE_LIMITED para status
   assert.equal(typeof calls[0][0], "string");
 
   const line = calls[0][0] as string;
+  const logEvent = JSON.parse(line) as {
+    event: string;
+    level: string;
+    context: Record<string, unknown>;
+  };
 
-  assert.match(line, /^\[[^\]]+\] DELETE /);
-  assert.match(line, /500/);
-  assert.match(line, /reportAccessToken=\[REDACTED\]/);
-  assert.doesNotMatch(line, /RATE_LIMITED/);
+  assert.equal(logEvent.event, "HTTP_REQUEST_COMPLETED");
+  assert.equal(logEvent.level, "info");
+  assert.equal(logEvent.context.method, "DELETE");
+  assert.equal(logEvent.context.statusCode, 500);
+  assert.equal(logEvent.context.statusClass, "5xx");
+  assert.equal(logEvent.context.rateLimited, false);
+  assert.equal(logEvent.context.routeTemplate, "UNMATCHED_ROUTE");
+
+  // Sin template seguro el evento cae a UNMATCHED_ROUTE y no conserva el
+  // pathname original: /api/reports/12 lleva un reportId real.
+  assert.deepEqual(Object.keys(logEvent.context).sort(), [
+    "durationMs",
+    "method",
+    "rateLimited",
+    "statusClass",
+    "statusCode",
+    "routeTemplate",
+  ].sort());
+  assert.equal("path" in logEvent.context, false);
+  assert.equal("url" in logEvent.context, false);
+
+  const serializedContext = JSON.stringify(logEvent.context);
+
+  assert.equal(serializedContext.includes("secret-token"), false);
+  assert.equal(serializedContext.includes("/api/reports"), false);
+  assert.equal(serializedContext.includes("12"), false);
+  assert.equal(line.includes("secret-token"), false);
 });

--- a/test/unit/infrastructure/request-logger-edge.test.ts
+++ b/test/unit/infrastructure/request-logger-edge.test.ts
@@ -151,10 +151,17 @@ test("requestLogger registra evento estructurado sin marcar rateLimited fuera de
   assert.equal("path" in logEvent.context, false);
   assert.equal("url" in logEvent.context, false);
 
-  const serializedContext = JSON.stringify(logEvent.context);
+  // Sólo las dimensiones string son deterministas: durationMs es un float y
+  // puede contener cualquier secuencia de digitos.
+  const serializedDimensions = JSON.stringify({
+    method: logEvent.context.method,
+    routeTemplate: logEvent.context.routeTemplate,
+    statusClass: logEvent.context.statusClass,
+  });
 
-  assert.equal(serializedContext.includes("secret-token"), false);
-  assert.equal(serializedContext.includes("/api/reports"), false);
-  assert.equal(serializedContext.includes("12"), false);
+  assert.equal(serializedDimensions.includes("secret-token"), false);
+  assert.equal(serializedDimensions.includes("/api/reports"), false);
+  assert.equal(serializedDimensions.includes("12"), false);
   assert.equal(line.includes("secret-token"), false);
+  assert.equal(line.includes("/api/reports"), false);
 });

--- a/test/unit/infrastructure/request-logger-middleware.test.ts
+++ b/test/unit/infrastructure/request-logger-middleware.test.ts
@@ -45,7 +45,7 @@ test("requestLogger llama next inmediatamente", () => {
   assert.equal(nextCalls[0], undefined);
 });
 
-test("requestLogger registra una línea al finalizar la respuesta", () => {
+test("requestLogger registra un evento estructurado al finalizar la respuesta", () => {
   const req = {
     method: "GET",
     originalUrl: "/api/public/report-access/abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890?token=abc",
@@ -75,14 +75,30 @@ test("requestLogger registra una línea al finalizar la respuesta", () => {
   assert.equal(typeof calls[0][0], "string");
 
   const line = calls[0][0] as string;
+  const logEvent = JSON.parse(line) as {
+    event: string;
+    timestamp: string;
+    context: Record<string, unknown>;
+  };
 
-  assert.match(line, /^\[[^\]]+\] GET /);
-  assert.match(line, /200/);
-  assert.match(line, /\[REDACTED\]/);
-  assert.match(line, /[0-9]+\.[0-9]ms$/);
+  assert.equal(logEvent.event, "HTTP_REQUEST_COMPLETED");
+  assert.equal(typeof logEvent.timestamp, "string");
+  assert.equal(logEvent.context.method, "GET");
+  assert.equal(logEvent.context.statusCode, 200);
+  assert.equal(logEvent.context.statusClass, "2xx");
+  assert.equal(logEvent.context.routeTemplate, "UNMATCHED_ROUTE");
+  assert.equal(typeof logEvent.context.durationMs, "number");
+
+  // El token de acceso publico viaja en el path; el evento no puede conservar
+  // ninguna forma de la URL, ni siquiera redactada.
+  assert.equal("path" in logEvent.context, false);
+  assert.equal("url" in logEvent.context, false);
+  assert.equal(line.includes("report-access"), false);
+  assert.equal(line.includes("abcdef1234567890"), false);
+  assert.equal(line.includes("[REDACTED]"), false);
 });
 
-test("requestLogger conserva el marker RATE_LIMITED cuando statusCode es 429", () => {
+test("requestLogger marca rateLimited cuando statusCode es 429", () => {
   const req = {
     method: "POST",
     originalUrl: "/api/auth/login",
@@ -110,8 +126,13 @@ test("requestLogger conserva el marker RATE_LIMITED cuando statusCode es 429", (
 
   assert.equal(calls.length, 1);
 
-  const line = calls[0][0] as string;
-  assert.match(line, /RATE_LIMITED/);
+  const logEvent = JSON.parse(calls[0][0] as string) as {
+    context: Record<string, unknown>;
+  };
+
+  assert.equal(logEvent.context.rateLimited, true);
+  assert.equal(logEvent.context.statusCode, 429);
+  assert.equal(logEvent.context.statusClass, "4xx");
 });
 
 test("buildRequestLogLine usa timestamp y url explícitos para status 200", () => {
@@ -142,4 +163,53 @@ test("buildRequestLogLine agrega RATE_LIMITED para 429", () => {
     line,
     "[2026-04-20T14:00:10.148Z] POST /api/auth/login 429 7.3ms RATE_LIMITED",
   );
+});
+
+test("requestLogger con un ID real en la URL sólo registra el route template", () => {
+  const req = {
+    method: "GET",
+    originalUrl: "/api/reports/4821/history?clinicId=307",
+    route: { path: "/api/reports/:reportId/history" },
+    ip: "127.0.0.1",
+    headers: {
+      "user-agent": "node-test",
+      "x-request-id": "req_correlation-1",
+    },
+  };
+
+  const res = createMockResponse(200);
+
+  const originalConsoleLog = console.log;
+  const calls: unknown[][] = [];
+
+  console.log = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  try {
+    requestLogger(req as any, res as any, (() => {}) as any);
+    res.emit("finish");
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  const line = calls[0][0] as string;
+  const logEvent = JSON.parse(line) as {
+    requestId?: string;
+    context: Record<string, unknown>;
+  };
+
+  assert.equal(logEvent.context.routeTemplate, "/api/reports/:reportId/history");
+  assert.equal(logEvent.requestId, "req_correlation-1");
+  assert.deepEqual(Object.keys(logEvent.context).sort(), [
+    "durationMs",
+    "method",
+    "rateLimited",
+    "routeTemplate",
+    "statusClass",
+    "statusCode",
+  ]);
+  assert.equal(line.includes("4821"), false);
+  assert.equal(line.includes("clinicId"), false);
+  assert.equal(line.includes("307"), false);
 });

--- a/test/unit/infrastructure/request-logger-middleware.test.ts
+++ b/test/unit/infrastructure/request-logger-middleware.test.ts
@@ -173,7 +173,7 @@ test("requestLogger con un ID real en la URL sólo registra el route template", 
     ip: "127.0.0.1",
     headers: {
       "user-agent": "node-test",
-      "x-request-id": "req_correlation-1",
+      "x-request-id": "323e4567-e89b-42d3-a456-426614174002",
     },
   };
 
@@ -200,7 +200,7 @@ test("requestLogger con un ID real en la URL sólo registra el route template", 
   };
 
   assert.equal(logEvent.context.routeTemplate, "/api/reports/:reportId/history");
-  assert.equal(logEvent.requestId, "req_correlation-1");
+  assert.equal(logEvent.requestId, "323e4567-e89b-42d3-a456-426614174002");
   assert.deepEqual(Object.keys(logEvent.context).sort(), [
     "durationMs",
     "method",
@@ -212,4 +212,55 @@ test("requestLogger con un ID real en la URL sólo registra el route template", 
   assert.equal(line.includes("4821"), false);
   assert.equal(line.includes("clinicId"), false);
   assert.equal(line.includes("307"), false);
+});
+
+test("requestLogger no promueve un request id opaco con caracteres previamente permitidos", () => {
+  const credentialShapedRequestId = [
+    "sess",
+    "opaque",
+    "fixture",
+    "abc123",
+  ].join("_");
+
+  const req = {
+    method: "GET",
+    originalUrl: "/api/health",
+    route: { path: "/api/health" },
+    headers: {
+      "x-request-id": credentialShapedRequestId,
+    },
+  };
+
+  const res = createMockResponse(200);
+  const originalConsoleLog = console.log;
+  const calls: unknown[][] = [];
+
+  console.log = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  try {
+    requestLogger(req as any, res as any, (() => {}) as any);
+    res.emit("finish");
+  } finally {
+    console.log = originalConsoleLog;
+  }
+
+  assert.equal(calls.length, 1);
+
+  const line = String(calls[0]?.[0]);
+  const logEvent = JSON.parse(line) as {
+    requestId?: string;
+    context: Record<string, unknown>;
+  };
+
+  assert.equal("requestId" in logEvent, false);
+  assert.equal(
+    line.includes(credentialShapedRequestId),
+    false,
+  );
+  assert.equal(
+    logEvent.context.routeTemplate,
+    "/api/health",
+  );
 });

--- a/test/unit/infrastructure/structured-logger.test.ts
+++ b/test/unit/infrastructure/structured-logger.test.ts
@@ -59,23 +59,40 @@ test("el logger emite una linea JSON parseable con campos estables", () => {
   );
 });
 
-test("el logger conserva requestId valido y descarta el invalido", () => {
+test("el logger promueve sólo requestId UUID v4", () => {
+  const validRequestId =
+    "123e4567-e89b-42d3-a456-426614174000";
+
   const valid = captureJsonLine("error", () => {
-    logError("SAMPLE_ERROR", { requestId: "client-req_1.a:2", status: 500 });
+    logError("SAMPLE_ERROR", {
+      requestId: validRequestId,
+      status: 500,
+    });
   });
 
-  assert.equal(valid.requestId, "client-req_1.a:2");
+  assert.equal(valid.requestId, validRequestId);
   assert.deepEqual(valid.context, { status: 500 });
+
+  const credentialShapedRequestId = [
+    "sess",
+    "opaque",
+    "fixture",
+    "abc123",
+  ].join("_");
 
   const invalid = captureJsonLine("error", () => {
     logError("SAMPLE_ERROR", {
-      requestId: "bad id;Authorization=Bearer secret",
+      requestId: credentialShapedRequestId,
       status: 500,
     });
   });
 
   assert.equal("requestId" in invalid, false);
   assert.deepEqual(invalid.context, { status: 500 });
+  assert.equal(
+    JSON.stringify(invalid).includes(credentialShapedRequestId),
+    false,
+  );
 });
 
 test("redactLogValue redacta claves sensibles anidadas y en arrays", () => {
@@ -105,33 +122,73 @@ test("redactLogValue redacta claves sensibles anidadas y en arrays", () => {
     assert.equal(value, "[REDACTED]");
   }
 
-  assert.deepEqual(redacted.list, [{ sessionToken: "[REDACTED]", tokenId: 12 }]);
+  assert.deepEqual(redacted.list, [
+    {
+      sessionToken: "[REDACTED]",
+      tokenId: "[REDACTED]",
+    },
+  ]);
 });
 
-test("redactLogValue preserva identificadores seguros", () => {
+test("redactLogValue no permite bypass sensible mediante sufijos Id o Count", () => {
+  const validRequestId =
+    "123e4567-e89b-42d3-a456-426614174000";
+
   const redacted = redactLogValue({
-    tokenId: 4,
-    reportAccessTokenId: 5,
-    actorReportAccessTokenId: 6,
-    targetReportAccessTokenId: 7,
-    tokenCount: 8,
-    requestId: "req-1",
+    clinicId: 4,
+    reportId: 5,
+    clinicCount: 8,
+    requestId: validRequestId,
+
+    tokenId: 10,
+    reportAccessTokenId: 11,
+    actorReportAccessTokenId: 12,
+    targetReportAccessTokenId: 13,
+    tokenCount: 14,
+    sessionTokenId: "opaque-session-value",
+    refreshTokenCount: "opaque-refresh-value",
   });
 
   assert.deepEqual(redacted, {
-    tokenId: 4,
-    reportAccessTokenId: 5,
-    actorReportAccessTokenId: 6,
-    targetReportAccessTokenId: 7,
-    tokenCount: 8,
-    requestId: "req-1",
+    clinicId: 4,
+    reportId: 5,
+    clinicCount: 8,
+    requestId: validRequestId,
+
+    tokenId: "[REDACTED]",
+    reportAccessTokenId: "[REDACTED]",
+    actorReportAccessTokenId: "[REDACTED]",
+    targetReportAccessTokenId: "[REDACTED]",
+    tokenCount: "[REDACTED]",
+    sessionTokenId: "[REDACTED]",
+    refreshTokenCount: "[REDACTED]",
   });
 
-  assert.equal(isSensitiveLogKey("tokenId"), false);
+  const serialized = JSON.stringify(redacted);
+
+  assert.equal(
+    serialized.includes("opaque-session-value"),
+    false,
+  );
+  assert.equal(
+    serialized.includes("opaque-refresh-value"),
+    false,
+  );
+
   assert.equal(isSensitiveLogKey("requestId"), false);
+  assert.equal(isSensitiveLogKey("clinicId"), false);
+  assert.equal(isSensitiveLogKey("clinicCount"), false);
+
+  assert.equal(isSensitiveLogKey("tokenId"), true);
+  assert.equal(isSensitiveLogKey("reportAccessTokenId"), true);
+  assert.equal(isSensitiveLogKey("sessionTokenId"), true);
+  assert.equal(isSensitiveLogKey("refreshTokenCount"), true);
   assert.equal(isSensitiveLogKey("sessionId"), true);
   assert.equal(isSensitiveLogKey("set-cookie"), true);
-  assert.equal(isSensitiveLogKey("proxy-authorization"), true);
+  assert.equal(
+    isSensitiveLogKey("proxy-authorization"),
+    true,
+  );
 });
 
 test("redactSensitiveText redacta secretos embebidos en strings", () => {

--- a/test/unit/infrastructure/structured-logger.test.ts
+++ b/test/unit/infrastructure/structured-logger.test.ts
@@ -10,6 +10,12 @@ import {
   serializeError,
 } from "../../../server/lib/logger.ts";
 
+const TEST_DATABASE_URL = [
+  "postgresql://user",
+  ":pass",
+  "@host:5432/db",
+].join("");
+
 function captureJsonLine(
   channel: "log" | "warn" | "error",
   run: () => void,
@@ -144,7 +150,7 @@ test("redactSensitiveText redacta secretos embebidos en strings", () => {
     "key [REDACTED]",
   );
   assert.equal(
-    redactSensitiveText("postgresql://user:pass@host:5432/db"),
+    redactSensitiveText(TEST_DATABASE_URL),
     "[REDACTED]",
   );
   assert.equal(
@@ -161,7 +167,7 @@ test("redactSensitiveText redacta secretos embebidos en strings", () => {
 
 test("serializeError no expone stack ni detalles de driver", () => {
   const error = new Error(
-    "connect failed for postgresql://user:pass@host:5432/db",
+    `connect failed for ${TEST_DATABASE_URL}`,
   );
   (error as Error & { query?: string }).query = "select * from clinics";
 

--- a/test/unit/infrastructure/structured-logger.test.ts
+++ b/test/unit/infrastructure/structured-logger.test.ts
@@ -165,20 +165,133 @@ test("redactSensitiveText redacta secretos embebidos en strings", () => {
   );
 });
 
-test("serializeError no expone stack ni detalles de driver", () => {
+test("serializeError elimina el mensaje libre completo, no sólo credenciales", () => {
   const error = new Error(
-    `connect failed for ${TEST_DATABASE_URL}`,
+    [
+      "Paciente Maria Gomez",
+      "tutor@example.com",
+      "biopsia con celulas atipicas",
+      "select nombre from pacientes where id = $1",
+      TEST_DATABASE_URL,
+    ].join(" | "),
   );
   (error as Error & { query?: string }).query = "select * from clinics";
+  (error as Error & { detail?: string }).detail = "Key (id)=(4821) exists";
+  (error as Error & { parameters?: unknown[] }).parameters = [4821];
+  (error as Error & { code?: string }).code = "23505";
 
   const serialized = serializeError(error) as Record<string, unknown>;
 
   assert.deepEqual(serialized, {
     name: "Error",
-    messageSanitized: "connect failed for [REDACTED]",
+    messageSanitized: "[REDACTED]",
   });
-  assert.equal("stack" in serialized, false);
-  assert.equal("query" in serialized, false);
+
+  const encoded = JSON.stringify(serialized);
+
+  for (const leaked of [
+    "Maria",
+    "Gomez",
+    "tutor@example.com",
+    "biopsia",
+    "atipicas",
+    "select",
+    "pacientes",
+    TEST_DATABASE_URL,
+    "4821",
+    "23505",
+    "Key (id)",
+  ]) {
+    assert.equal(
+      encoded.includes(leaked),
+      false,
+      `serializeError no debe exportar ${leaked}`,
+    );
+  }
+
+  for (const forbiddenKey of [
+    "stack",
+    "cause",
+    "message",
+    "query",
+    "detail",
+    "parameters",
+    "code",
+  ]) {
+    assert.equal(forbiddenKey in serialized, false, forbiddenKey);
+  }
+});
+
+test("serializeError conserva el nombre de la clase de error cuando es seguro", () => {
+  assert.deepEqual(serializeError(new TypeError("dato sensible")), {
+    name: "TypeError",
+    messageSanitized: "[REDACTED]",
+  });
+  assert.deepEqual(serializeError(new RangeError("otro dato")), {
+    name: "RangeError",
+    messageSanitized: "[REDACTED]",
+  });
+});
+
+test("serializeError degrada nombres de error inválidos a Error", () => {
+  const error = new Error("mensaje irrelevante");
+
+  error.name = "Postgres Error usuario@example.com";
+
+  const serialized = serializeError(error) as Record<string, unknown>;
+
+  assert.deepEqual(serialized, {
+    name: "Error",
+    messageSanitized: "[REDACTED]",
+  });
+  assert.equal(JSON.stringify(serialized).includes("usuario@example.com"), false);
+});
+
+test("serializeError encapsula cualquier valor lanzado que no sea Error", () => {
+  const expected = {
+    name: "UnknownError",
+    messageSanitized: "[REDACTED]",
+  };
+
+  assert.deepEqual(serializeError("Paciente Maria maria@example.com"), expected);
+  assert.deepEqual(serializeError({ patientName: "Maria", clinicId: 307 }), expected);
+  assert.deepEqual(serializeError(["maria@example.com", 4821]), expected);
+  assert.deepEqual(serializeError(null), expected);
+  assert.deepEqual(serializeError(undefined), expected);
+  assert.deepEqual(serializeError(42), expected);
+});
+
+test("serializeError no muta el input original", () => {
+  const error = new Error("mensaje original");
+  (error as Error & { query?: string }).query = "select 1";
+
+  serializeError(error);
+
+  assert.equal(error.message, "mensaje original");
+  assert.equal(error.name, "Error");
+  assert.equal((error as Error & { query?: string }).query, "select 1");
+
+  const thrown = { patientName: "Maria" };
+
+  serializeError(thrown);
+
+  assert.deepEqual(thrown, { patientName: "Maria" });
+});
+
+test("redactLogValue delega instancias Error al envelope seguro", () => {
+  const logEvent = captureJsonLine("error", () => {
+    logError("NESTED_ERROR_EVENT", {
+      cause: new TypeError("Paciente Maria maria@example.com"),
+    });
+  });
+
+  assert.deepEqual(logEvent.context, {
+    cause: {
+      name: "TypeError",
+      messageSanitized: "[REDACTED]",
+    },
+  });
+  assert.equal(JSON.stringify(logEvent).includes("Maria"), false);
 });
 
 test("el logger tolera referencias circulares, fechas y arrays", () => {

--- a/test/unit/infrastructure/structured-logger.test.ts
+++ b/test/unit/infrastructure/structured-logger.test.ts
@@ -222,29 +222,68 @@ test("serializeError elimina el mensaje libre completo, no sólo credenciales", 
   }
 });
 
-test("serializeError conserva el nombre de la clase de error cuando es seguro", () => {
-  assert.deepEqual(serializeError(new TypeError("dato sensible")), {
-    name: "TypeError",
-    messageSanitized: "[REDACTED]",
-  });
-  assert.deepEqual(serializeError(new RangeError("otro dato")), {
-    name: "RangeError",
+test("serializeError conserva el nombre de la clase de error cuando esta en la allowlist finita", () => {
+  for (const [ErrorClass, name] of [
+    [Error, "Error"],
+    [TypeError, "TypeError"],
+    [RangeError, "RangeError"],
+    [ReferenceError, "ReferenceError"],
+    [SyntaxError, "SyntaxError"],
+    [URIError, "URIError"],
+    [EvalError, "EvalError"],
+  ] as const) {
+    assert.deepEqual(serializeError(new ErrorClass("dato sensible")), {
+      name,
+      messageSanitized: "[REDACTED]",
+    });
+  }
+});
+
+test("serializeError conserva AggregateError como caso limite del constructor variadico", () => {
+  const aggregate = new AggregateError(
+    [new Error("uno"), new Error("dos")],
+    "dato sensible agregado",
+  );
+
+  assert.deepEqual(serializeError(aggregate), {
+    name: "AggregateError",
     messageSanitized: "[REDACTED]",
   });
 });
 
-test("serializeError degrada nombres de error inválidos a Error", () => {
-  const error = new Error("mensaje irrelevante");
+test("serializeError degrada a Error cualquier name con forma de identificador pero fuera de la allowlist finita", () => {
+  // Una regex sintactica ("cualquier identificador valido") sigue aceptando
+  // nombres con forma de PII. Sólo una lista cerrada de valores conocidos
+  // elimina esa clase de fuga; estos nombres pasarian una regex de
+  // identificador pero deben degradar igual que un name con espacios.
+  for (const rejectedName of [
+    "MariaGomez",
+    "Paciente_307",
+    "HistoriaClinica",
+    "BiopsiaAtipica",
+    "PostgresError",
+    "ZodError",
+    "FastifyError",
+    "ValidationError",
+    "Postgres Error usuario@example.com",
+  ]) {
+    const error = new Error("mensaje irrelevante");
 
-  error.name = "Postgres Error usuario@example.com";
+    error.name = rejectedName;
 
-  const serialized = serializeError(error) as Record<string, unknown>;
+    const serialized = serializeError(error) as Record<string, unknown>;
 
-  assert.deepEqual(serialized, {
-    name: "Error",
-    messageSanitized: "[REDACTED]",
-  });
-  assert.equal(JSON.stringify(serialized).includes("usuario@example.com"), false);
+    assert.deepEqual(
+      serialized,
+      { name: "Error", messageSanitized: "[REDACTED]" },
+      rejectedName,
+    );
+    assert.equal(
+      JSON.stringify(serialized).includes(rejectedName),
+      false,
+      rejectedName,
+    );
+  }
 });
 
 test("serializeError encapsula cualquier valor lanzado que no sea Error", () => {

--- a/test/unit/infrastructure/structured-logger.test.ts
+++ b/test/unit/infrastructure/structured-logger.test.ts
@@ -1,0 +1,234 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildStructuredLogEvent,
+  isSensitiveLogKey,
+  logError,
+  logInfo,
+  redactLogValue,
+  redactSensitiveText,
+  serializeError,
+} from "../../../server/lib/logger.ts";
+
+function captureJsonLine(
+  channel: "log" | "warn" | "error",
+  run: () => void,
+): Record<string, unknown> {
+  const original = console[channel];
+  const calls: unknown[][] = [];
+
+  console[channel] = (...args: unknown[]) => {
+    calls.push(args);
+  };
+
+  try {
+    run();
+  } finally {
+    console[channel] = original;
+  }
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].length, 1, "el logger emite una sola linea por evento");
+
+  return JSON.parse(calls[0][0] as string) as Record<string, unknown>;
+}
+
+test("el logger emite una linea JSON parseable con campos estables", () => {
+  const logEvent = captureJsonLine("log", () => {
+    logInfo("SAMPLE_EVENT", { clinicCount: 3 });
+  });
+
+  assert.deepEqual(Object.keys(logEvent).sort(), [
+    "context",
+    "event",
+    "level",
+    "timestamp",
+  ]);
+  assert.equal(logEvent.level, "info");
+  assert.equal(logEvent.event, "SAMPLE_EVENT");
+  assert.deepEqual(logEvent.context, { clinicCount: 3 });
+  assert.match(
+    logEvent.timestamp as string,
+    /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/,
+  );
+});
+
+test("el logger conserva requestId valido y descarta el invalido", () => {
+  const valid = captureJsonLine("error", () => {
+    logError("SAMPLE_ERROR", { requestId: "client-req_1.a:2", status: 500 });
+  });
+
+  assert.equal(valid.requestId, "client-req_1.a:2");
+  assert.deepEqual(valid.context, { status: 500 });
+
+  const invalid = captureJsonLine("error", () => {
+    logError("SAMPLE_ERROR", {
+      requestId: "bad id;Authorization=Bearer secret",
+      status: 500,
+    });
+  });
+
+  assert.equal("requestId" in invalid, false);
+  assert.deepEqual(invalid.context, { status: 500 });
+});
+
+test("redactLogValue redacta claves sensibles anidadas y en arrays", () => {
+  const redacted = redactLogValue({
+    outer: {
+      authorization: "Bearer abc",
+      cookie: "app_session_id=abc",
+      password: "hunter2",
+      clientSecret: "s",
+      serviceRoleKey: "s",
+      apiKey: "s",
+      accessToken: "s",
+      refreshToken: "s",
+      sessionId: "s",
+      tokenHash: "s",
+      rawToken: "s",
+      signedUrl: "s",
+      storagePath: "s",
+      databaseUrl: "s",
+      connectionString: "s",
+      dsn: "s",
+    },
+    list: [{ sessionToken: "s", tokenId: 12 }],
+  }) as Record<string, Record<string, unknown>>;
+
+  for (const value of Object.values(redacted.outer)) {
+    assert.equal(value, "[REDACTED]");
+  }
+
+  assert.deepEqual(redacted.list, [{ sessionToken: "[REDACTED]", tokenId: 12 }]);
+});
+
+test("redactLogValue preserva identificadores seguros", () => {
+  const redacted = redactLogValue({
+    tokenId: 4,
+    reportAccessTokenId: 5,
+    actorReportAccessTokenId: 6,
+    targetReportAccessTokenId: 7,
+    tokenCount: 8,
+    requestId: "req-1",
+  });
+
+  assert.deepEqual(redacted, {
+    tokenId: 4,
+    reportAccessTokenId: 5,
+    actorReportAccessTokenId: 6,
+    targetReportAccessTokenId: 7,
+    tokenCount: 8,
+    requestId: "req-1",
+  });
+
+  assert.equal(isSensitiveLogKey("tokenId"), false);
+  assert.equal(isSensitiveLogKey("requestId"), false);
+  assert.equal(isSensitiveLogKey("sessionId"), true);
+  assert.equal(isSensitiveLogKey("set-cookie"), true);
+  assert.equal(isSensitiveLogKey("proxy-authorization"), true);
+});
+
+test("redactSensitiveText redacta secretos embebidos en strings", () => {
+  assert.equal(
+    redactSensitiveText("Authorization: Bearer abc.def-ghi"),
+    "Authorization: Bearer [REDACTED]",
+  );
+  assert.equal(
+    redactSensitiveText(
+      "jwt eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxIn0.signature-part",
+    ),
+    "jwt [REDACTED]",
+  );
+  assert.equal(
+    redactSensitiveText("key sb_secret_abcdef123"),
+    "key [REDACTED]",
+  );
+  assert.equal(
+    redactSensitiveText("postgresql://user:pass@host:5432/db"),
+    "[REDACTED]",
+  );
+  assert.equal(
+    redactSensitiveText(
+      "https://cdn.example.com/storage/v1/object/sign/reports/a.pdf?token=abc",
+    ),
+    "[REDACTED]",
+  );
+  assert.equal(
+    redactSensitiveText("app_session_id=abc123; Path=/"),
+    "app_session_id=[REDACTED]; Path=/",
+  );
+});
+
+test("serializeError no expone stack ni detalles de driver", () => {
+  const error = new Error(
+    "connect failed for postgresql://user:pass@host:5432/db",
+  );
+  (error as Error & { query?: string }).query = "select * from clinics";
+
+  const serialized = serializeError(error) as Record<string, unknown>;
+
+  assert.deepEqual(serialized, {
+    name: "Error",
+    messageSanitized: "connect failed for [REDACTED]",
+  });
+  assert.equal("stack" in serialized, false);
+  assert.equal("query" in serialized, false);
+});
+
+test("el logger tolera referencias circulares, fechas y arrays", () => {
+  const circular: Record<string, unknown> = { name: "root" };
+  circular.self = circular;
+
+  const logEvent = captureJsonLine("log", () => {
+    logInfo("CIRCULAR_EVENT", {
+      circular,
+      when: new Date("2026-07-31T10:00:00.000Z"),
+      items: [1, "dos", { three: true }],
+    });
+  });
+
+  const context = logEvent.context as Record<string, unknown>;
+
+  assert.deepEqual(context.circular, { name: "root", self: "[Circular]" });
+  assert.equal(context.when, "2026-07-31T10:00:00.000Z");
+  assert.deepEqual(context.items, [1, "dos", { three: true }]);
+});
+
+test("el logger omite undefined y no muta el input original", () => {
+  const input = {
+    keep: 1,
+    drop: undefined,
+    nested: { password: "hunter2" },
+  };
+
+  const logEvent = captureJsonLine("log", () => {
+    logInfo("MUTATION_EVENT", input);
+  });
+
+  assert.deepEqual(logEvent.context, {
+    keep: 1,
+    nested: { password: "[REDACTED]" },
+  });
+  assert.equal(input.nested.password, "hunter2");
+  assert.equal("drop" in input, true);
+});
+
+test("buildStructuredLogEvent acota profundidad y volumen", () => {
+  let deep: Record<string, unknown> = { value: "leaf" };
+
+  for (let index = 0; index < 12; index += 1) {
+    deep = { nested: deep };
+  }
+
+  const logEvent = buildStructuredLogEvent("info", [
+    "DEEP_EVENT",
+    { deep, many: Array.from({ length: 200 }, (_item, index) => index) },
+  ]);
+
+  const serialized = JSON.stringify(logEvent);
+
+  assert.ok(serialized.includes("[MaxDepth]"));
+  assert.ok(serialized.includes("more]"));
+  assert.equal(logEvent.level, "info");
+  assert.equal(logEvent.event, "DEEP_EVENT");
+});


### PR DESCRIPTION
## Summary

- Change type: backend-only observability runtime implementation with supporting tests and mandatory M48 census alignment.
- Context / issue: Plan B slot 14/18, `PR-OBS-BACKEND-STRUCTURED-LOGGING-METRICS`, absorbing `PR-OBS-2` and `PR-OBS-3`.
- What changed: structured JSON logging, centralized redaction, UUID v4 request-ID correlation, bounded in-process HTTP metrics, and a private authenticated admin metrics query.
- Non-scope: frontend, DB, schema, migrations, dependencies, workflows, providers, staging, production, alerts, dashboards, paging, and RLS.

## Scope

- [x] backend runtime
- [ ] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Tests and the M48 LOC certification update are supporting evidence for the single backend runtime primary scope, not independent scopes. The existing architecture guard compares the computed backend census with the versioned M48 table, so the numeric realignment is required to keep the current validation contract green; it does not change census logic or narrative.

## Mixed-Scope Justification

Not applicable. Tests and documentation are supporting evidence for the single backend runtime scope.

## Other Scope Detail

Not applicable.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference: Not applicable.
- Justification: This change implements the local observability design already approved in `docs/ops/METRICS_BASELINE.md`. It does not alter service boundaries, deployment topology, external providers, the data model, database schema, authentication model, governed workflows, or public HTTP contracts. Metrics remain in-process and the query reuses the existing authenticated admin system-health plugin.

## Implementation

- Emits structured one-line JSON logs with a stable shape (`timestamp`, `level`, `event`, `requestId?`, `context`); preserves `logInfo`, `logWarn`, `logError`, and `serializeError`.
- `serializeError` returns a closed envelope: only `name` (validated against a finite allowlist of native Error classes; anything else, including identifier-shaped names, degrades to `Error`) and a fixed `messageSanitized` value. Free-form error messages are never exported.
- The global Fastify error handler (`API_ERROR`) and the pricing error handlers omit `error.code`/`safeCode` entirely — no partial allowlist of SQLSTATE or library codes.
- Incoming request IDs are preserved only when they are UUID v4; any other value (including credential-shaped or opaque tokens) is replaced by a server-generated `randomUUID()`. The logger promotes `requestId` to the top level of an event only after `isSafeRequestId` validates it.
- Removed the broad `tokenId`/`count` suffix exemption from sensitive-key redaction: `sessionTokenId`, `reportAccessTokenId`, `tokenCount`, and `refreshTokenCount` are always redacted regardless of suffix.
- Request-completion logs use normalized route templates only; no raw URL, path identifiers, or query values ever reach a log line.
- In-process request metrics (started/completed, in-flight, status-class, 5xx, error-rate, latency) finalize each request exactly once via a shared abort/completion finalizer, preventing in-flight gauge drift or double accounting on client disconnects.
- `GET /api/admin/system/health/metrics` reads from the `ObservabilityMetricsRegistry` instrumenting the current app (supports dependency injection for tests/multi-instance hosts) while preserving an explicit override; requires the existing admin session auth plus CORS preflight.
- Preserves status codes, response bodies, headers, CORS, `no-store`, auth, and public health behavior throughout.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected)
- [ ] `pnpm --dir frontend typecheck` (if frontend affected)
- [ ] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [x] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI when applicable`)

Additional local validation (final head):

- Focused fail-fast suite: PASSED — 138 tests / 138 pass / 0 fail.
- `pnpm lint:backend`: PASSED — 0 errors / 49 pre-existing warnings.
- `pnpm validate:local`: PASSED — 4080 tests / 4079 pass / 0 fail / 1 pre-existing skip.
- `pnpm build`: PASSED — 939.4kb.
- `pnpm security:public-surface`: PASSED.
- `git diff --check`: PASSED.
- Relevant CI checks: PASSED — 11 successful / 2 skipped / 0 pending / 0 failing.
- Frontend heavy validation, DB, schema, migrations, staging, and production: NOT_RUN / skipped as out of scope.

### M48 final census

| Area | Files | LOC |
| --- | ---: | ---: |
| `server/features` | 149 | 16,980 |
| `server/routes` | 35 | 22,934 |
| `server/lib` | 28 | 4,628 |
| `server/middlewares` | 7 | 947 |
| server root | 9 | 2,371 |
| **Total** | **228** | **47,860** |

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

Resulting limits: global console unification and access-log coverage remain `PARTIAL`; alerts and dashboards remain `NOT_IMPLEMENTED`; SLO compliance remains `NOT_VERIFIED`; `ERM-CTRL-021` remains `PARTIAL`; `ERM-OBS-001` remains `OPEN`.

## Rollback

- Trigger: logging/redaction regression, cardinality growth, private endpoint exposure, performance regression, or HTTP contract change.
- Steps: revert the squash commit for this pull request.
- Data impact: none. No schema, migration, persisted data, provider configuration, or environment variable is changed.
