### PR TITLE
fix(security): close A04 with shared session cookie boundary contract

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,8 +15,10 @@ DATABASE_URL=<database-url-fallback>
 DATABASE_MAX_CONNECTIONS=3
 SUPABASE_STORAGE_BUCKET=reports
 
-COOKIE_NAME=app_session_id
-ADMIN_COOKIE_NAME=admin_session_id
+# Las cookies de clinica y admin son un contrato fijo compartido con el proxy
+# (shared/session-cookie-names.ts): cruzan backend/frontend y ya no se configuran.
+# La cookie de particular si admite override; el arranque la rechaza si colisiona
+# con la de clinica o admin.
 PARTICULAR_COOKIE_NAME=particular_session_id
 OWNER_OPEN_ID=
 LAB_UPLOAD_USERNAMES=

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -85,7 +85,7 @@ jobs:
           should_run=false
           while IFS= read -r -d '' changed_path; do
             case "$changed_path" in
-              frontend/*|pnpm-lock.yaml|pnpm-workspace.yaml|package.json|.github/workflows/frontend-ci.yml|.github/workflows/e2e-completeness.yml)
+              frontend/*|shared/*|pnpm-lock.yaml|pnpm-workspace.yaml|package.json|.github/workflows/frontend-ci.yml|.github/workflows/e2e-completeness.yml)
                 should_run=true
                 break
                 ;;

--- a/docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md
+++ b/docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md
@@ -828,7 +828,7 @@ actual:
 | Separación de sesión (frontend) | `frontend/src/proxy.ts` fija los dos nombres de cookie, la selección por `ADMIN_DASHBOARD_PATH_PREFIX` y la redirección sin sesión |
 | Credenciales en el contrato frontend | `AuthUser` no declara `password`, `token`, `hash`, `secret` ni `session` |
 | Lectura manual de cookies | `document.cookie` prohibido en las 110 superficies del dashboard, en `AuthContext` y en el cliente HTTP |
-| Storage cliente | `localStorage`, `sessionStorage`, `indexedDB` y `window.name` prohibidos en las superficies del dashboard |
+| Storage cliente | Web Storage **permitido** para estado de UI; prohibido cuando el acceso nombra material de credencial. El guard inspecciona la clave y el valor del acceso, no la presencia de la API |
 | Cabeceras de credencial | `Authorization` y `Bearer` prohibidos; las llamadas autenticadas viajan por `credentials: "include"` |
 | `data-*` | Ningún nombre `data-*` del dashboard contiene un lexema de credencial de autenticación |
 | Colecciones | `AdminParticularTokenSummary` expone `tokenLast4` y nunca el token crudo; el módulo de sesiones no renderiza `tokenHash` ni material de sesión |
@@ -840,6 +840,7 @@ actual:
 | Un archivo nuevo del dashboard declara `data-auth-token` | **FAIL** · exit 1 |
 | Un archivo nuevo del dashboard lee `document.cookie` | **FAIL** · exit 1 |
 | Un archivo nuevo del dashboard persiste `admin_session_id` en `localStorage` | **FAIL** · exit 1 |
+| Un archivo nuevo guarda `dashboard-density` en `localStorage` | **PASS** · storage de UI legítimo |
 | Se borra un `moduleId` normativo del censo | **FAIL** · 3 aserciones · exit 1 |
 | La evidencia de proxy iguala el nombre de cookie admin y clínica | **FAIL** · exit 1 |
 
@@ -982,6 +983,20 @@ su tabla documental.
 
 **A04 = CLOSED.** Ambos defectos R2 están cerrados: ninguna configuración puede colapsar dos
 fronteras, y clínica/admin no pueden derivar entre backend y proxy.
+
+**Gobernanza del nuevo boundary cross-runtime *(closeout PR #1655)*.** Introducir `shared/` creó un
+path que ninguna política enrutaba: PR Governance falló, correctamente, con *«Quality gate impact
+policy has no route for changed path: shared/session-cookie-names.ts»*. Se cerró gobernando el
+boundary, no silenciando el gate: la regla `shared-cross-runtime` en
+`scripts/governance/quality-gate-impact-policy.mjs` enruta `shared/**` a **backend-ci y frontend-ci
+a la vez**, con los suites de ambos runtimes derivados de la taxonomía en vez de recopiados. Los
+paths desconocidos siguen fail-closed: no se añadió catch-all de raíz.
+
+En paralelo, el detector de impacto de `frontend-ci.yml` reconocía seis rutas y no `shared/*`, de
+modo que un PR que sólo tocara el contrato podía ejecutar Frontend CI con `should_run=false` y
+saltarse lint, typecheck, build, public-surface y E2E. Ahora son siete rutas. Se modificó
+únicamente el detector de `pull_request`; los filtros de `push` quedaron intactos a propósito, y el
+contrato de test distingue ambos mecanismos.
 
 **Riesgos residuales.**
 

--- a/docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md
+++ b/docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md
@@ -808,6 +808,195 @@ ausencia de secretos, `data-*` sin lexemas sensibles) sigue fuera de alcance.
 Alcance deliberadamente excluido: no se modificó runtime, CSS, el baseline A03, A05, backend, DB,
 CI ni dependencias. El diff es un único archivo de test más este registro documental.
 
+### 20.10 A04 cerrado: baseline ejecutable + fronteras de sesión garantizadas *(2026-08-17)*
+
+Supersede el registro de §20.9 **sólo** en el estado de A04. Lo anterior queda como estaba: cuando
+se escribió, A04 no tenía baseline y el registro era correcto.
+
+**Qué observó la auditoría histórica.** §11 y §5 afirman que el dashboard mantiene
+`admin_session_id` y `app_session_id` separados, que ningún superbuscador acepta un token completo,
+que ningún `data-*` del dashboard contiene lexemas sensibles y que ninguna colección expone hashes.
+Todo eso fue **observado**, no congelado: nada impedía que un componente nuevo lo rompiera en verde.
+
+**Qué queda congelado ahora.** `test/unit/ui/dashboard/dashboard-security-invariants.test.ts`
+(11 aserciones, 11/11 PASSED) convierte esas propiedades en contrato ejecutable contra la fuente
+actual:
+
+| Dimensión | Contrato ejecutable |
+|---|---|
+| Cobertura normativa | Los 15 `moduleId` se leen del registro canónico A03 y se comparan en ambas direcciones contra el censo A04; 15 módulos → 17 propietarios físicos existentes, sin duplicados y dentro de los árboles auditados |
+| Separación de sesión (frontend) | `frontend/src/proxy.ts` fija los dos nombres de cookie, la selección por `ADMIN_DASHBOARD_PATH_PREFIX` y la redirección sin sesión |
+| Credenciales en el contrato frontend | `AuthUser` no declara `password`, `token`, `hash`, `secret` ni `session` |
+| Lectura manual de cookies | `document.cookie` prohibido en las 110 superficies del dashboard, en `AuthContext` y en el cliente HTTP |
+| Storage cliente | `localStorage`, `sessionStorage`, `indexedDB` y `window.name` prohibidos en las superficies del dashboard |
+| Cabeceras de credencial | `Authorization` y `Bearer` prohibidos; las llamadas autenticadas viajan por `credentials: "include"` |
+| `data-*` | Ningún nombre `data-*` del dashboard contiene un lexema de credencial de autenticación |
+| Colecciones | `AdminParticularTokenSummary` expone `tokenLast4` y nunca el token crudo; el módulo de sesiones no renderiza `tokenHash` ni material de sesión |
+
+**Fail-closed demostrado por control de mutación, no afirmado:**
+
+| Mutación | Resultado |
+|---|---|
+| Un archivo nuevo del dashboard declara `data-auth-token` | **FAIL** · exit 1 |
+| Un archivo nuevo del dashboard lee `document.cookie` | **FAIL** · exit 1 |
+| Un archivo nuevo del dashboard persiste `admin_session_id` en `localStorage` | **FAIL** · exit 1 |
+| Se borra un `moduleId` normativo del censo | **FAIL** · 3 aserciones · exit 1 |
+| La evidencia de proxy iguala el nombre de cookie admin y clínica | **FAIL** · exit 1 |
+
+Las tres primeras mutaciones son **archivos nuevos**: el guard no depende de una lista de archivos
+declarada, de modo que una superficie de dashboard creada mañana queda cubierta sin tocar el test.
+La cuarta impide que una omisión silenciosa se vuelva verde (lección A07: auto-discovery por sí solo
+no demuestra completitud).
+
+**Frontera con lo ya cubierto.** La separación de sesión del **backend** no se reescribe aquí: ya
+está congelada por `security-session-cookie-boundaries`, `global-auth-boundary-contract` y
+`security-production-invariants`. A04 cubre el lado dashboard, que era el que no tenía guard.
+
+**Token de producto ≠ credencial de autenticación.** El guard distingue ambos deliberadamente.
+`tokenLast4`, `tokenId` y `tokenStatus` son metadata de dominio permitida; el campo prohibido es el
+token crudo dentro de la colección. Por el mismo criterio, el input `password` del alta de clínica
+(`AdminClinicsManagementCard`) es una **escritura** de credencial nueva, no una lectura de una
+almacenada, y no se marca. La lista de lexemas es el subconjunto de credenciales de autenticación de
+`scripts/security/audit-public-devtools-surface.mjs`; los stems de PII siguen cubiertos allí y no se
+duplican. Se usan stems en inglés a propósito: la convención aprobada del repo renombra las
+superficies sensibles a un stem no sensible (`data-admin-sesiones-*`, PR-SRV-1) precisamente para
+satisfacer ese guard.
+
+---
+
+#### Gap R2 descubierto por el baseline, y cerrado con autorización R2
+
+El baseline estático de arriba quedó verde, pero **no cerraba A04**: al trazar la frontera apareció
+un defecto que ningún test podía cerrar desde `test/`, porque no era una propiedad de la fuente sino
+de la **configuración de runtime**. Se registra aquí completo porque explica por qué A04 estuvo
+bloqueado y qué se cambió para desbloquearlo.
+
+**Hallazgo 1 — los nombres de cookie no tenían validación de unicidad.** `server/lib/env.ts`
+declaraba `COOKIE_NAME`, `ADMIN_COOKIE_NAME` y `PARTICULAR_COOKIE_NAME` como tres opcionales
+independientes con defaults distintos. No existía `refine`, `superRefine`, assertion ni guard de
+arranque que rechazara configurarlos al mismo valor: un deploy podía igualarlos y el proceso
+arrancaba normalmente.
+
+**Hallazgo 2 — no había fuente única de verdad entre proxy y backend.** `frontend/src/proxy.ts`
+**hardcodeaba** `"app_session_id"` y `"admin_session_id"` mientras el backend los leía de `ENV`. Los
+dos lados coincidían por coincidencia entre el literal y el default, no por contrato.
+
+**Camino trazado completo, sin exagerar el impacto.** Con `COOKIE_NAME="admin_session_id"` el gate
+del proxy **dejaba pasar** al route admin —acceso preliminar real—, pero no había exposición de
+contenido protegido: `frontend/src/app/dashboard/admin/page.tsx` es server component, valida contra
+backend antes de emitir HTML y `redirect()` aborta el render. La separación real la imponía la
+infraestructura (tres tablas: `activeSessions`, `adminSessions`, `particularSessions`). Los otros
+drifts producían lockout total de Administración o pisado de cookie entre dominios. El problema de
+fondo: la frontera no la sostenía el gate de sesión del dashboard sino enteramente la segunda
+validación de backend, y el gate era anulable por configuración.
+
+---
+
+#### R2 autorizado — contrato fijo donde cruza la frontera, override conservado donde no *(2026-08-17)*
+
+Nico autorizó R2 acotado a unicidad y drift. Se evaluaron cuatro estrategias; se descartó que el
+proxy leyera su propio env porque **backend y frontend son deploys separados**
+(`api.vetneb.com.ar` / `vetneb.com.ar`, con envs distintos): la misma variable escrita en dos
+servicios no es fuente única, sólo traslada el drift a configuración operacional.
+
+**El cierre se hizo de forma conservadora, separando las fronteras por su alcance real.** Clínica y
+admin **cruzan** backend ↔ proxy, así que su nombre es un contrato entre dos servicios y se fija en
+`shared/session-cookie-names.ts`. Particular **no participa del proxy** —sus consumidores viven
+todos dentro del backend y ya usaban `ENV.particularCookieName`—, así que **sigue siendo
+configurable** por `PARTICULAR_COOKIE_NAME` y ningún deploy con un override histórico se rompe.
+
+| Frontera | ¿Cruza al proxy? | Antes | Ahora |
+|---|:---:|---|---|
+| Clínica | **Sí** | `rawEnv.COOKIE_NAME ?? "app_session_id"` + literal en el proxy | `CLINIC_SESSION_COOKIE_NAME` del contrato, consumido por `env.ts` y por el proxy |
+| Admin | **Sí** | `rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id"` + literal en el proxy | `ADMIN_SESSION_COOKIE_NAME` del contrato, consumido por ambos |
+| Particular | **No** | `rawEnv.PARTICULAR_COOKIE_NAME ?? "particular_session_id"`, sin validación | Override conservado, resuelto por `resolveParticularSessionCookieName`, que **rechaza la colisión** |
+
+`server/lib/session-cookie-names.ts` aporta esa función pura, deliberadamente fuera de `env.ts` para
+poder probarla sin ejecutar el schema completo ni mutar `process.env` entre tests. Si el override
+iguala la cookie de clínica o de admin, **el proceso falla al arrancar** con un mensaje accionable,
+en vez de degradar una frontera en runtime. Como clínica y admin son distintos por construcción y
+particular no puede igualar a ninguno, las tres parejas quedan garantizadas:
+
+```text
+clinic !== admin        por contrato fijo
+clinic !== particular   rechazado en resolución
+admin  !== particular   rechazado en resolución
+```
+
+**Compatibilidad preservada por diseño, no por comprobación manual.** La versión anterior de este
+cierre fijaba también el nombre de particular, lo que obligaba a verificar a mano la configuración
+del servicio productivo para descartar un override histórico. Ese requisito desaparece: un
+`PARTICULAR_COOKIE_NAME` válido se conserva tal cual. Verificado ejecutando el arranque real:
+
+| Configuración de arranque | Resultado observado |
+|---|---|
+| `PARTICULAR_COOKIE_NAME` sin definir | arranca · `particular_session_id` (default) |
+| `PARTICULAR_COOKIE_NAME=legacy_particular_session` | arranca · override preservado |
+| `PARTICULAR_COOKIE_NAME=admin_session_id` | **rechazado en arranque** |
+| `PARTICULAR_COOKIE_NAME=app_session_id` | **rechazado en arranque** |
+
+Para clínica y admin la fijación sí es segura sin verificación externa: el proxy ya exigía esos
+literales, de modo que un valor no-default en producción habría dejado el dashboard en redirect
+infinito a `/login`. Que funcione demuestra que su configuración efectiva era la default.
+
+**Viabilidad cross-build demostrada empíricamente**, no asumida: el backend importa el contrato con
+extensión `.ts` (`allowImportingTsExtensions` de la raíz) y el frontend sin ella; es el mismo módulo
+físico con dos especificadores. `pnpm typecheck`, `pnpm build`, `pnpm --dir frontend typecheck` y
+`pnpm --dir frontend build` terminan en **exit 0**, sin tocar `package.json`, `tsconfig*` ni
+`next.config`. El contrato compartido es dependency-free y **no llega al bundle cliente**: los
+literales y el resolver aparecen 0 veces en `frontend/.next/static`. La lógica de particular queda
+fuera del proxy por construcción. `security:public-surface` sigue en PASS y clasifica los
+identificadores del proxy como `[server-only]`, igual que antes del cambio.
+
+**El proxy conserva su semántica**: selección de boundary por `ADMIN_DASHBOARD_PATH_PREFIX`, sin
+fallback entre cookies, redirect a `/login` preservando `next`, y sin convertirse en un segundo
+servidor de autorización — el backend sigue siendo la autoridad definitiva.
+
+**Contrato ejecutable.** `test/unit/infrastructure/session-cookie-name-contract.test.ts` (16
+aserciones) prueba el contrato fijo de clínica y admin y su distinctness, el default y el override
+válido de particular, el rechazo de ambas colisiones, el consumo por los dos owners, la ausencia de
+una segunda copia literal, la desaparición de los overrides de clínica/admin, que
+`PARTICULAR_COOKIE_NAME` sigue soportado, que el contrato no importa nada ni toca `process.env`, que
+el resolver backend-only no llega al proxy, y que el boundary del proxy sigue fail-closed.
+
+**Fail-closed demostrado por control de mutación:**
+
+| Mutación | Resultado |
+|---|---|
+| M6 · clínica == admin en el contrato fijo | **FAIL** · T2/T3/T7 · exit 1 |
+| M7 · override de particular == clínica | **FAIL** · resolver lanza · arranque rechazado |
+| M8 · override de particular == admin | **FAIL** · resolver lanza · arranque rechazado |
+| M9 · se reintroduce un literal independiente en el proxy | **FAIL** · T14 y además el baseline A04 · exit 1 |
+| M10 · el proxy deja de consumir la fuente compartida | **FAIL** · T10 · exit 1 |
+
+M1–M4 del baseline siguen vigentes. El antiguo M5 queda **superseded** por M6–M10: la propiedad que
+comprobaba (nombres de cookie compartidos en la evidencia del proxy) ya no es representable, porque
+el proxy no declara nombres.
+
+**Realineación in-PR.** El cambio rompió legítimamente 13 guards que anclaban los literales y el
+censo LOC de M48. Todos se realinearon en el mismo PR y **ninguno se debilitó**: los de clínica y
+admin pasaron de anclar un literal a exigir el consumo del contrato compartido —la aserción
+anti-drift, más fuerte—, y los de particular pasaron a anclar la resolución guardada en vez de un
+literal fijo. M48 se realineó a `server/lib` 29 archivos / 4.683 LOC y total 229 / 47.924, junto a
+su tabla documental.
+
+**A04 = CLOSED.** Ambos defectos R2 están cerrados: ninguna configuración puede colapsar dos
+fronteras, y clínica/admin no pueden derivar entre backend y proxy.
+
+**Riesgos residuales.**
+
+1. El contrato compartido vive en `shared/` fuera de los dos `include` de tsconfig; funciona porque
+   ambos compiladores siguen el import. Un cambio futuro de `tsconfig` o de bundler debe re-verificar
+   los cuatro builds.
+2. Los guards son estáticos salvo el resolver, que sí se probó contra el arranque real.
+3. Renombrar la cookie de clínica o de admin exige desplegar backend y frontend juntos: al ser un
+   contrato compilado en ambos bundles, un despliegue parcial dejaría las dos mitades en desacuerdo
+   hasta completarse.
+
+Alcance deliberadamente excluido: no se modificó DB, schema, endpoints, roles, permisos,
+dependencias, `package.json`, `pnpm-lock.yaml`, `tsconfig*`, `next.config`, CI ni workflows; no se
+ejecutó ninguna operación R3.
+
 ### 20.2 Consumidores compuestos y conteo de observaciones *(normativo)*
 
 Las filas 14 y 15 de §20 son **consumidores compuestos**: un único consumidor del hook con varias instancias o rutas reales, cada una con su propio contenedor medido y su propio contrato. El registro primario de cada combinación módulo/viewport contiene una **colección tipada de observaciones hoja**, una por variante. Está prohibido seleccionar arbitrariamente una única instancia o ruta y está prohibido agregar sus valores por mínimo, máximo, promedio o primer elemento (§20.5).

--- a/docs/implementation/m48-backend-modularization-final-certification.md
+++ b/docs/implementation/m48-backend-modularization-final-certification.md
@@ -196,11 +196,11 @@ newline final no se cuenta.
 | --- | ---: | ---: |
 | `server/features` | 149 | 16.980 |
 | `server/routes` | 35 | 22.943 |
-| `server/lib` | 28 | 4.628 |
+| `server/lib` | 29 | 4.683 |
 | `server/middlewares` | 7 | 947 |
 | raíz/entrypoints `server/*.ts` | 9 | 2.371 |
 | otros | 0 | 0 |
-| **Total `server`** | **228** | **47.869** |
+| **Total `server`** | **229** | **47.924** |
 
 El review P2 de M48 detectó que la primera metodología aplicaba una semántica
 equivalente a `source.split("\n").length`, que sumaba un segmento vacío por
@@ -210,7 +210,7 @@ features.
 
 - Features: 9.
 - Rutas productivas `*.fastify.ts`: 35.
-- Módulos `server/lib` raíz: 24.
+- Módulos `server/lib` raíz: 25.
 - Módulos `server/lib/http`: 3.
 
 ## 8. Inventario y topología por feature

--- a/frontend/src/proxy.ts
+++ b/frontend/src/proxy.ts
@@ -1,7 +1,10 @@
 import { NextResponse, type NextRequest } from "next/server";
 
-const CLINIC_SESSION_COOKIE_NAME = "app_session_id";
-const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";
+import {
+  ADMIN_SESSION_COOKIE_NAME,
+  CLINIC_SESSION_COOKIE_NAME,
+} from "../../shared/session-cookie-names";
+
 const LOGIN_PATH = "/login";
 const ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin";
 

--- a/scripts/governance/quality-gate-impact-policy.mjs
+++ b/scripts/governance/quality-gate-impact-policy.mjs
@@ -490,6 +490,15 @@ export const IMPACT_RULES = deepFreeze([
     description: "Root TypeScript config affects backend and test typechecking.",
   },
   {
+    id: "shared-cross-runtime",
+    matcher: { type: "prefix", path: "shared/" },
+    impacts: ["cross-runtime-contract", "backend-runtime", "frontend-runtime"],
+    gates: ["pr-governance", "backend-ci", "frontend-ci"],
+    suiteIds: [...BACKEND_SUITE_IDS, ...FRONTEND_SUITE_IDS],
+    description:
+      "Root-level protocol contracts consumed by both runtimes: the backend bundle and the Next proxy compile the same module, so a change must be validated by backend and frontend gates together.",
+  },
+  {
     id: "server-runtime",
     matcher: { type: "prefix", path: "server/" },
     impacts: ["backend-runtime"],

--- a/server/lib/env.ts
+++ b/server/lib/env.ts
@@ -1,6 +1,12 @@
 import "dotenv/config";
 import { z } from "zod";
 
+import {
+  ADMIN_SESSION_COOKIE_NAME,
+  CLINIC_SESSION_COOKIE_NAME,
+} from "../../shared/session-cookie-names.ts";
+import { resolveParticularSessionCookieName } from "./session-cookie-names.ts";
+
 const emptyToUndefined = (value: unknown) => {
   if (typeof value !== "string") return value;
   const trimmed = value.trim();
@@ -84,11 +90,6 @@ const envSchema = z.object({
   SUPABASE_ANON_KEY: z.preprocess(emptyToUndefined, z.string().min(1)),
   SUPABASE_SERVICE_ROLE_KEY: z.preprocess(emptyToUndefined, z.string().min(1)),
   SUPABASE_STORAGE_BUCKET: z.preprocess(
-    emptyToUndefined,
-    z.string().min(1).optional(),
-  ),
-  COOKIE_NAME: z.preprocess(emptyToUndefined, z.string().min(1).optional()),
-  ADMIN_COOKIE_NAME: z.preprocess(
     emptyToUndefined,
     z.string().min(1).optional(),
   ),
@@ -207,10 +208,11 @@ export const ENV = {
   supabaseAnonKey: rawEnv.SUPABASE_ANON_KEY,
   supabaseServiceRoleKey: rawEnv.SUPABASE_SERVICE_ROLE_KEY,
   supabaseStorageBucket: rawEnv.SUPABASE_STORAGE_BUCKET ?? "reports",
-  cookieName: rawEnv.COOKIE_NAME ?? "app_session_id",
-  adminCookieName: rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id",
-  particularCookieName:
-    rawEnv.PARTICULAR_COOKIE_NAME ?? "particular_session_id",
+  cookieName: CLINIC_SESSION_COOKIE_NAME,
+  adminCookieName: ADMIN_SESSION_COOKIE_NAME,
+  particularCookieName: resolveParticularSessionCookieName(
+    rawEnv.PARTICULAR_COOKIE_NAME,
+  ),
   corsOrigins,
   publicSiteUrl,
   trustProxy: rawEnv.TRUST_PROXY ?? 1,

--- a/server/lib/session-cookie-names.ts
+++ b/server/lib/session-cookie-names.ts
@@ -1,0 +1,53 @@
+import {
+  ADMIN_SESSION_COOKIE_NAME,
+  CLINIC_SESSION_COOKIE_NAME,
+  DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+} from "../../shared/session-cookie-names.ts";
+
+// Particular session cookie resolution.
+//
+// Unlike clinic and admin, this boundary never crosses into the Next proxy, so it stays
+// configurable through PARTICULAR_COOKIE_NAME and existing deployments keep working. The
+// risk that configurability reintroduces is a collision: pointing particular at the
+// clinic or admin cookie would let one boundary clobber another. That is rejected here,
+// at resolution time, so an invalid configuration fails the process at startup instead
+// of degrading a session boundary at runtime.
+//
+// Kept as a pure function in its own module — not inside `env.ts` — so the contract can
+// be tested directly without executing the full environment schema or mutating
+// process.env across tests.
+
+/** Matches the `emptyToUndefined` preprocessing applied by the environment schema. */
+function normalizeOverride(rawValue: string | undefined): string | undefined {
+  if (typeof rawValue !== "string") {
+    return undefined;
+  }
+
+  const trimmed = rawValue.trim();
+  return trimmed.length === 0 ? undefined : trimmed;
+}
+
+/**
+ * Resolve the particular session cookie name, rejecting any value that collides with a
+ * fixed boundary. Throws on collision; returns the default when unset or blank.
+ */
+export function resolveParticularSessionCookieName(
+  rawValue: string | undefined,
+): string {
+  const resolved =
+    normalizeOverride(rawValue) ?? DEFAULT_PARTICULAR_SESSION_COOKIE_NAME;
+
+  for (const [boundary, fixedName] of [
+    ["clinic", CLINIC_SESSION_COOKIE_NAME],
+    ["admin", ADMIN_SESSION_COOKIE_NAME],
+  ] as const) {
+    if (resolved === fixedName) {
+      throw new Error(
+        `PARTICULAR_COOKIE_NAME no puede ser "${resolved}": ese nombre pertenece a la sesión de ${boundary}. ` +
+          "Cada frontera de sesión debe usar una cookie distinta.",
+      );
+    }
+  }
+
+  return resolved;
+}

--- a/shared/session-cookie-names.ts
+++ b/shared/session-cookie-names.ts
@@ -1,0 +1,32 @@
+// Session cookie name contract — the single source of truth for the two boundaries
+// that cross the backend/proxy border.
+//
+// Clinic and admin are consumed by BOTH `server/lib/env.ts` and the Next proxy
+// (`frontend/src/proxy.ts`), which are separately deployed services. They used to be
+// declared independently — the backend resolved them from optional env vars, the proxy
+// hardcoded the literals — so they agreed only because a literal happened to match a
+// default. Renaming the cookie on the backend service silently broke the proxy
+// boundary. For those two the name is a protocol contract between two services, not a
+// per-deploy setting, so it is fixed here and owned by nobody else.
+//
+// The particular boundary does NOT cross this border: it is consumed only inside the
+// backend and never by the proxy. It therefore stays configurable via
+// PARTICULAR_COOKIE_NAME, with this module supplying only its default. Its collision
+// check lives in `server/lib/session-cookie-names.ts`, next to the resolution it
+// guards, so no backend-only logic ships in the proxy bundle.
+//
+// This module must stay dependency-free and side-effect-free: it is imported by the
+// backend bundle (esbuild) and by the Next proxy. It must never reach a client bundle,
+// and must never import `server/lib/env` or any node-only API.
+
+export const CLINIC_SESSION_COOKIE_NAME = "app_session_id";
+export const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";
+
+/** Default only: the effective particular name is resolved from the environment. */
+export const DEFAULT_PARTICULAR_SESSION_COOKIE_NAME = "particular_session_id";
+
+/** The two boundaries whose names are fixed by contract, in declaration order. */
+export const FIXED_SESSION_COOKIE_NAMES = [
+  CLINIC_SESSION_COOKIE_NAME,
+  ADMIN_SESSION_COOKIE_NAME,
+] as const;

--- a/test/architecture/backend-modularization-m48-final-certification.test.ts
+++ b/test/architecture/backend-modularization-m48-final-certification.test.ts
@@ -83,7 +83,7 @@ const m47KeepPaths = [
 const expectedAreaCensus = {
   "server/features": { files: 149, loc: 16_980 },
   "server/routes": { files: 35, loc: 22_943 },
-  "server/lib": { files: 28, loc: 4_628 },
+  "server/lib": { files: 29, loc: 4_683 },
   "server/middlewares": { files: 7, loc: 947 },
   "server root": { files: 9, loc: 2_371 },
   other: { files: 0, loc: 0 },
@@ -268,14 +268,14 @@ test("M48 congela el censo LOC global y de las nueve features", () => {
       (total, area) => total + area.loc,
       0,
     ),
-    47_869,
+    47_924,
   );
   assert.equal(
     Object.values(actualAreaCensus).reduce(
       (total, area) => total + area.files,
       0,
     ),
-    228,
+    229,
   );
 
   const actualFeatureCensus = Object.fromEntries(
@@ -319,7 +319,7 @@ test("M48 mantiene el censo LOC documentado igual al árbol computado", () => {
     ["server/middlewares", expectedAreaCensus["server/middlewares"]],
     ["raíz/entrypoints server/*.ts", expectedAreaCensus["server root"]],
     ["otros", expectedAreaCensus.other],
-    ["Total server", { files: 228, loc: 47_869 }],
+    ["Total server", { files: 229, loc: 47_924 }],
   ] as const) {
     assert.deepEqual(markdownTableRow(areaSection, label), expected, label);
   }

--- a/test/architecture/security/global-auth-boundary-contract.test.ts
+++ b/test/architecture/security/global-auth-boundary-contract.test.ts
@@ -131,24 +131,28 @@ test("session cookie names remain separated across backend and dashboard proxy",
   const envSource = read("server/lib/env.ts");
   const middlewareSource = read("frontend/src/proxy.ts");
 
-  assertContains(envSource, 'cookieName: rawEnv.COOKIE_NAME ?? "app_session_id"', "env clinic cookie");
+  // The names are a fixed shared contract (A04 R2): the backend no longer resolves
+  // them from env, so the anchor is consumption of the contract, not a literal.
   assertContains(
     envSource,
-    'adminCookieName: rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id"',
-    "env admin cookie",
+    'from "../../shared/session-cookie-names.ts"',
+    "env imports the shared session cookie contract",
   );
-  assertContains(envSource, "PARTICULAR_COOKIE_NAME", "env particular cookie");
+  assertContains(envSource, "cookieName: CLINIC_SESSION_COOKIE_NAME", "env clinic cookie");
+  assertContains(envSource, "adminCookieName: ADMIN_SESSION_COOKIE_NAME", "env admin cookie");
+  assertContains(
+    envSource,
+    "particularCookieName: resolveParticularSessionCookieName(",
+    "env particular cookie",
+  );
 
   assertContains(
     middlewareSource,
-    'const CLINIC_SESSION_COOKIE_NAME = "app_session_id"',
-    "frontend clinic cookie",
+    'from "../../shared/session-cookie-names"',
+    "frontend proxy imports the shared session cookie contract",
   );
-  assertContains(
-    middlewareSource,
-    'const ADMIN_SESSION_COOKIE_NAME = "admin_session_id"',
-    "frontend admin cookie",
-  );
+  assertContains(middlewareSource, "CLINIC_SESSION_COOKIE_NAME", "frontend clinic cookie");
+  assertContains(middlewareSource, "ADMIN_SESSION_COOKIE_NAME", "frontend admin cookie");
   assertContains(
     middlewareSource,
     "ADMIN_DASHBOARD_PATH_PREFIX",

--- a/test/architecture/security/security-boundary-suite-completeness.test.ts
+++ b/test/architecture/security/security-boundary-suite-completeness.test.ts
@@ -190,7 +190,11 @@ const SECURITY_BOUNDARY_SUITE: readonly SecurityBoundaryGuardrail[] = [
     runtimeAnchors: [
       {
         path: "server/lib/env.ts",
-        markers: ["COOKIE_NAME", "ADMIN_COOKIE_NAME", "PARTICULAR_COOKIE_NAME"],
+        markers: [
+          "cookieName: CLINIC_SESSION_COOKIE_NAME",
+          "adminCookieName: ADMIN_SESSION_COOKIE_NAME",
+          "particularCookieName: resolveParticularSessionCookieName(",
+        ],
       },
       {
         path: "server/lib/fastify-admin-auth.ts",

--- a/test/architecture/security/security-critical-route-surface-registry.test.ts
+++ b/test/architecture/security/security-critical-route-surface-registry.test.ts
@@ -26,9 +26,9 @@ const CRITICAL_ROUTE_SURFACE_REGISTRY: readonly CriticalSurface[] = [
       {
         path: "server/lib/env.ts",
         markers: [
-          'cookieName: rawEnv.COOKIE_NAME ?? "app_session_id"',
-          'adminCookieName: rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id"',
-          "PARTICULAR_COOKIE_NAME",
+          "cookieName: CLINIC_SESSION_COOKIE_NAME",
+          "adminCookieName: ADMIN_SESSION_COOKIE_NAME",
+          "particularCookieName: resolveParticularSessionCookieName(",
           "trustProxy: rawEnv.TRUST_PROXY ?? 1",
         ],
       },

--- a/test/architecture/security/security-production-invariants.test.ts
+++ b/test/architecture/security/security-production-invariants.test.ts
@@ -51,21 +51,10 @@ test("ENV mantiene cookies de sesión separadas y política productiva segura", 
   const file = "server/lib/env.ts";
   const source = read(file);
 
-  assertContains(
-    source,
-    'cookieName: rawEnv.COOKIE_NAME ?? "app_session_id"',
-    file,
-  );
-  assertContains(
-    source,
-    'adminCookieName: rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id"',
-    file,
-  );
-  assertContains(
-    source,
-    'rawEnv.PARTICULAR_COOKIE_NAME ?? "particular_session_id"',
-    file,
-  );
+  assertContains(source, 'from "../../shared/session-cookie-names.ts"', file);
+  assertContains(source, "cookieName: CLINIC_SESSION_COOKIE_NAME", file);
+  assertContains(source, "adminCookieName: ADMIN_SESSION_COOKIE_NAME", file);
+  assertContains(source, "particularCookieName: resolveParticularSessionCookieName(", file);
 
   assertContains(source, 'cookieSecure: nodeEnv === "production"', file);
   assertContains(

--- a/test/architecture/security/security-session-cookie-boundaries.test.ts
+++ b/test/architecture/security/security-session-cookie-boundaries.test.ts
@@ -168,9 +168,10 @@ test("session cookie boundary matrix documents separated auth domains", () => {
 test("env keeps session cookie names separated and production policy secure", () => {
   const envSource = readSource("server/lib/env.ts");
 
-  assertContains(envSource, 'cookieName: rawEnv.COOKIE_NAME ?? "app_session_id"', "clinic cookie env");
-  assertContains(envSource, 'adminCookieName: rawEnv.ADMIN_COOKIE_NAME ?? "admin_session_id"', "admin cookie env");
-  assertContains(envSource, 'rawEnv.PARTICULAR_COOKIE_NAME ?? "particular_session_id"', "particular cookie env");
+  assertContains(envSource, 'from "../../shared/session-cookie-names.ts"', "shared cookie contract");
+  assertContains(envSource, "cookieName: CLINIC_SESSION_COOKIE_NAME", "clinic cookie env");
+  assertContains(envSource, "adminCookieName: ADMIN_SESSION_COOKIE_NAME", "admin cookie env");
+  assertContains(envSource, "particularCookieName: resolveParticularSessionCookieName(", "particular cookie env");
   assertContains(envSource, 'cookieSecure: nodeEnv === "production"', "cookie secure env");
   assertContains(envSource, 'cookieSameSite: (nodeEnv === "production" ? "none" : "lax")', "cookie sameSite env");
 });

--- a/test/security/auth-session-boundaries.test.ts
+++ b/test/security/auth-session-boundaries.test.ts
@@ -441,8 +441,9 @@ test("frontend proxy mantiene separación dashboard/admin y deja particulares fu
     "utf8",
   ).replace(/\r\n/g, "\n");
 
-  assert.ok(source.includes('const CLINIC_SESSION_COOKIE_NAME = "app_session_id";'));
-  assert.ok(source.includes('const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";'));
+  assert.ok(source.includes('from "../../shared/session-cookie-names"'));
+  assert.ok(source.includes("CLINIC_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes("ADMIN_SESSION_COOKIE_NAME"));
   assert.ok(source.includes("function getRequiredSessionCookieName(pathname: string): string"));
   assert.ok(source.includes("return isAdminDashboardPath(pathname)"));
   assert.ok(source.includes("? ADMIN_SESSION_COOKIE_NAME"));

--- a/test/unit/infrastructure/api-production-session-contract.test.ts
+++ b/test/unit/infrastructure/api-production-session-contract.test.ts
@@ -122,16 +122,23 @@ test("backend production CORS and session cookie env contract stays credential-s
     "production cookies must remain SameSite=None for credentialed browser sessions",
   );
 
+  // A04 R2: the names moved to the fixed shared contract consumed by env.ts.
+  const sharedContract = readRepoFile("shared/session-cookie-names.ts");
+
   for (const cookieName of [
     "app_session_id",
     "admin_session_id",
     "particular_session_id",
   ]) {
     assert.ok(
-      env.includes(cookieName),
+      sharedContract.includes(cookieName),
       `session cookie name ${cookieName} must remain part of the production contract`,
     );
   }
+  assert.ok(
+    env.includes('from "../../shared/session-cookie-names.ts"'),
+    "env must consume the shared session cookie contract",
+  );
 });
 
 test("critical backend routes keep credentialed CORS preflight coverage", () => {

--- a/test/unit/infrastructure/auth-cookie-persistence-contract.test.ts
+++ b/test/unit/infrastructure/auth-cookie-persistence-contract.test.ts
@@ -320,12 +320,16 @@ test("cookie persistence contract: Next.js proxy guards dashboard using cookie p
     "middleware must read cookies from request to protect dashboard",
   );
   assert.ok(
-    source.includes("app_session_id"),
-    "middleware must check app_session_id for clinic dashboard",
+    source.includes('from "../../shared/session-cookie-names"'),
+    "middleware must consume the shared session cookie contract",
   );
   assert.ok(
-    source.includes("admin_session_id"),
-    "middleware must check admin_session_id for admin dashboard",
+    source.includes("CLINIC_SESSION_COOKIE_NAME"),
+    "middleware must check the clinic boundary for the clinic dashboard",
+  );
+  assert.ok(
+    source.includes("ADMIN_SESSION_COOKIE_NAME"),
+    "middleware must check the admin boundary for the admin dashboard",
   );
   assert.equal(
     source.includes("sessionStorage"),

--- a/test/unit/infrastructure/frontend-ci-workflow.test.ts
+++ b/test/unit/infrastructure/frontend-ci-workflow.test.ts
@@ -119,6 +119,9 @@ function shouldRunFrontend(changedPaths: readonly string[]): boolean {
   return changedPaths.some(
     (changedPath) =>
       changedPath.startsWith("frontend/") ||
+      // shared/** is a cross-runtime protocol contract compiled into the Next
+      // proxy, so a shared-only PR must still request heavy frontend validation.
+      changedPath.startsWith("shared/") ||
       frontendImpactPaths.has(changedPath),
   );
 }
@@ -320,7 +323,7 @@ test("Frontend CI excluye cambios exclusivos de una base que avanzó", () => {
   }
 });
 
-test("Frontend CI usa exactamente las seis rutas vigentes para solicitar heavy", () => {
+test("Frontend CI usa exactamente las siete rutas vigentes para solicitar heavy", () => {
   const detector = getJobBlock(readWorkflow(), "detect-frontend-impact");
 
   assertContains(
@@ -328,7 +331,7 @@ test("Frontend CI usa exactamente las seis rutas vigentes para solicitar heavy",
     `          should_run=false
           while IFS= read -r -d '' changed_path; do
             case "$changed_path" in
-              frontend/*|pnpm-lock.yaml|pnpm-workspace.yaml|package.json|.github/workflows/frontend-ci.yml|.github/workflows/e2e-completeness.yml)
+              frontend/*|shared/*|pnpm-lock.yaml|pnpm-workspace.yaml|package.json|.github/workflows/frontend-ci.yml|.github/workflows/e2e-completeness.yml)
                 should_run=true
                 break
                 ;;
@@ -338,6 +341,33 @@ test("Frontend CI usa exactamente las seis rutas vigentes para solicitar heavy",
           echo "should_run=$should_run" >> "$GITHUB_OUTPUT"`,
   );
   assertNotContains(detector, ".github/workflows/backend-ci.yml)");
+});
+
+test("Frontend CI pide heavy cuando el PR sólo cambia el contrato cross-runtime", () => {
+  // P1: shared/session-cookie-names.ts is compiled into the Next proxy. Before this
+  // route existed a shared-only PR ran Frontend CI with should_run=false and skipped
+  // lint, typecheck, build, public-surface and E2E.
+  assert.equal(shouldRunFrontend(["shared/session-cookie-names.ts"]), true);
+  assert.equal(shouldRunFrontend(["shared/nested/contract.ts"]), true);
+
+  // The benign baselines must stay unchanged.
+  assert.equal(shouldRunFrontend(["docs/audit/example.md"]), false);
+  assert.equal(shouldRunFrontend(["server/routes/example.fastify.ts"]), false);
+});
+
+test("Frontend CI distingue push path filters del detector de impacto de PR", () => {
+  // Only the pull_request impact detector gained shared/*. The push filters are a
+  // separate mechanism and were deliberately left untouched in this change.
+  const pushTriggerBlock = readWorkflow().split("pull_request:")[0];
+
+  assert.ok(
+    !pushTriggerBlock.includes("'shared/**'"),
+    "push paths no deben ampliarse en este cambio",
+  );
+  assertContains(
+    getJobBlock(readWorkflow(), "detect-frontend-impact"),
+    "shared/*|",
+  );
 });
 
 test("Frontend CI condiciona el job pesado al output del detector", () => {

--- a/test/unit/infrastructure/quality-gate-impact-contract.test.ts
+++ b/test/unit/infrastructure/quality-gate-impact-contract.test.ts
@@ -117,6 +117,7 @@ test("impact rule precedence resolves specific routes before general routes", ()
 test("impact routing classifies representative paths", () => {
   const expectations = new Map([
     ["server/routes/clinics.ts", "server-runtime"],
+    ["shared/session-cookie-names.ts", "shared-cross-runtime"],
     ["frontend/src/app/page.tsx", "frontend-runtime"],
     ["test/unit/example.test.ts", "node-tests"],
     ["frontend/e2e/admin-mobile.spec.ts", "frontend-e2e"],
@@ -277,6 +278,91 @@ test("frontend CI taxonomy exposes one catalog-backed Playwright command", () =>
         command: "pnpm --dir frontend e2e:ci",
       },
     ],
+  );
+});
+
+test("shared cross-runtime contract routes through both runtime gates", () => {
+  // A04/PR #1655: shared/session-cookie-names.ts is compiled into BOTH the backend
+  // bundle and the Next proxy. Governance previously had no route for it, so the
+  // path failed fail-closed. It must now demand backend and frontend validation
+  // together — routing it to a single runtime would let one half ship unvalidated.
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "M",
+        path: "shared/session-cookie-names.ts",
+        display: "shared/session-cookie-names.ts",
+      },
+    ],
+  });
+
+  assert.deepEqual(result.failures, []);
+  assert.equal(result.passed, true);
+
+  const [routed] = result.changedPaths;
+  assert.equal(routed.rule?.id, "shared-cross-runtime");
+
+  for (const gate of ["pr-governance", "backend-ci", "frontend-ci"]) {
+    assert.ok(
+      routed.rule?.gates.includes(gate),
+      `shared-cross-runtime must require ${gate}`,
+    );
+  }
+
+  for (const impact of [
+    "cross-runtime-contract",
+    "backend-runtime",
+    "frontend-runtime",
+  ]) {
+    assert.ok(
+      routed.rule?.impacts.includes(impact),
+      `shared-cross-runtime must declare ${impact}`,
+    );
+  }
+
+  // Derived from the taxonomy, never restated: a suite added to either runtime is
+  // covered automatically instead of silently escaping the cross-runtime route.
+  const backendSuiteIds = TEST_TAXONOMY.filter(
+    (suite) => suite.gate === "backend-ci",
+  ).map((suite) => suite.id);
+  const frontendSuiteIds = TEST_TAXONOMY.filter(
+    (suite) => suite.gate === "frontend-ci",
+  ).map((suite) => suite.id);
+
+  assert.ok(backendSuiteIds.length > 0 && frontendSuiteIds.length > 0);
+  for (const suiteId of [...backendSuiteIds, ...frontendSuiteIds]) {
+    assert.ok(
+      routed.rule?.suiteIds.includes(suiteId),
+      `shared-cross-runtime must cover suite ${suiteId}`,
+    );
+  }
+});
+
+test("removing the shared cross-runtime rule restores the fail-closed failure", () => {
+  // Mutation control G1: the route is what makes the path governed. Without it the
+  // policy must go back to refusing the path, not silently absorbing it elsewhere.
+  const rulesWithoutShared = IMPACT_RULES.filter(
+    (rule) => rule.id !== "shared-cross-runtime",
+  );
+
+  assert.equal(rulesWithoutShared.length, IMPACT_RULES.length - 1);
+
+  const result = evaluateChangedPathImpact({
+    entries: [
+      {
+        status: "M",
+        path: "shared/session-cookie-names.ts",
+        display: "shared/session-cookie-names.ts",
+      },
+    ],
+    rules: rulesWithoutShared,
+  });
+
+  assert.equal(result.passed, false);
+  assert.ok(
+    result.failures.includes(
+      "Quality gate impact policy has no route for changed path: shared/session-cookie-names.ts",
+    ),
   );
 });
 

--- a/test/unit/infrastructure/session-cookie-name-contract.test.ts
+++ b/test/unit/infrastructure/session-cookie-name-contract.test.ts
@@ -1,0 +1,321 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  ADMIN_SESSION_COOKIE_NAME,
+  CLINIC_SESSION_COOKIE_NAME,
+  DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+  FIXED_SESSION_COOKIE_NAMES,
+} from "../../../shared/session-cookie-names.ts";
+import { resolveParticularSessionCookieName } from "../../../server/lib/session-cookie-names.ts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A04 · R2 · Session cookie name contract.
+//
+// Closes the two defects the A04 baseline surfaced, without widening the runtime
+// change further than the boundary requires:
+//
+//   R2-A  `server/lib/env.ts` accepted three independent optional cookie names
+//         with no rejection of repeated values, so two boundaries could be
+//         configured onto the same cookie.
+//   R2-B  `frontend/src/proxy.ts` hardcoded the clinic and admin literals while
+//         the backend read them from ENV, so the two sides agreed only by
+//         coincidence and a backend rename desynchronized the proxy boundary.
+//
+// Clinic and admin cross the backend/proxy border, so their names are a fixed
+// shared contract. Particular never reaches the proxy, so it stays configurable
+// and existing deployments keep their override — but the resolver rejects any
+// value that collides with a fixed boundary, so no configuration can collapse
+// the three boundaries.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_FILE = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(TEST_FILE), "..", "..", "..");
+
+const LINE_BREAK = String.fromCharCode(10);
+
+const SHARED_CONTRACT_PATH = "shared/session-cookie-names.ts";
+const RESOLVER_PATH = "server/lib/session-cookie-names.ts";
+const ENV_PATH = "server/lib/env.ts";
+const PROXY_PATH = "frontend/src/proxy.ts";
+
+function readSource(repoRelativePath: string): string {
+  const absolute = resolve(REPO_ROOT, repoRelativePath);
+  assert.ok(existsSync(absolute), `source not found: ${repoRelativePath}`);
+  return readFileSync(absolute, "utf8").replace(/\r\n/g, "\n");
+}
+
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+// ─── T1-T3 · the fixed contract ──────────────────────────────────────────────
+
+test("T1 the clinic boundary name is fixed by contract", () => {
+  assert.equal(CLINIC_SESSION_COOKIE_NAME, "app_session_id");
+  assert.ok(CLINIC_SESSION_COOKIE_NAME.trim().length > 0);
+});
+
+test("T2 the admin boundary name is fixed by contract", () => {
+  assert.equal(ADMIN_SESSION_COOKIE_NAME, "admin_session_id");
+  assert.ok(ADMIN_SESSION_COOKIE_NAME.trim().length > 0);
+});
+
+test("T3 the two fixed boundaries are distinct by construction", () => {
+  assert.notEqual(CLINIC_SESSION_COOKIE_NAME, ADMIN_SESSION_COOKIE_NAME);
+  assert.equal(
+    new Set(FIXED_SESSION_COOKIE_NAMES).size,
+    FIXED_SESSION_COOKIE_NAMES.length,
+    "fixed boundaries must not share a cookie name",
+  );
+});
+
+// ─── T4-T7 · particular stays configurable, collisions rejected ──────────────
+
+test("T4 particular falls back to its default when unset or blank", () => {
+  assert.equal(
+    resolveParticularSessionCookieName(undefined),
+    DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+  );
+  assert.equal(
+    resolveParticularSessionCookieName(""),
+    DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+  );
+  assert.equal(
+    resolveParticularSessionCookieName("   "),
+    DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+  );
+  assert.notEqual(
+    DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+    CLINIC_SESSION_COOKIE_NAME,
+  );
+  assert.notEqual(
+    DEFAULT_PARTICULAR_SESSION_COOKIE_NAME,
+    ADMIN_SESSION_COOKIE_NAME,
+  );
+});
+
+test("T5 a valid particular override is preserved", () => {
+  assert.equal(
+    resolveParticularSessionCookieName("legacy_particular_session"),
+    "legacy_particular_session",
+    "an existing deployment must keep its historical override",
+  );
+  assert.equal(
+    resolveParticularSessionCookieName("  padded_particular_session  "),
+    "padded_particular_session",
+    "trimming must match the environment schema preprocessing",
+  );
+});
+
+test("T6 a particular override colliding with clinic is rejected", () => {
+  assert.throws(
+    () => resolveParticularSessionCookieName(CLINIC_SESSION_COOKIE_NAME),
+    /PARTICULAR_COOKIE_NAME no puede ser "app_session_id".*clinic/s,
+  );
+});
+
+test("T7 a particular override colliding with admin is rejected", () => {
+  assert.throws(
+    () => resolveParticularSessionCookieName(ADMIN_SESSION_COOKIE_NAME),
+    /PARTICULAR_COOKIE_NAME no puede ser "admin_session_id".*admin/s,
+  );
+
+  // Padding must not smuggle a collision past the check.
+  assert.throws(
+    () => resolveParticularSessionCookieName(`  ${ADMIN_SESSION_COOKIE_NAME} `),
+    /PARTICULAR_COOKIE_NAME no puede ser/,
+  );
+});
+
+// ─── T8-T11 · single source of truth for the border-crossing boundaries ──────
+
+test("T8 the backend clinic cookie comes from the shared contract", () => {
+  const env = stripComments(readSource(ENV_PATH));
+
+  assert.ok(
+    env.includes('from "../../shared/session-cookie-names.ts"'),
+    `${ENV_PATH} must import the shared contract`,
+  );
+  assert.ok(
+    env.includes("cookieName: CLINIC_SESSION_COOKIE_NAME"),
+    `${ENV_PATH} clinic cookie must come from the contract`,
+  );
+});
+
+test("T9 the backend admin cookie comes from the shared contract", () => {
+  const env = stripComments(readSource(ENV_PATH));
+
+  assert.ok(
+    env.includes("adminCookieName: ADMIN_SESSION_COOKIE_NAME"),
+    `${ENV_PATH} admin cookie must come from the contract`,
+  );
+});
+
+test("T10 the proxy clinic boundary comes from the shared contract", () => {
+  const proxy = stripComments(readSource(PROXY_PATH));
+
+  assert.ok(
+    proxy.includes('from "../../shared/session-cookie-names"'),
+    `${PROXY_PATH} must import the shared contract`,
+  );
+  assert.ok(
+    proxy.includes(": CLINIC_SESSION_COOKIE_NAME"),
+    `${PROXY_PATH} clinic boundary must come from the contract`,
+  );
+});
+
+test("T11 the proxy admin boundary comes from the shared contract", () => {
+  const proxy = stripComments(readSource(PROXY_PATH));
+
+  assert.ok(
+    proxy.includes("? ADMIN_SESSION_COOKIE_NAME"),
+    `${PROXY_PATH} admin boundary must come from the contract`,
+  );
+});
+
+// ─── T12-T14 · no runtime override and no second literal owner ───────────────
+
+test("T12 clinic and admin are no longer runtime-configurable", () => {
+  const env = stripComments(readSource(ENV_PATH));
+
+  // Distinguish the ENV VAR from the contract symbol: CLINIC_SESSION_COOKIE_NAME
+  // legitimately contains "COOKIE_NAME". The env var only ever appears as a schema
+  // key or as a rawEnv access, so those two forms are what must be gone.
+  for (const removed of ["COOKIE_NAME", "ADMIN_COOKIE_NAME"]) {
+    assert.equal(
+      env.includes("rawEnv." + removed),
+      false,
+      `${ENV_PATH} must not read the removed env var "${removed}"`,
+    );
+
+    const declaresSchemaKey = env
+      .split(LINE_BREAK)
+      .some((line) => line.trim().startsWith(removed + ":"));
+
+    assert.equal(
+      declaresSchemaKey,
+      false,
+      `${ENV_PATH} must not declare "${removed}" in the environment schema`,
+    );
+  }
+});
+
+test("T13 the particular override stays supported by the backend", () => {
+  const env = stripComments(readSource(ENV_PATH));
+
+  assert.ok(
+    env.includes("PARTICULAR_COOKIE_NAME"),
+    `${ENV_PATH} must keep accepting PARTICULAR_COOKIE_NAME`,
+  );
+  assert.ok(
+    env.includes("particularCookieName: resolveParticularSessionCookieName("),
+    `${ENV_PATH} must resolve particular through the guarded resolver`,
+  );
+  assert.ok(
+    env.includes("rawEnv.PARTICULAR_COOKIE_NAME"),
+    `${ENV_PATH} must feed the override into the resolver`,
+  );
+
+  const envExample = readSource(".env.example");
+  assert.ok(
+    envExample.includes("PARTICULAR_COOKIE_NAME"),
+    ".env.example must keep documenting the supported particular override",
+  );
+  for (const removed of ["COOKIE_NAME=app_session_id", "ADMIN_COOKIE_NAME="]) {
+    assert.equal(
+      envExample.includes(removed),
+      false,
+      `.env.example must not advertise "${removed}" as configurable`,
+    );
+  }
+});
+
+test("T14 no owner reintroduces an independent clinic or admin literal", () => {
+  for (const path of [ENV_PATH, PROXY_PATH]) {
+    const source = stripComments(readSource(path));
+
+    for (const name of FIXED_SESSION_COOKIE_NAMES) {
+      assert.equal(
+        source.includes(`"${name}"`),
+        false,
+        `${path} must not restate the literal "${name}"; it is owned by ${SHARED_CONTRACT_PATH}`,
+      );
+    }
+  }
+});
+
+test("T14b the shared contract stays dependency-free and client-safe", () => {
+  const contract = stripComments(readSource(SHARED_CONTRACT_PATH));
+
+  assert.equal(
+    /\bimport\b/.test(contract),
+    false,
+    `${SHARED_CONTRACT_PATH} must not import anything; it is bundled by both builds`,
+  );
+  for (const forbidden of ["process.env", "node:", "require(", "dotenv"]) {
+    assert.equal(
+      contract.includes(forbidden),
+      false,
+      `${SHARED_CONTRACT_PATH} must not reference ${forbidden}`,
+    );
+  }
+
+  // The particular resolver is backend-only and must not leak into the proxy bundle.
+  const proxy = stripComments(readSource(PROXY_PATH));
+  assert.equal(
+    proxy.includes("resolveParticularSessionCookieName"),
+    false,
+    `${PROXY_PATH} must not import backend-only particular resolution`,
+  );
+  assert.equal(
+    stripComments(readSource(RESOLVER_PATH)).includes("process.env"),
+    false,
+    `${RESOLVER_PATH} must stay a pure function over its argument`,
+  );
+});
+
+// ─── T15 · the proxy boundary is unchanged and fail-closed ───────────────────
+
+test("T15 the proxy keeps its redirect and refuses any boundary fallback", () => {
+  const proxy = stripComments(readSource(PROXY_PATH));
+
+  assert.ok(proxy.includes('const LOGIN_PATH = "/login"'), "login path pinned");
+  assert.ok(
+    proxy.includes("return NextResponse.redirect(loginUrl)"),
+    "a missing session must redirect",
+  );
+  assert.ok(
+    proxy.includes('loginUrl.searchParams.set("next", nextPath)'),
+    "the redirect must preserve the requested path",
+  );
+  assert.ok(
+    proxy.includes("ADMIN_DASHBOARD_PATH_PREFIX"),
+    "the admin boundary must be selected by path",
+  );
+  assert.ok(
+    proxy.includes("request.cookies.get(requiredCookieName)?.value"),
+    "the proxy must check exactly the required boundary cookie",
+  );
+
+  assert.equal(
+    /ADMIN_SESSION_COOKIE_NAME\s*\|\||\|\|\s*ADMIN_SESSION_COOKIE_NAME/.test(proxy),
+    false,
+    "the admin boundary must not fall back to another cookie",
+  );
+  assert.equal(
+    /CLINIC_SESSION_COOKIE_NAME\s*\|\||\|\|\s*CLINIC_SESSION_COOKIE_NAME/.test(proxy),
+    false,
+    "the clinic boundary must not fall back to another cookie",
+  );
+  assert.equal(
+    proxy.includes(DEFAULT_PARTICULAR_SESSION_COOKIE_NAME),
+    false,
+    "the particular boundary does not participate in the dashboard proxy",
+  );
+});

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -92,7 +92,7 @@ const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "ff7fca08d621e757c8aad6b71cbd4d6d48b8ebdff5113c5c29dd574102298a38"],
   [".github/workflows/e2e-completeness.yml", "3ecc24d620b47bd71c53c3371d04a62de0a616439c84236d2135afd16f0d17a7"],
-  [".github/workflows/frontend-ci.yml", "4be3b3303e74152a053d26d739fce5b0fea4cade7e54c1bb86d5c0ba248fe4eb"],
+  [".github/workflows/frontend-ci.yml", "4c062a444de53da74aa928906e828b4a6c94cc50433937c1ee99cff09cf76d8d"],
   [".github/workflows/pr-governance.yml", "4e0bf177a8581c9dd655f1ca6aa1510a823cdd976c885c4ba50b41129e4157d7"],
   [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],
   [".github/workflows/visual-regression-manual.yml", "86784fe26f1f15e2ae6fb60ee8c26ef050f311bcebab72a2e1732739e035fee9"],

--- a/test/unit/ui/dashboard/dashboard-security-invariants.test.ts
+++ b/test/unit/ui/dashboard/dashboard-security-invariants.test.ts
@@ -1,0 +1,480 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// A04 · Dashboard security invariants baseline.
+//
+// The global audit (§11, §5) *observed* that the dashboard keeps admin and
+// clinic sessions separated, materializes no credential in the DOM and carries
+// no sensitive `data-*` lexeme. Observation is not a contract: this guard turns
+// those properties into executable, fail-closed evidence against current source.
+//
+// Scope is the A04 scope: the 15 normative modules and the dashboard surface
+// trees that contain them, plus the frontend auth boundary they depend on.
+// Backend session separation is already frozen elsewhere and is NOT restated
+// here (test/architecture/security/security-session-cookie-boundaries.test.ts,
+// global-auth-boundary-contract.test.ts); this guard covers the dashboard side.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TEST_FILE = fileURLToPath(import.meta.url);
+const REPO_ROOT = resolve(dirname(TEST_FILE), "..", "..", "..", "..");
+
+const sourceCache = new Map<string, string>();
+
+/** Repo source with CRLF normalized so markers match on Windows and Linux. */
+function readSource(repoRelativePath: string): string {
+  const cached = sourceCache.get(repoRelativePath);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const absolute = resolve(REPO_ROOT, repoRelativePath);
+  assert.ok(existsSync(absolute), `source not found: ${repoRelativePath}`);
+
+  const source = readFileSync(absolute, "utf8").replace(/\r\n/g, "\n");
+  sourceCache.set(repoRelativePath, source);
+  return source;
+}
+
+/**
+ * Prose is not behaviour. A file that merely NAMES `document.cookie` in a
+ * comment must not fail the guard, and a comment must not be able to satisfy a
+ * positive anchor either.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1");
+}
+
+function collectSourceFiles(relativeDir: string): string[] {
+  const rootDir = resolve(REPO_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (/\.tsx?$/.test(entry.name)) {
+        files.push(relative(REPO_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files.sort();
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Normative scope
+// ─────────────────────────────────────────────────────────────────────────────
+
+const A03_MATRIX_PATH =
+  "frontend/e2e/helpers/dashboard-adaptive-limit-matrix.ts";
+
+/** The dashboard surface trees that physically contain the 15 modules. */
+const DASHBOARD_SURFACE_TREES = [
+  "frontend/src/app/dashboard",
+  "frontend/src/components/dashboard",
+  "frontend/src/features/dashboard",
+] as const;
+
+/** The frontend auth boundary the dashboard depends on. */
+const AUTH_CONTEXT_PATH = "frontend/src/context/AuthContext.tsx";
+const API_CLIENT_PATH = "frontend/src/lib/api.ts";
+const DASHBOARD_PROXY_PATH = "frontend/src/proxy.ts";
+const AUTH_USER_TYPES_PATH = "frontend/src/types/index.ts";
+
+/**
+ * The 15 normative `moduleId` (§20.1) mapped to the files that physically own
+ * their surface. Two modules render mutually exclusive desktop and mobile
+ * presentations, so the 15 modules resolve to 17 owners. Same physical census
+ * as A07: the module surface is where a credential would leak into the DOM.
+ */
+const A04_OWNERS_BY_MODULE_ID: Readonly<Record<string, readonly string[]>> =
+  Object.freeze({
+    "admin-audit-log": ["frontend/src/app/dashboard/admin/AdminAuditCard.tsx"],
+    "admin-report-upload": [
+      "frontend/src/app/dashboard/admin/AdminReportsCard.tsx",
+    ],
+    "admin-particular-tokens": [
+      "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx",
+    ],
+    "admin-clinics": [
+      "frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx",
+    ],
+    "admin-users-roles": [
+      "frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx",
+    ],
+    "admin-sessions": [
+      "frontend/src/app/dashboard/admin/AdminSessionsReadOnlyCard.tsx",
+    ],
+    "admin-failed-login-alerts": [
+      "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+    ],
+    "admin-pricing": [
+      "frontend/src/app/dashboard/admin/AdminPricingEditorCard.tsx",
+      "frontend/src/app/dashboard/admin/AdminMobilePricingModule.tsx",
+    ],
+    "informes-reports-list": [
+      "frontend/src/app/dashboard/informes/InformesReportsList.tsx",
+    ],
+    "admin-maintenance": [
+      "frontend/src/app/dashboard/admin/AdminMaintenanceDryRunCard.tsx",
+      "frontend/src/app/dashboard/admin/AdminMobileMaintenanceModule.tsx",
+    ],
+    "clinic-informes-summary": [
+      "frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx",
+    ],
+    "clinic-logistica-summary": [
+      "frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx",
+    ],
+    "clinic-particular-tokens": [
+      "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx",
+    ],
+    "logistics-recent-list": [
+      "frontend/src/app/dashboard/logistica/LogisticsRecentListCanvas.tsx",
+    ],
+    "logistics-bounded-canvas": [
+      "frontend/src/app/dashboard/logistica/LogisticsBoundedCanvas.tsx",
+    ],
+  });
+
+const A04_DECLARED_OWNERS = Object.values(A04_OWNERS_BY_MODULE_ID).flat();
+
+/**
+ * Read from the A03 registry rather than restated here: a second hand-written
+ * copy of the 15 ids would drift silently, which is the failure this contract
+ * exists to catch.
+ */
+function readA03ModuleIds(): string[] {
+  const literal = readSource(A03_MATRIX_PATH).match(
+    /export const A03_MODULE_IDS = \[([\s\S]*?)\] as const;/,
+  );
+
+  assert.ok(
+    literal,
+    `${A03_MATRIX_PATH}: the canonical A03 registry literal must stay identifiable`,
+  );
+  return [...literal[1].matchAll(/"([^"]+)"/g)].map(([, id]) => id);
+}
+
+/**
+ * All dashboard surface files, discovered. Discovery makes the surface scans
+ * apply to files that do not exist yet; it does NOT prove completeness, which
+ * is why the 15-module census above is declared and cross-checked (A07 lesson).
+ */
+const DASHBOARD_SURFACE_FILES = DASHBOARD_SURFACE_TREES.flatMap(
+  collectSourceFiles,
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Sensitive lexemes
+//
+// Authentication credentials, not domain vocabulary. The product legitimately
+// owns "particular tokens" as an entity: `tokenLast4`, `tokenId` and
+// `tokenStatus` are non-secret metadata and must stay permitted. What may never
+// name a DOM attribute is the material that authenticates a request.
+//
+// The list is the auth-credential subset of the `security:public-surface`
+// normative list (scripts/security/audit-public-devtools-surface.mjs). PII
+// stems (email/phone/dni) stay covered there and are not restated here.
+//
+// English stems only, deliberately: the repo's approved convention renames
+// sensitive surfaces to a non-sensitive stem (`data-admin-sesiones-*`, PR-SRV-1)
+// precisely to satisfy that guard. Adding the Spanish stem here would invalidate
+// an approved naming decision and force a runtime rename outside A04 scope.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const SENSITIVE_DATA_ATTRIBUTE_STEMS = [
+  "password",
+  "passwd",
+  "secret",
+  "credential",
+  "authorization",
+  "bearer",
+  "cookie",
+  "jwt",
+  "session-token",
+  "session_token",
+  "session-id",
+  "session_id",
+  "access-token",
+  "access_token",
+  "refresh-token",
+  "refresh_token",
+  "auth-token",
+  "auth_token",
+  "api-key",
+  "api_key",
+  "apikey",
+  "private-key",
+  "private_key",
+] as const;
+
+/** Client-side persistence of an authentication credential. */
+const CLIENT_CREDENTIAL_STORAGE_MARKERS = [
+  "document.cookie",
+  "localStorage",
+  "sessionStorage",
+  "indexedDB",
+  "window.name",
+] as const;
+
+/** Manual serialization of a credential into a request. */
+const MANUAL_CREDENTIAL_HEADER_MARKERS = ["Authorization", "Bearer "] as const;
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 1 · Fail-closed coverage of the 15 normative modules
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("A04 covers the canonical A03 registry exactly", () => {
+  const registryIds = readA03ModuleIds();
+  const censusIds = Object.keys(A04_OWNERS_BY_MODULE_ID);
+
+  assert.equal(
+    registryIds.length,
+    15,
+    "A03 declares exactly 15 normative modules",
+  );
+  assert.equal(
+    new Set(registryIds).size,
+    registryIds.length,
+    "the A03 registry carries no duplicate moduleId",
+  );
+  assert.equal(
+    new Set(censusIds).size,
+    censusIds.length,
+    "the A04 census carries no duplicate moduleId",
+  );
+  assert.deepEqual(
+    censusIds,
+    registryIds,
+    "the A04 security census must cover the 15 canonical moduleId, in canonical order",
+  );
+});
+
+test("every normative module resolves to an existing owner inside the audited trees", () => {
+  assert.equal(
+    A04_DECLARED_OWNERS.length,
+    17,
+    "the 15 normative modules resolve to exactly 17 physical owners",
+  );
+  assert.equal(
+    new Set(A04_DECLARED_OWNERS).size,
+    A04_DECLARED_OWNERS.length,
+    "an owner file may not be claimed by two modules",
+  );
+
+  for (const [moduleId, owners] of Object.entries(A04_OWNERS_BY_MODULE_ID)) {
+    for (const path of owners) {
+      assert.ok(
+        existsSync(resolve(REPO_ROOT, path)),
+        `${moduleId}: declared owner "${path}" does not exist`,
+      );
+      assert.ok(
+        DASHBOARD_SURFACE_FILES.includes(path),
+        `${moduleId}: "${path}" must live inside an audited dashboard tree`,
+      );
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 2 · No sensitive `data-*` lexeme on the dashboard surface
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("no dashboard data-* attribute names an authentication credential", () => {
+  assert.ok(
+    DASHBOARD_SURFACE_FILES.length >= 100,
+    "the dashboard surface scan must not silently collapse to an empty set",
+  );
+
+  for (const path of DASHBOARD_SURFACE_FILES) {
+    const source = stripComments(readSource(path));
+
+    for (const [, name] of source.matchAll(/\bdata-([a-zA-Z0-9:_-]+)\s*=/g)) {
+      const normalized = name.toLowerCase();
+
+      for (const stem of SENSITIVE_DATA_ATTRIBUTE_STEMS) {
+        assert.equal(
+          normalized.includes(stem),
+          false,
+          `${path}: data-${name} names sensitive material ("${stem}")`,
+        );
+      }
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 3 · No client-side credential storage and no manual cookie read
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("no dashboard surface reads cookies or persists credentials client-side", () => {
+  for (const path of DASHBOARD_SURFACE_FILES) {
+    const source = stripComments(readSource(path));
+
+    for (const marker of CLIENT_CREDENTIAL_STORAGE_MARKERS) {
+      assert.equal(
+        source.includes(marker),
+        false,
+        `${path}: dashboard surfaces must not use ${marker}; the session is an HttpOnly cookie`,
+      );
+    }
+  }
+});
+
+test("no dashboard surface serializes a credential into a request header", () => {
+  for (const path of DASHBOARD_SURFACE_FILES) {
+    const source = stripComments(readSource(path));
+
+    for (const marker of MANUAL_CREDENTIAL_HEADER_MARKERS) {
+      assert.equal(
+        source.includes(marker),
+        false,
+        `${path}: dashboard surfaces must not build an ${marker.trim()} header`,
+      );
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 4 · The frontend auth contract holds no raw credential
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the authenticated user contract carries no credential material", () => {
+  const types = readSource(AUTH_USER_TYPES_PATH);
+  const block = types.match(/export type AuthUser = \{([\s\S]*?)\};/);
+
+  assert.ok(block, `${AUTH_USER_TYPES_PATH}: AuthUser must stay identifiable`);
+
+  for (const field of ["password", "token", "hash", "secret", "session"]) {
+    assert.equal(
+      new RegExp(`\\b${field}`, "i").test(block[1]),
+      false,
+      `AuthUser must not expose "${field}" to the browser`,
+    );
+  }
+});
+
+test("the auth context never materializes the session value", () => {
+  const source = stripComments(readSource(AUTH_CONTEXT_PATH));
+
+  for (const marker of CLIENT_CREDENTIAL_STORAGE_MARKERS) {
+    assert.equal(
+      source.includes(marker),
+      false,
+      `${AUTH_CONTEXT_PATH}: must not use ${marker}`,
+    );
+  }
+
+  for (const marker of MANUAL_CREDENTIAL_HEADER_MARKERS) {
+    assert.equal(
+      source.includes(marker),
+      false,
+      `${AUTH_CONTEXT_PATH}: must not build an ${marker.trim()} header`,
+    );
+  }
+});
+
+test("authenticated calls travel by cookie, never by a hand-built credential", () => {
+  const source = readSource(API_CLIENT_PATH);
+
+  assert.ok(
+    source.includes('credentials: options.credentials ?? "include"'),
+    `${API_CLIENT_PATH}: authenticated calls must rely on the HttpOnly session cookie`,
+  );
+  assert.equal(
+    stripComments(source).includes("document.cookie"),
+    false,
+    `${API_CLIENT_PATH}: the client must never read the session cookie`,
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 5 · Session separation at the dashboard boundary
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the dashboard boundary keeps admin and clinic sessions separated", () => {
+  const proxy = readSource(DASHBOARD_PROXY_PATH);
+
+  // A04 R2: the proxy no longer owns the literals. Both boundaries come from the
+  // fixed shared contract, so the anchor is consumption of that contract and the
+  // absence of an independent second copy. Distinctness itself is proven over the
+  // contract in test/unit/infrastructure/session-cookie-name-contract.test.ts.
+  assert.ok(
+    proxy.includes('from "../../shared/session-cookie-names"'),
+    `${DASHBOARD_PROXY_PATH}: must consume the shared session cookie contract`,
+  );
+  assert.ok(
+    proxy.includes("CLINIC_SESSION_COOKIE_NAME"),
+    `${DASHBOARD_PROXY_PATH}: clinic boundary must come from the contract`,
+  );
+  assert.ok(
+    proxy.includes("ADMIN_SESSION_COOKIE_NAME"),
+    `${DASHBOARD_PROXY_PATH}: admin boundary must come from the contract`,
+  );
+
+  for (const literal of ["app_session_id", "admin_session_id"]) {
+    assert.equal(
+      proxy.includes(`"${literal}"`),
+      false,
+      `${DASHBOARD_PROXY_PATH}: must not restate the literal "${literal}"`,
+    );
+  }
+
+  assert.ok(
+    proxy.includes("ADMIN_DASHBOARD_PATH_PREFIX"),
+    `${DASHBOARD_PROXY_PATH}: the admin boundary must be selected by path`,
+  );
+  assert.ok(
+    proxy.includes("return NextResponse.redirect(loginUrl)"),
+    `${DASHBOARD_PROXY_PATH}: a missing session must not reveal the dashboard`,
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// 6 · Collections expose token metadata, never the token
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("particular token collections expose only the last four characters", () => {
+  const source = readSource(API_CLIENT_PATH);
+  const block = source.match(
+    /export type AdminParticularTokenSummary = \{([\s\S]*?)\};/,
+  );
+
+  assert.ok(
+    block,
+    `${API_CLIENT_PATH}: AdminParticularTokenSummary must stay identifiable`,
+  );
+  assert.ok(
+    block[1].includes("tokenLast4: string;"),
+    "the token collection must carry the last-four metadata",
+  );
+  assert.equal(
+    /^\s*token\s*\??\s*:/m.test(block[1]),
+    false,
+    "the token collection must never carry the raw token",
+  );
+});
+
+test("the sessions module exposes row identifiers, never session material", () => {
+  const path = A04_OWNERS_BY_MODULE_ID["admin-sessions"][0];
+  const source = stripComments(readSource(path));
+
+  for (const marker of ["tokenHash", "sessionToken", "session.token"]) {
+    assert.equal(
+      source.includes(marker),
+      false,
+      `${path}: the sessions module must not render ${marker}`,
+    );
+  }
+});

--- a/test/unit/ui/dashboard/dashboard-security-invariants.test.ts
+++ b/test/unit/ui/dashboard/dashboard-security-invariants.test.ts
@@ -219,14 +219,73 @@ const SENSITIVE_DATA_ATTRIBUTE_STEMS = [
   "private_key",
 ] as const;
 
-/** Client-side persistence of an authentication credential. */
-const CLIENT_CREDENTIAL_STORAGE_MARKERS = [
-  "document.cookie",
-  "localStorage",
-  "sessionStorage",
-  "indexedDB",
-  "window.name",
+/**
+ * Manual cookie reads stay absolutely forbidden: the session travels as an
+ * HttpOnly cookie sent by `credentials: "include"`, so a dashboard surface has no
+ * legitimate reason to parse `document.cookie` itself.
+ */
+const MANUAL_COOKIE_READ_MARKER = "document.cookie";
+
+/**
+ * Web Storage is NOT forbidden. Storing UI state — density, dismissed hints,
+ * filters, panel layout — is legitimate and must keep working. What A04 forbids is
+ * putting authentication material there, so the guard inspects the *access* (its
+ * key and value expression) rather than the mere presence of the API name.
+ */
+const CLIENT_STORAGE_ACCESS_PATTERNS: readonly RegExp[] = [
+  // localStorage.setItem("k", v) · getItem("k") · removeItem("k")
+  /(?:localStorage|sessionStorage)\s*\.\s*(?:setItem|getItem|removeItem)\s*\(([^)]*)\)/g,
+  // localStorage["k"] = v
+  /(?:localStorage|sessionStorage)\s*\[([^\]]*)\]/g,
+  // window.name = v
+  /window\s*\.\s*name\s*=([^;\n]*)/g,
+  // indexedDB.open("db")
+  /indexedDB\s*\.\s*open\s*\(([^)]*)\)/g,
+];
+
+/**
+ * Credential lexemes looked for inside a storage access expression. The API name
+ * itself is never part of the captured group, so `sessionStorage` does not match
+ * its own "session" stem and benign keys stay green.
+ */
+const CREDENTIAL_STORAGE_LEXEMES = [
+  "token",
+  "session",
+  "auth",
+  "credential",
+  "password",
+  "passwd",
+  "secret",
+  "cookie",
+  "jwt",
+  "bearer",
+  "apikey",
+  "api_key",
+  "api-key",
+  "private_key",
+  "private-key",
 ] as const;
+
+/** Storage accesses whose key or value expression names credential material. */
+function findCredentialStorageAccesses(source: string): string[] {
+  const offenders: string[] = [];
+
+  for (const pattern of CLIENT_STORAGE_ACCESS_PATTERNS) {
+    for (const match of source.matchAll(pattern)) {
+      const accessExpression = (match[1] ?? "").toLowerCase();
+
+      if (
+        CREDENTIAL_STORAGE_LEXEMES.some((lexeme) =>
+          accessExpression.includes(lexeme),
+        )
+      ) {
+        offenders.push(match[0].trim());
+      }
+    }
+  }
+
+  return offenders;
+}
 
 /** Manual serialization of a credential into a request. */
 const MANUAL_CREDENTIAL_HEADER_MARKERS = ["Authorization", "Bearer "] as const;
@@ -322,13 +381,17 @@ test("no dashboard surface reads cookies or persists credentials client-side", (
   for (const path of DASHBOARD_SURFACE_FILES) {
     const source = stripComments(readSource(path));
 
-    for (const marker of CLIENT_CREDENTIAL_STORAGE_MARKERS) {
-      assert.equal(
-        source.includes(marker),
-        false,
-        `${path}: dashboard surfaces must not use ${marker}; the session is an HttpOnly cookie`,
-      );
-    }
+    assert.equal(
+      source.includes(MANUAL_COOKIE_READ_MARKER),
+      false,
+      `${path}: dashboard surfaces must not read ${MANUAL_COOKIE_READ_MARKER}; the session is an HttpOnly cookie`,
+    );
+
+    assert.deepEqual(
+      findCredentialStorageAccesses(source),
+      [],
+      `${path}: dashboard surfaces must not put credential material in client storage`,
+    );
   }
 });
 
@@ -368,13 +431,17 @@ test("the authenticated user contract carries no credential material", () => {
 test("the auth context never materializes the session value", () => {
   const source = stripComments(readSource(AUTH_CONTEXT_PATH));
 
-  for (const marker of CLIENT_CREDENTIAL_STORAGE_MARKERS) {
-    assert.equal(
-      source.includes(marker),
-      false,
-      `${AUTH_CONTEXT_PATH}: must not use ${marker}`,
-    );
-  }
+  assert.equal(
+    source.includes(MANUAL_COOKIE_READ_MARKER),
+    false,
+    `${AUTH_CONTEXT_PATH}: must not read ${MANUAL_COOKIE_READ_MARKER}`,
+  );
+
+  assert.deepEqual(
+    findCredentialStorageAccesses(source),
+    [],
+    `${AUTH_CONTEXT_PATH}: must not put credential material in client storage`,
+  );
 
   for (const marker of MANUAL_CREDENTIAL_HEADER_MARKERS) {
     assert.equal(

--- a/test/unit/ui/dashboard/frontend-dashboard-middleware.test.ts
+++ b/test/unit/ui/dashboard/frontend-dashboard-middleware.test.ts
@@ -22,8 +22,9 @@ test("frontend dashboard proxy exists and protects dashboard routes", () => {
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(source.includes('from "next/server"'));
-  assert.ok(source.includes('CLINIC_SESSION_COOKIE_NAME = "app_session_id"'));
-  assert.ok(source.includes('ADMIN_SESSION_COOKIE_NAME = "admin_session_id"'));
+  assert.ok(source.includes('from "../../shared/session-cookie-names"'));
+  assert.ok(source.includes("CLINIC_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes("ADMIN_SESSION_COOKIE_NAME"));
   assert.ok(source.includes('LOGIN_PATH = "/login"'));
   assert.ok(source.includes('ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin"'));
   assert.ok(source.includes("NextResponse.next()"));

--- a/test/unit/ui/frontend/frontend-extreme-speed-guardrails.test.ts
+++ b/test/unit/ui/frontend/frontend-extreme-speed-guardrails.test.ts
@@ -323,12 +323,16 @@ test("proxy protects /dashboard and /dashboard/admin with correct cookies", () =
   const source = read("frontend/src/proxy.ts");
 
   assert.ok(
-    source.includes('app_session_id'),
-    "middleware must check app_session_id for clinic sessions",
+    source.includes('from "../../shared/session-cookie-names"'),
+    "middleware must consume the shared session cookie contract",
   );
   assert.ok(
-    source.includes('admin_session_id'),
-    "middleware must check admin_session_id for admin sessions",
+    source.includes("CLINIC_SESSION_COOKIE_NAME"),
+    "middleware must check the clinic boundary for clinic sessions",
+  );
+  assert.ok(
+    source.includes("ADMIN_SESSION_COOKIE_NAME"),
+    "middleware must check the admin boundary for admin sessions",
   );
   assert.ok(
     source.includes('"/dashboard/:path*"'),

--- a/test/unit/ui/frontend/frontend-middleware.test.ts
+++ b/test/unit/ui/frontend/frontend-middleware.test.ts
@@ -22,8 +22,9 @@ test("frontend proxy imports Next response and request types", () => {
 test("frontend proxy separates clinic and admin dashboard session cookies", () => {
   const source = read(MIDDLEWARE_PATH);
 
-  assert.ok(source.includes('const CLINIC_SESSION_COOKIE_NAME = "app_session_id";'));
-  assert.ok(source.includes('const ADMIN_SESSION_COOKIE_NAME = "admin_session_id";'));
+  assert.ok(source.includes('from "../../shared/session-cookie-names"'));
+  assert.ok(source.includes("CLINIC_SESSION_COOKIE_NAME"));
+  assert.ok(source.includes("ADMIN_SESSION_COOKIE_NAME"));
   assert.ok(source.includes('const ADMIN_DASHBOARD_PATH_PREFIX = "/dashboard/admin";'));
   assert.ok(source.includes("function isAdminDashboardPath(pathname: string): boolean"));
   assert.ok(source.includes("pathname === ADMIN_DASHBOARD_PATH_PREFIX"));

--- a/test/unit/ui/frontend/frontend-next-config-security-headers.test.ts
+++ b/test/unit/ui/frontend/frontend-next-config-security-headers.test.ts
@@ -175,12 +175,16 @@ test("middleware session separation contract is intact after next.config changes
   const source = read(MIDDLEWARE_PATH);
 
   assert.ok(
-    source.includes('CLINIC_SESSION_COOKIE_NAME = "app_session_id"'),
-    "clinic session cookie name must be app_session_id",
+    source.includes('from "../../shared/session-cookie-names"'),
+    "proxy must consume the shared session cookie contract",
   );
   assert.ok(
-    source.includes('ADMIN_SESSION_COOKIE_NAME = "admin_session_id"'),
-    "admin session cookie name must be admin_session_id",
+    source.includes("CLINIC_SESSION_COOKIE_NAME"),
+    "clinic session boundary must come from the shared contract",
+  );
+  assert.ok(
+    source.includes("ADMIN_SESSION_COOKIE_NAME"),
+    "admin session boundary must come from the shared contract",
   );
   assert.ok(
     source.includes("return NextResponse.redirect(loginUrl)"),


### PR DESCRIPTION
## Summary

Closes **A04** (dashboard security baseline) and the two review findings raised on it.

A04 required proving, not observing, that the dashboard keeps its session boundaries separated and
materializes no credential. Building that executable baseline surfaced a real boundary defect, which
this PR fixes, and introducing the fix surfaced a governance gap, which this PR governs.

### 1 · A04 baseline (executable evidence)

`test/unit/ui/dashboard/dashboard-security-invariants.test.ts` freezes the A04 invariants against
current source: the 15 normative modules read from the canonical A03 registry (bidirectional, so a
silently dropped module fails), no credential in `AuthUser`, no manual cookie read, no credential in
client storage, no `Authorization`/`Bearer` hand-built header, no sensitive `data-*` lexeme,
`tokenLast4` never the raw token, and the sessions module never rendering session material.

### 2 · Session boundary fix (R2, authorized)

The baseline exposed two defects:

- **Uniqueness** — `server/lib/env.ts` accepted `COOKIE_NAME`, `ADMIN_COOKIE_NAME` and
  `PARTICULAR_COOKIE_NAME` as three independent optional vars with no rejection of repeated values.
- **Drift** — `frontend/src/proxy.ts` hardcoded the clinic/admin literals while the backend read
  them from `ENV`, so the two sides agreed only by coincidence and a backend rename silently broke
  the proxy boundary.

Fixed asymmetrically, matching each boundary's real reach:

| Boundary | Crosses backend ↔ proxy? | Resolution |
|---|:---:|---|
| Clinic | **Yes** | fixed in `shared/session-cookie-names.ts`, consumed by `env.ts` and the proxy |
| Admin | **Yes** | same contract |
| Particular | **No** | `PARTICULAR_COOKIE_NAME` **stays configurable**; `resolveParticularSessionCookieName()` returns the default or a valid override and **rejects at startup** any collision with clinic or admin |

Backend and frontend are separately deployed services, so duplicating a variable across both would
not have been a single source of truth — only relocated drift. Existing deployments keep any valid
historical particular override; verified against real startup.

### 3 · Governance route for the new cross-runtime boundary (review P1)

`shared/**` had no Quality Gate Impact route, so PR Governance failed **correctly** on the previous
SHA. Fixed by governing the boundary, not silencing the gate: rule `shared-cross-runtime` routes
`shared/**` to **backend-ci and frontend-ci together**, with both runtimes' suites derived from the
taxonomy rather than recopied. Unknown paths stay fail-closed — no root catch-all was added.

The `frontend-ci.yml` **pull_request impact detector** recognized six routes and not `shared/*`, so
a shared-only PR could run Frontend CI with `should_run=false` and skip lint, typecheck, build,
public-surface and E2E. Now seven. Only the detector changed; `push` path filters were deliberately
left untouched, and the contract test distinguishes the two mechanisms.

### 4 · Credential-aware client storage (review P2)

The baseline previously banned `localStorage`, `sessionStorage`, `indexedDB` and `window.name`
outright, which would have blocked legitimate UI state. A04's goal is not to ban Web Storage — it is
to keep authentication material out of it. The guard now inspects the **access expression** (key and
value), not the presence of the API name:

- `document.cookie` — still absolutely forbidden.
- `localStorage.setItem("admin_session_id", token)` / `sessionStorage.setItem("auth-token", cred)` /
  `localStorage.getItem("app_session_id")` / `window.name = adminSessionToken` — **fail**.
- `localStorage.setItem("dashboard-density", "compact")` /
  `sessionStorage.setItem("dismissed-help", "1")` — **pass**.

## Mutation controls

Every guard is demonstrated fail-closed, and the storage guard is additionally demonstrated
**not** to false-positive.

| Control | Result |
|---|---|
| `data-auth-token` in a new dashboard file | FAIL |
| `document.cookie` in a new dashboard file | FAIL |
| credential stored/read in client storage (4 shapes) | FAIL |
| benign UI storage (4 shapes) | **PASS** |
| a normative `moduleId` removed from the census | FAIL |
| clinic == admin in the fixed contract | FAIL |
| particular override == clinic / == admin | rejected at startup |
| independent literal reintroduced in the proxy | FAIL |
| proxy stops consuming the shared contract | FAIL |
| `shared-cross-runtime` rule removed | governance returns to fail-closed |
| `shared/*` removed from the frontend detector | workflow contract FAIL |

## Validation

Local validation of this diff: `pnpm typecheck`, `pnpm typecheck:test`, `pnpm test`
(4211 pass / 0 fail / 1 pre-existing skip), `pnpm build`, `pnpm --dir frontend lint`,
`pnpm --dir frontend typecheck`, `pnpm --dir frontend build`, `pnpm security:public-surface` and
`pnpm validate:local` — all exit 0. The shared contract does not reach the client bundle: 0
occurrences in `frontend/.next/static`.

Backend CI and Frontend CI passed on the previous SHA; PR Governance failed there for the missing
`shared/**` route, which is what this commit fixes. **Remote CI for the new SHA has not run yet.**

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference:
- Justification: A separate ADR/RFC is not required for this closeout. The PR does not introduce a new service, persistence model, database boundary, API contract, authorization model, or deployment topology. It makes the existing clinic/admin session-cookie protocol single-owner across the already existing backend and Next proxy boundary, and updates Governance plus the frontend impact detector so that the new cross-runtime contract is validated by both runtime gates. The coupling boundary, validation evidence, and single-revert rollback boundary are documented directly in this PR.
## Scope

- [x] backend runtime
- [x] frontend runtime
- [ ] tests
- [x] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [x] other
- [x] mixed-scope exception

## Other Scope Detail

Two root-level paths fall outside the backend/frontend taxonomy:

- **`shared/session-cookie-names.ts`** is a root-level **protocol contract** consumed by both
  runtimes: the backend bundle (esbuild) and the Next proxy compile the same module. It belongs
  exclusively to neither runtime, so `classifyPath` keeps it as `other` — while Quality Gate Impact
  routes it explicitly to **both** `backend-ci` and `frontend-ci` via `shared-cross-runtime`. The two
  taxonomies answer different questions: metadata scope describes ownership, impact routing describes
  which gates must execute. `shared/` remains scoped to this single file; it is not a general-purpose
  bucket.
- **`.env.example`** is the root deployment configuration example, already routed by the existing
  `root-env-example` rule.

## Mixed-Scope Justification

Backend runtime, frontend runtime, the shared cross-runtime contract, the workflow impact detector
and the governance route are **one atomic correction of the session boundary**, not five changes
bundled for convenience.

The boundary defect is precisely that clinic and admin cookie names had two independent owners on
opposite sides of a deploy split. Fixing it requires changing both owners in the same commit — a
split would leave the backend and the proxy disagreeing about the cookie name, which is the very
failure being repaired, and would ship a runtime regression between PRs. The shared contract is the
mechanism that removes the second owner, so it cannot be separated from either side.

The governance route and the frontend detector are not follow-up work either: they are what makes
the new path governed at all. Landing `shared/**` without them means the boundary contract can be
edited in a future PR while Frontend CI reports success without validating the frontend — the exact
gap review P1 identified. Rollback is a single revert of one commit.

## Rollback

Revert the commit. Runtime returns to env-resolved clinic/admin cookie names, the proxy returns to
its literals, and `shared/` disappears together with its governance route.

