### PR TITLE
fix(audit): isolate session revocation audit failures

### DIFF
--- a/docs/implementation/admin-session-revocation-audit-failure-isolation.md
+++ b/docs/implementation/admin-session-revocation-audit-failure-isolation.md
@@ -1,0 +1,158 @@
+# Aislamiento de fallos de auditoría en revocación de sesiones admin
+
+## Baseline
+
+```text
+branch: main
+HEAD antes del cambio: 544c70cbb8d94ad03089e5daab789c485e4f175a
+origin/main: 544c70cbb8d94ad03089e5daab789c485e4f175a
+working tree antes del cambio: clean
+stashes: 4 declarados por Nico; no inspeccionados (git stash prohibido); preservados
+```
+
+## Problema
+
+`server/routes/admin-sessions.fastify.ts`, ruta `POST /:sessionType/:sessionId/revoke`,
+revocaba la sesión mediante `revokeAdminSessionById` y a continuación ejecutaba
+`await deps.createAuditLog(...)` sin `try/catch`, antes de responder `200`. Si la
+escritura de auditoría fallaba (rechazo de la promesa), el error se propagaba a
+Fastify y la ruta devolvía un error HTTP **aunque la revocación de sesión ya se
+había persistido exitosamente**. Esto contradice el contrato ya vigente en el resto
+del sistema (`server/lib/audit.ts`, función `writeAuditLog`): un fallo de escritura de
+auditoría no debe alterar una respuesta de negocio exitosa.
+
+Esta unidad no forma parte del Plan B / slots 1-18 ni cierra ningún control
+enterprise. Control candidato: `ERM-CTRL-016` (Security Hardening Program), que
+permanece `PARTIAL` después de este cambio.
+
+## Scope incluido
+
+- `server/routes/admin-sessions.fastify.ts`: aislar exclusivamente la llamada
+  `deps.createAuditLog(...)` de la ruta de revocación con `try/catch`.
+- Test de regresión runtime que fuerza el fallo de `createAuditLog` y verifica que
+  la respuesta de negocio permanece intacta.
+- Recalculo del censo LOC congelado de M48 para `server/routes` y el total
+  `server`, único efecto colateral físico del cambio.
+
+## Scope excluido
+
+- No se modifica el payload exitoso de auditoría (mismos campos, mismo orden).
+- No se modifica autenticación, CORS, `enforceTrustedOrigin`, `no-store`, permisos
+  ni el contrato de respuesta de ninguna otra ruta.
+- No se introduce ningún helper global ni refactor del subsistema de auditoría
+  (`server/lib/audit.ts`, `server/lib/audit-log.ts`, `server/db-audit.ts` no se
+  tocan).
+- No se resuelve la duplicación de registros `AUDIT_EVENTS` ni la ausencia de
+  redacción de metadata sensible identificados previamente en el inventario R0 de
+  auditoría — son hallazgos separados, con causa raíz distinta, fuera de esta
+  unidad.
+- No se toca staging, producción, DB real, restore ni rollback.
+
+## Clasificación
+
+```text
+Tipo: backend-only security hardening
+Riesgo: R2
+Control: ERM-CTRL-016 (permanece PARTIAL)
+Slot Plan B: ninguno
+```
+
+## Cambio aplicado
+
+En `server/routes/admin-sessions.fastify.ts`:
+
+1. Se importan `logError` y `serializeError` desde `../lib/logger.ts` (funciones ya
+   existentes y exportadas; no se duplica ni se crea un segundo motor de logging).
+2. Se conserva el orden de la ruta sin alteración: autenticar → validar parámetros
+   → bloquear auto-revocación → revocar sesión (`revokeAdminSessionById`) → 404 si
+   no existe → **intentar auditoría** → responder `200`.
+3. Se envuelve exclusivamente la llamada `await deps.createAuditLog({...})` en
+   `try/catch`. El payload de auditoría exitoso no cambia.
+4. En caso de error:
+   - no se relanza (`catch` sin `throw`);
+   - no se modifica `statusCode`, headers ni body de la respuesta ya planificada;
+   - se emite `logError("ADMIN_SESSION_REVOKE_AUDIT_WRITE_ERROR", { requestId,
+     event, error })`;
+   - `error` se serializa con `serializeError` (envelope cerrado: solo nombre de
+     clase de error contra allowlist finita, mensaje siempre `[REDACTED]`);
+   - `requestId` es `request.id` (UUID v4 generado por
+     `generateFastifyRequestId`/`genReqId` de Fastify); `buildStructuredLogEvent`
+     de `server/lib/logger.ts` solo lo promueve al log si pasa `isSafeRequestId`,
+     igual que en `server/lib/audit.ts`;
+   - `event` es únicamente el nombre del evento de auditoría afectado
+     (`"auth.session.revoked"`);
+   - el log **no incluye** `sessionId`, `actorId`, IP, user-agent, URL,
+     `metadata`, cookie, token, hash ni el mensaje crudo del error.
+5. `deps.createAuditLog` se conserva como dependencia inyectable (sin cambios en
+   `AdminSessionsNativeRoutesOptions`).
+
+## Contrato HTTP preservado
+
+- `POST /:sessionType/:sessionId/revoke` sigue devolviendo `200` con
+  `{ success: true, revokedSession, revokedBy }` cuando la revocación tiene éxito,
+  **independientemente de si la escritura de auditoría tuvo éxito o falló**.
+- Los códigos `400` (parámetros inválidos / auto-revocación) y `404` (sesión no
+  encontrada) no cambian: en esos casos `createAuditLog` ni siquiera se invoca,
+  igual que antes.
+- CORS, `enforceTrustedOrigin`, autenticación admin y el resto de rutas del
+  archivo (`GET /`, `OPTIONS`) permanecen sin modificación.
+
+## Tests ejecutados y estados canónicos
+
+```text
+node --test test/integration/adapters/controllers/admin-sessions.fastify.test.ts
+  → PASSED (11/11, incluye el nuevo test de regresión, exit code 0)
+
+node --test test/architecture/backend-modularization-m48-final-certification.test.ts
+  → PASSED (35/35, incluye M44/M45/M46 delegados y el censo LOC recalculado, exit code 0)
+
+pnpm lint:backend             → PASSED (0 errores, 49 warnings preexistentes, exit code 0;
+                                  admin-sessions.fastify.ts solo conserva el warning
+                                  preexistente de "ENV" no usado, sin warnings nuevos)
+pnpm validate:local            → PASSED (typecheck + typecheck:test + test + build;
+                                  4081 tests, 4080 pass, 1 skipped, 0 fail; build esbuild
+                                  exitoso; exit code 0)
+pnpm security:public-surface   → PASSED (sin hallazgos de exposición devtools pública;
+                                  exit code 0; los dos findings "server-only" listados son
+                                  preexistentes y no relacionados con este cambio)
+git diff --check               → PASSED (exit code 0, sin errores de espacio en blanco)
+```
+
+No se afirma ningún estado `PASSED` sin exit code 0 observado.
+
+## Riesgo residual
+
+- El aislamiento cubre únicamente la llamada `createAuditLog` de esta ruta. El
+  patrón de escritura directa de auditoría (sin pasar por `writeAuditLog` de
+  `server/lib/audit.ts`) en `admin-sessions.fastify.ts` se conserva intacto — no
+  se unificó con el resto del sistema porque el pedido de esta unidad fue
+  exclusivamente el aislamiento de fallos, no un refactor del subsistema.
+- La ausencia de redacción centralizada de `metadata` sensible en la vía de
+  auditoría (hallazgo previo, no resuelto aquí) sigue vigente para todas las
+  rutas, incluida esta.
+- No se declara esta auditoría "durable", "no repudiable", "compliant" ni
+  "completa". Este cambio solo evita que un fallo transitorio de escritura de
+  auditoría degrade una operación de negocio ya exitosa; no mejora la
+  durabilidad ni la integridad del propio registro de auditoría.
+- El log de error (`ADMIN_SESSION_REVOKE_AUDIT_WRITE_ERROR`) no contiene
+  suficiente detalle para diagnosticar la causa exacta del fallo de escritura sin
+  acceso a los logs de la capa de datos — deliberado, para no exponer
+  información sensible en el log estructurado.
+
+## Rollback lógico
+
+Revertir el commit que introduce este cambio restaura el comportamiento anterior
+(fallo de auditoría propaga error HTTP). No hay migración de schema, no hay dato
+persistido que dependa de este cambio, no hay estado externo a revertir. Reversión
+= `git revert` del commit correspondiente (comando `[MANUAL-NICO]`, no ejecutado
+por el agente).
+
+## Estado final
+
+```text
+Código modificado: SÍ, dentro de la allowlist autorizada por Nico
+Implementación autorizada: SÍ (R2, autorización explícita en el mensaje de Nico)
+Staging/producción/DB real: BLOCKED (no aplica, no se intentó)
+Cierre de control enterprise: NO — ERM-CTRL-016 permanece PARTIAL
+Cierre de slot Plan B: NO — esta unidad no es un slot
+```

--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -195,12 +195,12 @@ newline final no se cuenta.
 | Área | Archivos TypeScript | LOC |
 | --- | ---: | ---: |
 | `server/features` | 149 | 16.980 |
-| `server/routes` | 35 | 22.934 |
+| `server/routes` | 35 | 22.943 |
 | `server/lib` | 28 | 4.628 |
 | `server/middlewares` | 7 | 947 |
 | raíz/entrypoints `server/*.ts` | 9 | 2.371 |
 | otros | 0 | 0 |
-| **Total `server`** | **228** | **47.860** |
+| **Total `server`** | **228** | **47.869** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por

--- a/server/routes/admin-sessions.fastify.ts
+++ b/server/routes/admin-sessions.fastify.ts
@@ -12,6 +12,7 @@ import {
   enforceTrustedOrigin,
 } from "../lib/cors-headers.ts";
 import { authenticateFastifyAdmin } from "../lib/fastify-admin-auth.ts";
+import { logError, serializeError } from "../lib/logger.ts";
 import type {
   AdminSessionsQuery,
   AdminSessionsSnapshot,
@@ -409,37 +410,45 @@ export const adminSessionsNativeRoutes: FastifyPluginAsync<
         });
       }
 
-      await deps.createAuditLog({
-        event: "auth.session.revoked",
-        actorType: "admin_user",
-        actorAdminUserId: admin.id,
-        targetAdminUserId:
-          revokedSession.actorType === "admin_user"
-            ? revokedSession.actorId
-            : null,
-        targetClinicUserId:
-          revokedSession.actorType === "clinic_user"
-            ? revokedSession.actorId
-            : null,
-        requestMethod: request.method,
-        requestPath: request.url,
-        ipAddress: request.ip,
-        userAgent: getRequestUserAgent(request),
-        metadata: {
-          sessionType: revokedSession.sessionType,
-          sessionId: revokedSession.sessionId,
-          actorType: revokedSession.actorType,
-          actorId: revokedSession.actorId,
-          statusAtRevocation: revokedSession.status,
-          createdAt: revokedSession.createdAt,
-          lastAccess: revokedSession.lastAccess,
-          expiresAt: revokedSession.expiresAt,
-          revokedAt: revokedSession.revokedAt,
-        },
-        action: "auth.session.revoked",
-        entity: "session",
-        entityId: revokedSession.sessionId,
-      });
+      try {
+        await deps.createAuditLog({
+          event: "auth.session.revoked",
+          actorType: "admin_user",
+          actorAdminUserId: admin.id,
+          targetAdminUserId:
+            revokedSession.actorType === "admin_user"
+              ? revokedSession.actorId
+              : null,
+          targetClinicUserId:
+            revokedSession.actorType === "clinic_user"
+              ? revokedSession.actorId
+              : null,
+          requestMethod: request.method,
+          requestPath: request.url,
+          ipAddress: request.ip,
+          userAgent: getRequestUserAgent(request),
+          metadata: {
+            sessionType: revokedSession.sessionType,
+            sessionId: revokedSession.sessionId,
+            actorType: revokedSession.actorType,
+            actorId: revokedSession.actorId,
+            statusAtRevocation: revokedSession.status,
+            createdAt: revokedSession.createdAt,
+            lastAccess: revokedSession.lastAccess,
+            expiresAt: revokedSession.expiresAt,
+            revokedAt: revokedSession.revokedAt,
+          },
+          action: "auth.session.revoked",
+          entity: "session",
+          entityId: revokedSession.sessionId,
+        });
+      } catch (error) {
+        logError("ADMIN_SESSION_REVOKE_AUDIT_WRITE_ERROR", {
+          requestId: request.id,
+          event: "auth.session.revoked",
+          error: serializeError(error),
+        });
+      }
 
       return reply.code(200).send({
         success: true,

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -82,7 +82,7 @@ const m47KeepPaths = [
 
 const expectedAreaCensus = {
   "server/features": { files: 149, loc: 16_980 },
-  "server/routes": { files: 35, loc: 22_934 },
+  "server/routes": { files: 35, loc: 22_943 },
   "server/lib": { files: 28, loc: 4_628 },
   "server/middlewares": { files: 7, loc: 947 },
   "server root": { files: 9, loc: 2_371 },
@@ -268,7 +268,7 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_860,
+    47_869,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 228, loc: 47_860 }],
+    ["Total server", { files: 228, loc: 47_869 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/integration/adapters/controllers/admin-sessions.fastify.test.ts
+++ b/test/integration/adapters/controllers/admin-sessions.fastify.test.ts
@@ -268,6 +268,65 @@ test("admin sessions revoca sesión remota y audita sin filtrar tokenHash", asyn
   }
 });
 
+test("admin sessions revoke conserva 200 y success cuando createAuditLog falla", async () => {
+  const app = Fastify();
+  const revokeCalls: unknown[] = [];
+  let auditAttempted = false;
+
+  await app.register(
+    adminSessionsNativeRoutes,
+    buildDeps({
+      revokeAdminSessionById: async (target): Promise<AdminSessionRevocationResult> => {
+        revokeCalls.push(target);
+
+        return {
+          sessionType: "clinic",
+          sessionId: target.sessionId,
+          actorType: "clinic_user",
+          actorId: 7,
+          createdAt: "2026-05-08T00:00:00.000Z",
+          lastAccess: "2026-05-08T00:10:00.000Z",
+          expiresAt: "2099-01-01T00:00:00.000Z",
+          status: "active",
+          revokedAt: "2026-05-08T00:00:00.000Z",
+        };
+      },
+      createAuditLog: async () => {
+        auditAttempted = true;
+        throw new Error("db down");
+      },
+    }),
+  );
+
+  try {
+    const response = await app.inject({
+      method: "POST",
+      url: "/clinic/20/revoke",
+      headers: {
+        cookie: `${ENV.adminCookieName}=admin-session-token`,
+        "user-agent": "node-test",
+      },
+    });
+
+    assert.equal(response.statusCode, 200);
+
+    const body = JSON.parse(response.body);
+    const serialized = JSON.stringify(body);
+
+    assert.equal(body.success, true);
+    assert.equal(body.revokedSession.sessionType, "clinic");
+    assert.equal(body.revokedSession.sessionId, 20);
+    assert.equal(body.revokedSession.tokenHash, undefined);
+    assert.equal(body.revokedSession.token, undefined);
+    assert.equal(serialized.includes("hash:"), false);
+    assert.equal(serialized.includes("admin-session-token"), false);
+    assert.equal(auditAttempted, true);
+    assert.deepEqual(revokeCalls, [{ sessionType: "clinic", sessionId: 20 }]);
+  } finally {
+    await app.close();
+  }
+});
+
 test("admin sessions bloquea auto-revocación de sesión admin actual", async () => {
   const app = Fastify();
   let revokeCalled = false;


### PR DESCRIPTION
## Summary

- isolate audit persistence failures from successful admin session revocations
- preserve the existing `200` response and revoked-session result when `createAuditLog` rejects
- emit a structured, redacted diagnostic without session, actor, request-path, credential, or metadata values
- add runtime regression coverage for the audit-failure path
- realign the frozen M48 backend LOC census
- document scope, validation, residual risks, and logical rollback

## Scope

- [x] backend runtime

Supporting changes:

- integration regression tests
- architecture census guard realignment
- implementation and certification documentation

Risk classification:

- **Risk:** R2
- **Scope:** backend-only security hardening
- **Enterprise control:** supports `ERM-CTRL-016`, which remains `PARTIAL`
- **Plan B slot:** none

## Validation

- `admin-sessions.fastify.test.ts`: **PASSED — 11/11**
- M48 final-certification guard: **PASSED — 35/35**
- `pnpm lint:backend`: **PASSED — 0 errors, 49 baseline warnings**
- `pnpm validate:local`: **PASSED**
  - 4081 tests
  - 4080 passed
  - 1 skipped
  - 0 failed
  - build passed
- `pnpm security:public-surface`: **PASSED**
- `git diff --check`: **PASSED**
- commit signature: **PASSED**
  - commit: `f602d12b48999d65edfc70e89793c7cb42230cb2`
  - SSH signature verified locally

## Rollback

Revert commit `f602d12b48999d65edfc70e89793c7cb42230cb2`.

This restores the previous behavior in which an audit persistence failure propagates through the session-revocation route.

This PR introduces:

- no schema migration
- no database transformation
- no data backfill
- no dependency change
- no workflow change
- no staging or production operation
- no external infrastructure state

The rollback command is manual and is not executed by the agent.

## Explicit exclusions

This PR does not:

- centralize audit metadata redaction
- remove or transform clinical metadata such as `patientName`
- unify the parallel `AUDIT_EVENTS` registries
- change audit schema, retention, deletion, or immutability
- modify authentication, CORS, trusted-origin enforcement, permissions, or response contracts
- perform staging, production, real-database, restore, rollback, RLS, or cross-tenant operations
- close `ERM-CTRL-016`
- close any Plan B slot

## Residual risk

The route continues to write directly through `createAuditLog` rather than the shared `writeAuditLog` abstraction.

Centralized audit metadata sanitization, clinical metadata classification, and audit-event registry consolidation remain separate unresolved findings.