### PR TITLE
fix(dashboard): stabilize informes adaptive rows

### DIFF
--- a/frontend/src/app/dashboard/informes/InformesReportsList.tsx
+++ b/frontend/src/app/dashboard/informes/InformesReportsList.tsx
@@ -269,10 +269,20 @@ export function InformesReportsList({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [query]);
 
+  // The measured `effectiveLimit` can shrink faster than the corrective
+  // server re-fetch resolves (network round trip). Capping the rendered
+  // rows at the current limit prevents briefly showing more rows than the
+  // measured canvas actually fits (silent clipping under `overflow-hidden`)
+  // while the fetch for the smaller page size is still in flight.
+  const visibleReports = useMemo(
+    () => (reports.length > effectiveLimit ? reports.slice(0, effectiveLimit) : reports),
+    [reports, effectiveLimit],
+  );
+
   const reportsTotalPages = Math.max(1, Math.ceil(totalCount / effectiveLimit));
   const page = Math.min(Math.floor(offset / effectiveLimit) + 1, reportsTotalPages);
   const pageStart = totalCount > 0 ? offset + 1 : 0;
-  const pageEnd = Math.min(offset + reports.length, totalCount);
+  const pageEnd = Math.min(offset + visibleReports.length, totalCount);
   const hasActiveFilters = Boolean(filters.query || filters.status || filters.studyType);
 
   const selectedReport =
@@ -555,7 +565,7 @@ export function InformesReportsList({
               data-informes-rows-canvas="true"
               className="flex min-h-0 flex-1 flex-col divide-y divide-vetneb-line/60 overflow-hidden"
             >
-              {reports.map((report, index) => {
+              {visibleReports.map((report, index) => {
                 const isSelected = selectedReport?.id === report.id;
 
                 return (

--- a/test/unit/ui/dashboard/frontend-dashboard-empty-states.test.ts
+++ b/test/unit/ui/dashboard/frontend-dashboard-empty-states.test.ts
@@ -60,7 +60,7 @@ test("dashboard informes page shows empty state when reports are unavailable", (
   assert.ok(listSource.includes('role="alert"'));
   assert.ok(listSource.includes("No hay informes disponibles."));
   assert.ok(listSource.includes("<EmptyState"));
-  assert.ok(listSource.includes("reports.map((report"));
+  assert.ok(listSource.includes("visibleReports.map((report"));
 });
 
 test("dashboard logistics page distinguishes overview load failures from empty states", () => {

--- a/test/unit/ui/dashboard/frontend-dashboard-informes.test.ts
+++ b/test/unit/ui/dashboard/frontend-dashboard-informes.test.ts
@@ -156,7 +156,7 @@ test("dashboard informes renders compact inline filters and profile-layout list/
 test("dashboard informes keeps list rendering badges dates and selected report actions", () => {
   const source = read(INFORMES_LIST_PATH);
 
-  assert.ok(source.includes("reports.map((report, index) =>"));
+  assert.ok(source.includes("visibleReports.map((report, index) =>"));
   assert.ok(source.includes("const isSelected = selectedReport?.id === report.id;"));
   assert.ok(source.includes('report.patientName ?? "Paciente sin nombre"'));
   assert.ok(source.includes('report.studyType ?? "Tipo sin registrar"'));

--- a/test/unit/ui/dashboard/frontend-dashboard-reports-master-detail.test.ts
+++ b/test/unit/ui/dashboard/frontend-dashboard-reports-master-detail.test.ts
@@ -150,8 +150,15 @@ test("dashboard informes pagination is server-adaptive and does not use client-s
   assert.ok(source.includes("useAdaptiveItemsPerPage"));
   assert.ok(source.includes("effectiveLimit = rowsPerPage"));
   assert.ok(source.includes("getInformesPage("));
-  assert.equal(source.includes("reports.slice("), false);
+  // Pagination itself must stay server-driven (page/pageSize/offset via
+  // getInformesPage): no offset-based client slice may stand in for it.
+  assert.equal(source.includes("reports.slice(offset"), false);
   assert.equal(source.includes("reports.filter("), false);
+  // The one allowed client-side trim caps the already-fetched page at the
+  // measured canvas capacity (always from index 0, never offset-derived) so
+  // the corrective re-fetch's network latency can't render more rows than
+  // the container actually fits.
+  assert.ok(source.includes("reports.slice(0, effectiveLimit)"));
 });
 
 test("dashboard informes reportId null selects first report by default without silent fallback", () => {

--- a/test/unit/ui/frontend/frontend-reports-live-read-contract.test.ts
+++ b/test/unit/ui/frontend/frontend-reports-live-read-contract.test.ts
@@ -48,7 +48,7 @@ test("frontend reports page uses reports API client wrapper", () => {
   assertIncludes(source, ": await getReportsPaginated(", reportsPage);
   assertIncludes(source, "{ throwOnError: true }", reportsPage);
   assertIncludes(source, "const reports = pagedResult.reports", reportsPage);
-  assertIncludes(listSource, "reports.map", reportsList);
+  assertIncludes(listSource, "visibleReports.map", reportsList);
   assertIncludes(listSource, "reports.length", reportsList);
   assertIncludes(listSource, "totalCount", reportsList);
   assertIncludes(listSource, "reportsTotalPages", reportsList);


### PR DESCRIPTION
## Summary

- Change type: frontend runtime bug fix.
- Context / issue: `E2E Completeness` run `30720839274` reproduced a race in `/dashboard/informes`: mobile could expose the six-row SSR fallback before its corrective adaptive fetch resolved, then desktop rendered the correctly measured two-row result and violated `desktopRows >= mobileRows`.
- What changed: caps the currently rendered reports to the measured `effectiveLimit` while the corrective server fetch is in flight. Server-side adaptive pagination, offset handling, request-id race protection and the existing E2E contract remain intact.

## Scope

Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [x] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

The four modified unit-contract files support the single frontend-runtime change and are not an independent primary scope.

## Mixed-Scope Justification

Not applicable. Exactly one primary scope is selected.

## Other Scope Detail

Not applicable.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference: Not applicable.
- Justification: The fix preserves the established server-adaptive pagination architecture, existing Server Action, request-id anti-race mechanism, data model and workflow boundaries. It only prevents stale already-fetched rows from exceeding the currently measured canvas capacity while the corrective fetch resolves.

## Validation

- [ ] `pnpm typecheck` — not required separately; frontend typecheck and repository test typecheck passed.
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [ ] `pnpm build` — backend not affected.
- [x] `pnpm --dir frontend lint`
- [x] `pnpm --dir frontend typecheck`
- [x] `pnpm --dir frontend build`
- [ ] `pnpm audit --prod` — dependencies not affected.
- [ ] `pnpm audit` — dependencies not affected.
- [ ] Relevant CI checks passed — `Frontend CI`, `Backend CI` and QGA passed on the functional head; `PR Governance` is being refreshed after this body correction.

Additional focused evidence:

- `pnpm install --frozen-lockfile`: passed.
- `pnpm --dir frontend e2e:verify-catalog`: passed.
- `dashboard-adaptive-rows.spec.ts --repeat-each=5`: passed, 15/15.
- Focused adaptive-row test with `--repeat-each=25 --workers=10`: passed, 25/25.
- `dashboard-informes-server-adaptive-pagination.spec.ts --repeat-each=3`: passed, 15/15.
- `pnpm test`: passed, 4,080/4,081 with one pre-existing skip.
- `pnpm security:public-surface`: passed.
- `pnpm --dir frontend e2e:verify-teardown`: passed.
- `git diff --check`: passed.

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs or config.
- [x] AuthN/AuthZ and data-access impact reviewed; no authentication, authorization or data-source change.
- [x] Dependency and supply-chain impact reviewed; manifests and lockfile are unchanged.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact explicitly not applicable.

## Rollback

- Trigger: regression in report selection, adaptive page sizing, pagination, visible-row accounting or frontend CI attributable to this change.
- Steps: revert the squash commit produced by this PR.
- Data impact: none. No database, schema, migration, dependency, lockfile, external environment or production state is modified.