### PR TITLE
fix(ci): realign e2e completeness workflow security digest

### DIFF
--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -91,7 +91,7 @@ const mutableActionReferences = [
 const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "ff7fca08d621e757c8aad6b71cbd4d6d48b8ebdff5113c5c29dd574102298a38"],
-  [".github/workflows/e2e-completeness.yml", "3ecc24d620b47bd71c53c3371d04a62de0a616439c84236d2135afd16f0d17a7"],
+  [".github/workflows/e2e-completeness.yml", "a4fb65f47d4e7164b0517b9e38487391c5da5881479954f4effcf098a32b414d"],
   [".github/workflows/frontend-ci.yml", "4c062a444de53da74aa928906e828b4a6c94cc50433937c1ee99cff09cf76d8d"],
   [".github/workflows/pr-governance.yml", "4e0bf177a8581c9dd655f1ca6aa1510a823cdd976c885c4ba50b41129e4157d7"],
   [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],


### PR DESCRIPTION
## Summary
- Change type: CI / workflow-security governance fix (contract realignment only).
- Context / issue: `main` is red at `1e78017`. `pnpm test` (and therefore `pnpm validate:local` and `Backend CI`) fails on `test/unit/infrastructure/workflow-security-policy-contract.test.ts` → `canonical workflow security state is frozen until parser-backed enforcement`. This blocks every open and future PR until it is realigned.
- What changed: exactly one reviewed SHA-256 digest literal, on line 94 of the workflow-security contract, for `.github/workflows/e2e-completeness.yml`.

**Root cause.** Commit `1e78017` (`test(dashboard): close A08 with canonical 21x13 zero-scroll freeze`) intentionally hardened `.github/workflows/e2e-completeness.yml` — it split out `playwright install-deps` and replaced the single `playwright install --with-deps chromium` step with a bounded retry loop (2 attempts, 180s timeout, 10s backoff). That commit realigned the sibling anchor `test/unit/infrastructure/e2e-completeness-workflow.test.ts`, but omitted the `canonicalWorkflowDigests` entry in the workflow-security contract. The freeze test did its job and caught the change; it was simply never closed out.

**Evidence that the digest is the correct reviewed value, not a rubber stamp:**

| Reference | SHA-256 (CRLF→LF, UTF-8 — the exact normalization `readWorkflow`/`workflowDigest` use) |
| --- | --- |
| Digest pinned in the contract before this PR | `3ecc24d620b47bd71c53c3371d04a62de0a616439c84236d2135afd16f0d17a7` |
| Workflow at `c9c1869e` (parent of `1e78017`) | `3ecc24d620b47bd71c53c3371d04a62de0a616439c84236d2135afd16f0d17a7` |
| Workflow at `1e78017` (HEAD of `main`) | `a4fb65f47d4e7164b0517b9e38487391c5da5881479954f4effcf098a32b414d` |

The stale pin matches the workflow at the **parent** commit exactly, which proves the contract was green before `1e78017` and that `1e78017` is what broke it. A sweep of all seven canonical workflows shows **6 MATCH, 1 DRIFT** — the drift is isolated to `e2e-completeness.yml`.

**The workflow file is deliberately NOT modified.** Its current content is the intentional A08 hardening. "Fixing" the digest by reverting the workflow would silently undo that hardening. This PR realigns the contract to the intentional workflow, which is what the test's own message asks for ("update the reviewed canonical digest only after explicit workflow-security review").

## Scope

- [ ] backend runtime
- [ ] frontend runtime
- [x] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

The governed domain of this change is workflow-security, but the only changed path is `test/unit/infrastructure/workflow-security-policy-contract.test.ts`, which `classifyPath` maps to `tests` and `derivePrimaryCategories` reduces to the single primary scope `tests`. The checkbox is set to match the scope the validator actually derives. No workflow file is touched by this PR.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference:
- Justification: The Architecture Decision gate does not apply here: it triggers on `drizzle/`, `.github/workflows/` or `server/` paths, and this PR changes only a test contract constant. The change updates one reviewed digest literal so the frozen contract matches the workflow already merged into `main`. It alters no architectural boundary, no data model, no composition, and no governed workflow behavior — the workflow file itself is byte-for-byte unchanged, so CI execution semantics are identical before and after.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected)
- [ ] `pnpm --dir frontend typecheck` (if frontend affected)
- [ ] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Executed locally on the branch commit:

- Targeted contract: `node --experimental-strip-types --experimental-specifier-resolution=node --test test/unit/infrastructure/workflow-security-policy-contract.test.ts` → **PASSED, 8/8** (was 7/8 with 1 failure before the change).
- Governance validator: `node scripts/governance/workflow-security-validator.mjs` → **PASSED** (policy QGA-4.2, 7 workflows, 28 external actions, 0 local actions, 1 container image, 1 exception used).
- `pnpm validate:local` (`typecheck && typecheck:test && test && build`) → **PASSED**, 4220 tests, 4219 pass, 0 fail, 1 skipped.
- `git diff --check 1e78017..HEAD` → **PASSED**, empty.

Frontend gates are unchecked because no frontend path is affected. Dependency audits are unchecked because no manifest or lockfile is affected. The CI checkbox is left unchecked deliberately: CI has not completed at the time of opening, and it will not be ticked without an observed green run.

Disclosure on local validation: the working tree used for `pnpm validate:local` also carried unrelated, uncommitted local work, so that run is a combined working-tree validation and does not by itself prove isolation. The isolation proof is this PR's CI, because the pushed commit contains only the contract file. The targeted contract test and the governance validator both read only `.github/workflows/**` and the contract, so they are unaffected by anything in the working tree.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

Security review notes: the changed value is a content digest of a workflow already committed to `main` — it is not a credential, token, or hash derived from a secret, and it is safe to record. No action reference changed, so `pinnedActionReferences` and `test/architecture/toolchain-contract.test.ts` need no realignment; the test `canonical workflows pin only allowlisted external action references` passes untouched. No runtime code, no auth surface, no cookie or session behavior, no endpoint, no query string, no schema and no migration are involved. There is no runtime change of any kind.

## Rollback
- Trigger: `validate-pr-governance`, `validate-backend`, `qga-workflow-security` or `validate-frontend` failing on this PR, or any reviewer objection to accepting the A08 workflow content as the reviewed baseline.
- Steps: `git revert` of the single commit. There is nothing else to undo — one file, one line, no runtime effect, no schema, no migration, no data.
- Data impact: none. Note that reverting restores the previous digest and therefore restores the current red state of `main`, since the workflow on `main` would again disagree with the frozen contract. The correct response to a rollback would be an explicit workflow-security review of the A08 workflow content, not a revert of that workflow.

## Excluded from this PR
Unrelated local dashboard work (B01 presentation barrels), all frontend and runtime code, backend, database, dependencies, and every workflow file including `.github/workflows/e2e-completeness.yml` itself. This PR is deliberately a single-file, single-line change so it can land independently and unblock `main`.
