### PR TITLE
fix(security): resolve dependency advisories

### DIFF
--- a/docs/implementation/security-fast-uri-postcss-brace-expansion-advisory-hotfix.md
+++ b/docs/implementation/security-fast-uri-postcss-brace-expansion-advisory-hotfix.md
@@ -1,0 +1,133 @@
+# Hotfix de advisories de fast-uri, PostCSS y brace-expansion
+
+## Estado base
+
+- Fecha: 2026-08-05.
+- Repositorio: `C:\PORTAL-VETNEB`.
+- Rama: `security/fast-uri-postcss-advisories`.
+- Base exacta: `45acfa79dad87432c932e8f381572602408fec6a`.
+- Commit de implementación: `d9ffa3b432858c90a5f5142c1342f5764c7134a7`.
+- El árbol y el índice estaban limpios antes de iniciar la remediación.
+- `fast-uri` resolvía a `3.1.4` y `4.1.1`.
+- PostCSS resolvía a `8.5.19`.
+- `brace-expansion` resolvía a `5.0.8` para el toolchain de desarrollo.
+
+## Scope incluido
+
+- Actualización del override de `fast-uri` 3.x a la versión parcheada `3.1.5`.
+- Actualización del override de `fast-uri` 4.x a la versión parcheada `4.1.2`.
+- Actualización del override de PostCSS a la versión parcheada `8.5.23`.
+- Actualización del override de `brace-expansion` a la versión parcheada `5.0.9`.
+- Acotación del selector de `brace-expansion` al rango vulnerable real.
+- Regeneración controlada de `pnpm-lock.yaml`.
+- Realineación del contrato exacto de overrides de seguridad en
+  `test/architecture/toolchain-contract.test.ts`.
+
+## Scope excluido
+
+- Runtime frontend y backend.
+- `package.json` y `frontend/package.json`.
+- Fastify, Next.js y cualquier upgrade major.
+- Dependencias directas nuevas.
+- Workflows, schema, migraciones, autenticación y configuración productiva.
+- A01 y el PR #1637.
+- Deploy y merge.
+
+## Auditoría previa
+
+- `pnpm audit --prod` detectó dos advisories high de `fast-uri` por confusión
+  de host mediante un introductor de autoridad con barra invertida.
+- La rama 3.x requería como mínimo `fast-uri@3.1.5`.
+- La rama 4.x requería como mínimo `fast-uri@4.1.2`.
+- PostCSS era vulnerable hasta `8.5.22`; la versión corregida mínima era
+  `8.5.23`.
+- Después de resolver los advisories productivos, `pnpm audit` detectó
+  `brace-expansion@5.0.8` en dependencias de desarrollo del toolchain ESLint.
+- El rango vulnerable de `brace-expansion` era `>=4.0.0 <5.0.9`; la versión
+  corregida mínima era `5.0.9`.
+- No se deshabilitó ningún audit ni se redujo su nivel de bloqueo.
+
+## Cambios
+
+- `pnpm-workspace.yaml`:
+  - `"fast-uri@<3.1.5": "3.1.5"`.
+  - `"fast-uri@>=4.0.0 <4.1.2": "4.1.2"`.
+  - `"postcss@<=8.5.22": "8.5.23"`.
+  - `"brace-expansion@>=4.0.0 <5.0.9": "5.0.9"`.
+
+- `pnpm-lock.yaml`:
+  - `fast-uri@3.1.4` fue reemplazado por `fast-uri@3.1.5`.
+  - `fast-uri@4.1.1` fue reemplazado por `fast-uri@4.1.2`.
+  - PostCSS `8.5.19` fue reemplazado por `8.5.23`.
+  - `nanoid@3.3.12` fue reemplazado por `3.3.17` como dependencia transitiva
+    de PostCSS `8.5.23`.
+  - `brace-expansion@5.0.8` fue reemplazado por `5.0.9`.
+  - `minimatch@3.1.5` volvió a resolver su dependencia nativa compatible
+    `brace-expansion@1.1.18`, fuera del rango vulnerable de la rama 5.x.
+  - `balanced-match@1.0.2` y `concat-map@0.0.1` se incorporaron únicamente
+    como transitivas de `brace-expansion@1.1.18`.
+  - No se agregaron dependencias directas ni upgrades major.
+
+- `test/architecture/toolchain-contract.test.ts`:
+  - Se actualizaron únicamente las expectativas literales correspondientes a
+    los cuatro overrides remediados.
+  - El guard conserva su estructura y sus assertions estrictas.
+
+## Archivos de implementación
+
+- `pnpm-workspace.yaml`.
+- `pnpm-lock.yaml`.
+- `test/architecture/toolchain-contract.test.ts`.
+- `docs/implementation/security-fast-uri-postcss-brace-expansion-advisory-hotfix.md`.
+
+## Validaciones
+
+- `pnpm install --frozen-lockfile` — `PASSED`.
+- Test dirigido de `test/architecture/toolchain-contract.test.ts` —
+  `PASSED`; 8/8.
+- `pnpm audit --prod` — `PASSED`; sin vulnerabilidades conocidas.
+- `pnpm audit` — `PASSED`; sin vulnerabilidades conocidas.
+- `pnpm validate:local` — `PASSED`; 4111 aprobados, 0 fallos y 1 omitido
+  preexistente.
+- `pnpm --dir frontend lint` — `PASSED`.
+- `pnpm --dir frontend typecheck` — `PASSED`.
+- `pnpm --dir frontend build` — `PASSED`.
+- `pnpm security:public-surface` — `PASSED`.
+- `git diff --check` — `PASSED`.
+- Checks requeridos de #1638 — `PASSED` antes del commit documental.
+
+## Resultado
+
+El workspace queda con resoluciones parcheadas de:
+
+- `fast-uri@3.1.5`;
+- `fast-uri@4.1.2`;
+- `postcss@8.5.23`;
+- `brace-expansion@5.0.9`.
+
+Las auditorías productiva y completa terminan con exit code 0. El cambio no
+introduce upgrades major ni dependencias directas nuevas y no modifica código
+de runtime.
+
+## Riesgo residual
+
+- `brace-expansion@1.1.18` permanece como dependencia legítima de
+  `minimatch@3.1.5`. No pertenece al rango vulnerable
+  `>=4.0.0 <5.0.9`.
+- Los cambios afectan resoluciones transitivas y tooling. La instalación
+  frozen, los audits, el contrato de arquitectura y la validación general
+  reducen el riesgo de incompatibilidad.
+- Los checks remotos posteriores al commit documental siguen siendo el gate
+  definitivo previo al merge.
+
+## Rollback
+
+Revertir los commits del hotfix restaura los overrides, el guard y el lockfile
+anteriores. No requiere migración de schema, datos, credenciales,
+infraestructura ni configuración productiva.
+
+## Estado final
+
+Implementación y documentación listas para publicación. El PR debe permanecer
+abierto y sin merge hasta que el hilo de revisión quede resuelto y los checks
+requeridos posteriores al commit documental estén verdes.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,13 +5,13 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
-  brace-expansion@<=5.0.7: 5.0.8
+  brace-expansion@>=4.0.0 <5.0.9: 5.0.9
   esbuild: 0.28.1
-  fast-uri@<3.1.4: 3.1.4
-  fast-uri@>=4.0.0 <4.1.1: 4.1.1
+  fast-uri@<3.1.5: 3.1.5
+  fast-uri@>=4.0.0 <4.1.2: 4.1.2
   find-my-way@<=9.6.0: 9.7.0
   sharp@<0.35.0: 0.35.3
-  postcss@<=8.5.17: 8.5.19
+  postcss@<=8.5.22: 8.5.23
   ws@>=8.0.0 <8.20.1: 8.20.1
   js-yaml@<=5.2.1: 5.2.2
 
@@ -163,8 +163,8 @@ importers:
         specifier: ^7.0.0
         version: 7.0.0
       postcss:
-        specifier: ^8.5.19
-        version: 8.5.19
+        specifier: 8.5.23
+        version: 8.5.23
       tailwindcss:
         specifier: ^4.3.3
         version: 4.3.3
@@ -1584,6 +1584,9 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  balanced-match@1.0.2:
+    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
+
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -1593,8 +1596,11 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@1.1.18:
+    resolution: {integrity: sha512-Edep/X9fGqVNmzKBVsDYIOtD+z1tuezV70LBjdCst9Tqu76lsnvRiZ6oTic1n+/BIwX6QDGAO94PN4N2SADvtw==}
+
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -1637,6 +1643,9 @@ packages:
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
     engines: {node: '>=6'}
+
+  concat-map@0.0.1:
+    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@2.0.0:
     resolution: {integrity: sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==}
@@ -2020,11 +2029,11 @@ packages:
   fast-querystring@1.1.2:
     resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
 
-  fast-uri@3.1.4:
-    resolution: {integrity: sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==}
+  fast-uri@3.1.5:
+    resolution: {integrity: sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==}
 
-  fast-uri@4.1.1:
-    resolution: {integrity: sha512-YPOs1zD5TG2+EZt+r88LwF6mclA7TPkpwMP7ZN3TO2HiHS8TXvq7QA/17iJsV9dubcLo/f8eEYqMBruyQV21hQ==}
+  fast-uri@4.1.2:
+    resolution: {integrity: sha512-TyGmBcbDTZXcb2cj5MV89DrF42DKvb3y5DDUNh95iO+IMeAzMkVSxK1PZRrRIpc9yg8U2GhGdbofNa0LS/a4Bw==}
 
   fastify@5.10.0:
     resolution: {integrity: sha512-A9L0ziuWGQHgEEVgF3davQ9vbD93IuX+lo2IsxapQmu5b/Y/ynn9m9K5JHt9dvyJXOFc5iN0Zk5GHEOqnzhWjg==}
@@ -2532,8 +2541,8 @@ packages:
     resolution: {integrity: sha512-Tz09sEL2EEuv5fFowm419c1+a/jSMiBjI9gHxVLrVdbUkkNUUfjsVYs9pVZu5oCon/kmRh9TfLEObFtkVxmY0w==}
     engines: {node: '>=8.0.0'}
 
-  nanoid@3.3.12:
-    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+  nanoid@3.3.17:
+    resolution: {integrity: sha512-xQLf0A3HOMlgHq0n247/LRuAOYmB7dXJ/DvAxGvsSBij45XtBSmQycu+F8ODbHwns/XyFZagyL1+J0Offw1E0g==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
@@ -2722,8 +2731,8 @@ packages:
     resolution: {integrity: sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg==}
     engines: {node: '>= 0.4'}
 
-  postcss@8.5.19:
-    resolution: {integrity: sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ==}
+  postcss@8.5.23:
+    resolution: {integrity: sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postgres-array@2.0.0:
@@ -3462,7 +3471,7 @@ snapshots:
     dependencies:
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
 
   '@fastify/error@4.2.0': {}
 
@@ -4080,7 +4089,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.3.3
       '@tailwindcss/oxide': 4.3.3
-      postcss: 8.5.19
+      postcss: 8.5.23
       tailwindcss: 4.3.3
 
   '@tybys/wasm-util@0.10.2':
@@ -4345,7 +4354,7 @@ snapshots:
   ajv@8.20.0:
     dependencies:
       fast-deep-equal: 3.1.3
-      fast-uri: 3.1.4
+      fast-uri: 3.1.5
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
@@ -4455,11 +4464,18 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  balanced-match@1.0.2: {}
+
   balanced-match@4.0.4: {}
 
   baseline-browser-mapping@2.11.0: {}
 
-  brace-expansion@5.0.8:
+  brace-expansion@1.1.18:
+    dependencies:
+      balanced-match: 1.0.2
+      concat-map: 0.0.1
+
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.4
 
@@ -4507,6 +4523,8 @@ snapshots:
   client-only@0.0.1: {}
 
   clsx@2.1.1: {}
+
+  concat-map@0.0.1: {}
 
   concat-stream@2.0.0:
     dependencies:
@@ -4971,7 +4989,7 @@ snapshots:
       '@fastify/merge-json-schemas': 0.2.1
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
-      fast-uri: 4.1.1
+      fast-uri: 4.1.2
       json-schema-ref-resolver: 3.0.0
       rfdc: 1.4.1
 
@@ -4981,9 +4999,9 @@ snapshots:
     dependencies:
       fast-decode-uri-component: 1.0.1
 
-  fast-uri@3.1.4: {}
+  fast-uri@3.1.5: {}
 
-  fast-uri@4.1.1: {}
+  fast-uri@4.1.2: {}
 
   fastify@5.10.0:
     dependencies:
@@ -5447,11 +5465,11 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 1.1.18
 
   minimist@1.2.8: {}
 
@@ -5482,7 +5500,7 @@ snapshots:
       lru.min: 1.1.4
     optional: true
 
-  nanoid@3.3.12: {}
+  nanoid@3.3.17: {}
 
   napi-postinstall@0.3.4: {}
 
@@ -5494,7 +5512,7 @@ snapshots:
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.11.0
       caniuse-lite: 1.0.30001806
-      postcss: 8.5.19
+      postcss: 8.5.23
       react: 19.2.8
       react-dom: 19.2.8(react@19.2.8)
       styled-jsx: 5.1.6(@babel/core@7.29.7)(react@19.2.8)
@@ -5682,9 +5700,9 @@ snapshots:
 
   possible-typed-array-names@1.1.0: {}
 
-  postcss@8.5.19:
+  postcss@8.5.23:
     dependencies:
-      nanoid: 3.3.12
+      nanoid: 3.3.17
       picocolors: 1.1.1
       source-map-js: 1.2.1
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -7,13 +7,13 @@ autoInstallPeers: true
 preferWorkspacePackages: true
 
 overrides:
-  "brace-expansion@<=5.0.7": "5.0.8"
+  "brace-expansion@>=4.0.0 <5.0.9": "5.0.9"
   esbuild: "0.28.1"
-  "fast-uri@<3.1.4": "3.1.4"
-  "fast-uri@>=4.0.0 <4.1.1": "4.1.1"
+  "fast-uri@<3.1.5": "3.1.5"
+  "fast-uri@>=4.0.0 <4.1.2": "4.1.2"
   "find-my-way@<=9.6.0": "9.7.0"
   "sharp@<0.35.0": "0.35.3"
-  "postcss@<=8.5.17": "8.5.19"
+  "postcss@<=8.5.22": "8.5.23"
   "ws@>=8.0.0 <8.20.1": "8.20.1"
   "js-yaml@<=5.2.1": "5.2.2"
 

--- a/test/architecture/toolchain-contract.test.ts
+++ b/test/architecture/toolchain-contract.test.ts
@@ -17,13 +17,13 @@ const PNPM_WORKFLOW_FILES = [
 ] as const;
 
 const SECURITY_OVERRIDE_LINES = [
-  '  "brace-expansion@<=5.0.7": "5.0.8"',
+  '  "brace-expansion@>=4.0.0 <5.0.9": "5.0.9"',
   '  esbuild: "0.28.1"',
-  '  "fast-uri@<3.1.4": "3.1.4"',
-  '  "fast-uri@>=4.0.0 <4.1.1": "4.1.1"',
+  '  "fast-uri@<3.1.5": "3.1.5"',
+  '  "fast-uri@>=4.0.0 <4.1.2": "4.1.2"',
   '  "find-my-way@<=9.6.0": "9.7.0"',
   '  "sharp@<0.35.0": "0.35.3"',
-  '  "postcss@<=8.5.17": "8.5.19"',
+  '  "postcss@<=8.5.22": "8.5.23"',
   '  "ws@>=8.0.0 <8.20.1": "8.20.1"',
   '  "js-yaml@<=5.2.1": "5.2.2"',
 ] as const;


### PR DESCRIPTION
## Summary

- update the existing supply-chain overrides for `fast-uri` 3.x and 4.x to patched versions `3.1.5` and `4.1.2`
- update `postcss` to patched version `8.5.23`
- update the development-toolchain resolution of `brace-expansion` to patched version `5.0.9`
- realign the architecture guard that freezes the exact security override contract
- regenerate the PNPM lockfile without major upgrades or new direct dependencies

The change is limited to dependency overrides, the generated lockfile and the corresponding architecture guard. No runtime, database, schema, authentication, workflow or production configuration changes are included.

## Scope

- [x] Dependencies

## Validation

- `pnpm install --frozen-lockfile`: PASSED
- architecture toolchain contract: PASSED, 8/8
- `pnpm audit --prod`: PASSED, no known vulnerabilities
- `pnpm audit`: PASSED, no known vulnerabilities
- `pnpm validate:local`: PASSED, 4111 passed / 0 failed / 1 pre-existing skip
- frontend lint: PASSED
- frontend typecheck: PASSED
- frontend build: PASSED
- public-surface security validation: PASSED
- `git diff --check`: PASSED

## Rollback

Revert the dependency-security commit and restore or regenerate the previous `pnpm-lock.yaml`.

No database, persistent-data, runtime or production rollback is required.
