### PR TITLE
refactor(dashboard): populate B01 presentation shell and navigation

### DIFF
--- a/docs/implementation/dashboard-presentation-shell-navigation-barrels.md
+++ b/docs/implementation/dashboard-presentation-shell-navigation-barrels.md
@@ -1,0 +1,220 @@
+# B01 — `presentation/shell` + `presentation/navigation` re-export barrels
+
+> **Tipo:** arquitectura de imports. **No mueve componentes, no migra consumidores, no cambia comportamiento, no toca CSS, DOM, rutas, auth ni backend.**
+> **Base:** `main` limpio · **HEAD:** `8769f68` fix(ci): realign e2e completeness workflow security digest (#1657)
+> **Documento rector:** [`docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md`](../audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md) — §47.2, §49 (B01), §54, §56.1, §59–§62
+> **Antecedente estructural:** [`dashboard-presentation-boundaries.md`](./dashboard-presentation-boundaries.md) (PR-PRES-2) · patrón de re-export puro: [`dashboard-surface-primitives.md`](./dashboard-surface-primitives.md) (PR-PRES-5)
+
+## 1. Estado base
+
+`presentation/shell/index.ts` y `presentation/navigation/index.ts` eran barrels
+placeholder (`export {};`) creados por PR-PRES-2. Cero exports, cero
+consumidores. Las capas hermanas ya habían aterrizado exports reales:
+`config` (PR-PRES-3), `application` (PR-PRES-4) y `surfaces` (PR-PRES-5).
+
+La frontera de presentación existía **solo como prosa JSDoc**: no había ninguna
+regla de import ejecutable. Verificado: cero ocurrencias de
+`no-restricted-imports` en el repo, `frontend/tsconfig.json` sin restricciones, y
+ningún guard de `test/architecture/**` cubriendo `features/dashboard/presentation`.
+
+Dependencia de B01 según §49: **A07**, cerrado en `7ef58c1` (#1653). Gate **G3**
+(`limit` invariante, A05–A07), exigido por §58 antes de B01: cumplido.
+
+## 2. Scope B01
+
+- Poblar `presentation/shell/index.ts` con re-exports behaviour-preserving.
+- Poblar `presentation/navigation/index.ts` con re-exports behaviour-preserving.
+- Crear el guard ejecutable de import boundaries.
+- Este documento.
+
+## 3. No-alcance
+
+- No se mueve ningún archivo de `frontend/src/components/dashboard/**`.
+- No se migra ningún consumidor: los imports actuales quedan idénticos.
+- No se retira ni se borra ningún componente (B02).
+- No se retiran `DashboardHorizontalNav` ni `DashboardModuleRail` (B08).
+- No se tocan tokens, CSS, WorkspaceAppBar, NavigationDrawer/Rail (B03–B07).
+- No se tocan `server/**`, `drizzle/**`, `shared/**`, `frontend/src/app/**`,
+  `@/lib/api*`, `@/lib/auth*`, `frontend/tsconfig.json`, configs ESLint,
+  `package.json`, `pnpm-lock.yaml`, `.github/**`, CI ni dependencias.
+
+## 4. Decisión: re-exports behaviour-preserving
+
+Los barrels re-exportan las implementaciones legacy con path absoluto pinneado
+(`@/components/dashboard/*`). Es el paso sancionado por §47.2 ("Reexportar
+durante la migración: los barriles de `presentation/*` reexportan desde
+`components/dashboard/` hasta que el último consumidor migre") y por la
+mitigación **R14** de §60 ("ambas gramáticas conviven sin romper imports").
+
+Se eligieron re-exports explícitos por símbolo en lugar de `export *`, para que
+la superficie pública sea declarada y auditable, y en lugar de 15 archivos
+wrapper de una línea, que serían churn sin valor.
+
+`isolatedModules: true` obliga al modificador `type` inline en los re-exports de
+tipos; se sigue el estilo ya aterrizado en PR-PRES-5.
+
+## 5. Por qué no se movieron componentes
+
+Los 15 componentes están anclados por `readFileSync(".../components/dashboard/X.tsx")`
+en ~20 tests de contrato de origen. Mover obligaría a realinear todos esos
+anclajes en el mismo PR (AGENTS.md §4) — riesgo alto, sin beneficio, y
+contradiciendo §47.2, que pide exactamente lo contrario durante la migración.
+
+Los dos ciclos type-only preexistentes (`DashboardModuleRail` ↔
+`ClinicDashboardWorkspaceController` y `DashboardModuleHub` ↔
+`AdminMobileHubLauncher`) viven íntegramente dentro de `components/dashboard/`.
+Como cada re-export apunta al archivo concreto y nunca a otro barrel, B01 **no
+añade ninguna arista** al grafo y no crea ni agrava ciclo alguno.
+
+## 6. Re-exports de `presentation/shell` (5 módulos · 10 símbolos)
+
+| Módulo legacy | Símbolos re-exportados |
+|---|---|
+| `DashboardShellRouter` | `DashboardShellRouter` |
+| `PrivateDashboardShell` | `PrivateDashboardShell`, `type PrivateDashboardShellProps` |
+| `DashboardModuleWorkspace` | `DashboardModuleWorkspace` |
+| `DashboardModuleHub` | `DashboardModuleHub`, `type DashboardModuleCard` |
+| `DashboardHubHero` | `DashboardHubHero`, `type DashboardHubHeroMetric`, `type DashboardHubHeroProps`, `type DashboardHubHeroStatusTone` |
+
+## 7. Re-exports de `presentation/navigation` (10 módulos · 17 símbolos)
+
+| Módulo legacy | Símbolos re-exportados |
+|---|---|
+| `DashboardHorizontalNav` | `DashboardHorizontalNav`, `type DashboardNavSurface` |
+| `DashboardModuleRail` | `DashboardModuleRail`, `CLINIC_MODULE_RAIL_ITEMS` |
+| `AdminMobileBottomNav` | `AdminMobileBottomNav` |
+| `ClinicMobileBottomNav` | `ClinicMobileBottomNav` |
+| `AdminMobileHubLauncher` | `AdminMobileHubLauncher` |
+| `AdminMobileHubPager` | `AdminMobileHubPager` |
+| `AdminMobileKebabMenu` | `AdminMobileKebabMenu` |
+| `AdminMobileModuleMenu` | `AdminMobileModuleMenu` |
+| `DashboardPager` | `DashboardPager`, `type DashboardPagerProps`, `DASHBOARD_PAGER_RESERVATION`, `DASHBOARD_TOUCH_PAGER_RESERVATION`, `DASHBOARD_INLINE_PAGER_RESERVATION` |
+| `CompactPager` | `CompactPager`, `type CompactPagerProps` |
+
+El catálogo sigue siendo single-owner: `CLINIC_MODULE_NAV_LABELS` y
+`buildDashboardModuleHref` se consumen desde `@/features/dashboard/config` y
+`@/features/dashboard/application`; los barrels no redeclaran ids, labels,
+storage keys ni tablas de navegación.
+
+## 8. `DashboardTopbar` — excluido temporalmente
+
+`frontend/src/components/dashboard/DashboardTopbar.tsx:12` importa `@/lib/api`
+directamente (`logout`, `logoutAdmin`). Exponerlo por `presentation/shell`
+convertiría el barrel en la vía sancionada de un componente que viola la regla
+de frontera que el propio barrel declara, y obligaría a escribir el guard en su
+versión débil para que pasara — exactamente el riesgo **R4** de §59
+("realinear tests de contrato degenera en debilitarlos").
+
+**B01 no modifica `DashboardTopbar` ni `DashboardLogoutControl`.** Ambos
+concentran la misma responsabilidad de logout (duplicación funcional de
+responsabilidad; no se ha verificado igualdad textual). Sacar el logout a
+`application` es auth-adjacent y por tanto **R2**: PR separado.
+
+La exclusión **no está congelada**. El guard no afirma en ningún punto que la
+violación persista: aplica la regla genérica "ningún módulo re-exportado puede
+importar `@/lib/api`". Cuando ese import desaparezca, `DashboardTopbar` pasa a
+ser admisible sin editar el guard.
+
+## 9. Sidebars muertos — excluidos (dominio B02)
+
+`AdminDashboardSidebar` y `ClinicDashboardSidebar` tienen **cero consumidores
+runtime** (verificado en todo el repo; solo se importan entre sí y desde
+`DashboardSidebar.tsx`, también muerto). Son parte de los 6 componentes que
+**B02** retira (§47.2). Darles superficie de import pública en B01 para
+retirarla en B02 sería churn puro, y §56.1 exige "sin componentes muertos".
+
+**B01 no los borra ni los modifica**: simplemente no los incorpora a la nueva
+API de `presentation`. El guard lo fija con un `FORBIDDEN_EXPORTS` explícito,
+documentado como valla de scope y no como veredicto permanente.
+
+## 10. Architecture guard
+
+`test/architecture/dashboard-presentation-import-boundaries.test.ts` — 8 tests.
+
+Es la forma ejecutable del criterio de cierre de §54 ("sin imports cruzados") y
+del plan de pruebas de §56.1. Verifica:
+
+1. `shell/index.ts` expone los REQUIRED_EXPORTS de B01.
+2. `navigation/index.ts` expone los REQUIRED_EXPORTS de B01.
+3. Todo re-export apunta a un target existente bajo `components/dashboard/`.
+4. Cada símbolo declarado está realmente exportado por su target.
+5. Ningún source físico bajo `presentation/**` importa `@/lib/api` ni `@/app`.
+6. Ningún **target legacy re-exportado** importa `@/lib/api` ni `@/app`.
+7. La valla B02: los sidebars no aparecen en `navigation/index.ts`.
+8. Los barrels son módulos de re-export puro, sin declaraciones locales.
+
+**Por qué no da falso verde.** Un barrel puede pasar un escaneo ingenuo de
+carpeta mientras re-exporta un componente legacy que sí llega a la capa de
+datos. Por eso el guard no se limita a recorrer `presentation/**`: **parsea los
+barrels, deriva los targets del propio source** y les aplica las mismas reglas.
+La lista de targets se descubre, nunca se declara como allowlist de escape, así
+que un re-export añadido en el futuro queda cubierto automáticamente. Los tests
+de conjunto vacío se protegen con aserciones anti-vacuas.
+
+**Falsos positivos evitados.** Los JSDoc de los 7 barrels contienen literalmente
+el texto `@/lib/api` al documentar la regla. Un `source.includes("@/lib/api")`
+marcaría todos. El guard extrae specifiers solo de declaraciones reales:
+patrones anclados a inicio de línea (que una línea de continuación JSDoc `* …`
+no puede satisfacer) más una forma de llamada para `import()`/`require()`. El
+emparejamiento es exacto-o-subpath, de modo que `@/lib/api-error` no se barre por
+accidente. Sin dependencias de parser nuevas.
+
+**Verificación fail-closed.** El guard se validó por mutación sobre una copia
+aislada del árbol (fuera del repo, ningún archivo versionado tocado). Las 6
+mutaciones fueron detectadas y el baseline volvió a 8/8:
+
+| Mutación | Resultado |
+|---|---|
+| M1 · shell re-exporta `DashboardTopbar` (llega a `@/lib/api`) | FALLA (correcto) |
+| M2 · navigation re-exporta `AdminDashboardSidebar` | FALLA (correcto) |
+| M3 · shell omite `DashboardHubHeroStatusTone` | FALLA (correcto) |
+| M4 · navigation redeclara un literal de catálogo | FALLA (correcto) |
+| M5 · source de presentation importa `@/lib/api` | FALLA (correcto) |
+| M6 · escape relativo hacia `app/` | FALLA (correcto) |
+
+M1 es exactamente el escenario de falso verde que el diseño debía impedir.
+
+## 11. Cero cambios de runtime
+
+Ningún consumidor importa todavía los barrels, y ninguna implementación se tocó.
+En consecuencia: DOM idéntico, CSS idéntico, geometría idéntica, zero-scroll
+idéntico; auth, cookies, sesiones, roles y permisos idénticos; API, endpoints,
+query strings y handlers idénticos; `limit`/`offset` y paginación idénticos.
+No se introdujeron atributos `data-*`, JSX, llamadas de red ni handlers nuevos.
+
+## 12. Validaciones
+
+Ver el informe de la corrida en la respuesta de entrega. Gates seleccionados
+por AGENTS.md §6: el cambio toca `frontend/src/**` y `test/**`, por lo que
+aplican la matriz de frontend no visual y `pnpm validate:local` (que además
+ejecuta el guard nuevo dentro del runner completo).
+
+Playwright: **NOT_RUN justificado**. B01 no altera DOM, CSS, geometría ni ningún
+path de render, y los barrels no los importa nadie: ninguna cohorte de §7 aplica.
+
+## 13. Riesgos residuales
+
+1. `DashboardTopbar` sigue violando la frontera. Único hueco real; registrado por
+   el guard de forma auto-expirante. Cierre = PR separado (R2, auth-adjacent).
+2. Los barrels quedan como superficie declarada que todavía nadie importa. Es el
+   diseño previsto por §47.2/R14; el valor de B01 es el guard y habilitar B02+.
+3. `export` sobre 11 componentes `"use client"`: sin efecto hoy (nadie importa
+   los barrels), pero cuando un PR posterior migre el primer consumidor deberá
+   vigilarse el arrastre del grafo client del barrel. El precedente PR-PRES-5 no
+   cubre este caso: `StatusBadge` no es client component.
+4. Ciclos type-only preexistentes: no agravados, no corregidos, fuera de B01.
+5. Los sidebars muertos siguen presentes hasta B02, por diseño.
+
+## 14. Rollback
+
+`git revert` del commit. Restaura los dos barrels a `export {};` y elimina guard
+y documento. Sin migraciones, sin cambios de esquema, sin efecto runtime que
+deshacer. Coincide con §61: "B01–B02 · Revert restaura los barriles · riesgo
+residual nulo".
+
+## 15. Estado final
+
+B01 implementado localmente: 2 barrels poblados, 1 guard ejecutable (8/8), 1
+documento. Cero movimiento de runtime, cero migración de consumidores, cero
+cambios en los 15 componentes legacy. Pendiente de revisión y autorización git
+de Nico. **B02 no iniciado.**

--- a/docs/implementation/dashboard-presentation-shell-navigation-barrels.md
+++ b/docs/implementation/dashboard-presentation-shell-navigation-barrels.md
@@ -76,7 +76,7 @@ añade ninguna arista** al grafo y no crea ni agrava ciclo alguno.
 | `DashboardModuleHub` | `DashboardModuleHub`, `type DashboardModuleCard` |
 | `DashboardHubHero` | `DashboardHubHero`, `type DashboardHubHeroMetric`, `type DashboardHubHeroProps`, `type DashboardHubHeroStatusTone` |
 
-## 7. Re-exports de `presentation/navigation` (10 módulos · 17 símbolos)
+## 7. Re-exports de `presentation/navigation` (9 módulos · 16 símbolos)
 
 | Módulo legacy | Símbolos re-exportados |
 |---|---|
@@ -86,7 +86,6 @@ añade ninguna arista** al grafo y no crea ni agrava ciclo alguno.
 | `ClinicMobileBottomNav` | `ClinicMobileBottomNav` |
 | `AdminMobileHubLauncher` | `AdminMobileHubLauncher` |
 | `AdminMobileHubPager` | `AdminMobileHubPager` |
-| `AdminMobileKebabMenu` | `AdminMobileKebabMenu` |
 | `AdminMobileModuleMenu` | `AdminMobileModuleMenu` |
 | `DashboardPager` | `DashboardPager`, `type DashboardPagerProps`, `DASHBOARD_PAGER_RESERVATION`, `DASHBOARD_TOUCH_PAGER_RESERVATION`, `DASHBOARD_INLINE_PAGER_RESERVATION` |
 | `CompactPager` | `CompactPager`, `type CompactPagerProps` |
@@ -115,6 +114,51 @@ violación persista: aplica la regla genérica "ningún módulo re-exportado pue
 importar `@/lib/api`". Cuando ese import desaparezca, `DashboardTopbar` pasa a
 ser admisible sin editar el guard.
 
+## 8-bis. `AdminMobileKebabMenu` — excluido por frontera transitiva (review fix)
+
+Hallazgo **P2 de Codex** en la revisión de PR #1658, **confirmado como correcto**.
+
+La primera versión del guard afirmaba "ningún módulo reexportado alcanza la data
+layer" pero solo inspeccionaba el **target inmediato** de cada re-export. Un
+componente sancionado puede alcanzar `@/lib/api` **a través de otro componente
+local**, y en ese caso el guard reportaba la frontera como limpia mientras el
+export sancionado seguía cruzándola. Falso verde real, no hipotético:
+
+```text
+presentation/navigation
+  -> AdminMobileKebabMenu
+     -> DashboardLogoutControl      -> @/lib/api
+     -> DashboardNotificationsBell  -> @/lib/api
+```
+
+**Censo transitivo completo** ejecutado sobre los 15 roots sancionados antes de
+tocar ningún barrel (no se parcheó solo el ejemplo del review). Resolver
+estático con alias `@/`, specifiers relativos, extensiones `.ts`/`.tsx`, index
+modules y visited set; **0 specifiers locales sin resolver**, así que el censo no
+tiene saltos silenciosos:
+
+| Barrel | Roots | Veredicto |
+|---|---|---|
+| `shell` | `DashboardShellRouter`, `PrivateDashboardShell`, `DashboardModuleWorkspace`, `DashboardModuleHub`, `DashboardHubHero` | 5/5 **PASS** |
+| `navigation` | `DashboardHorizontalNav`, `DashboardModuleRail`, `AdminMobileBottomNav`, `ClinicMobileBottomNav`, `AdminMobileHubLauncher`, `AdminMobileHubPager`, `AdminMobileModuleMenu`, `DashboardPager`, `CompactPager` | 9/9 **PASS** |
+| `navigation` | `AdminMobileKebabMenu` | **FAIL** (cadenas arriba) |
+
+**Un solo root falla**, y solo ese se retira. No se sobre-excluyó por sospecha:
+toda exclusión exige una cadena concreta hasta la dependencia prohibida.
+
+**Decisión: retirar el re-export, no refactorizar el componente.** B01 no está
+autorizado a refactorizar componentes runtime/auth para hacerlos compatibles
+(§4 de AGENTS.md: sacar el logout es auth-adjacent, R2, PR separado). Se retira
+`AdminMobileKebabMenu` del barrel y de `REQUIRED_EXPORTS`, preservando cero
+cambio de runtime, cero migración de consumidores y cero cambio de auth/API.
+
+`AdminMobileKebabMenu` **no es un componente muerto y no pertenece a B02**: es un
+componente vivo con consumidores reales. Es una **exclusión de frontera B01**, no
+una eliminación. El archivo legacy no se toca, sus consumidores siguen
+importándolo por su path actual, y queda admisible automáticamente —sin editar
+el guard— en cuanto `DashboardLogoutControl` y `DashboardNotificationsBell`
+dejen de importar `@/lib/api`.
+
 ## 9. Sidebars muertos — excluidos (dominio B02)
 
 `AdminDashboardSidebar` y `ClinicDashboardSidebar` tienen **cero consumidores
@@ -139,17 +183,50 @@ del plan de pruebas de §56.1. Verifica:
 3. Todo re-export apunta a un target existente bajo `components/dashboard/`.
 4. Cada símbolo declarado está realmente exportado por su target.
 5. Ningún source físico bajo `presentation/**` importa `@/lib/api` ni `@/app`.
-6. Ningún **target legacy re-exportado** importa `@/lib/api` ni `@/app`.
+6. **Nada alcanzable desde los barrels** —a cualquier profundidad— llega a
+   `@/lib/api` ni a `@/app`.
 7. La valla B02: los sidebars no aparecen en `navigation/index.ts`.
 8. Los barrels son módulos de re-export puro, sin declaraciones locales.
 
+**Cierre transitivo (test 6).** El recorrido **arranca en el barrel**, no en la
+lista de targets, y sigue recursivamente cada arista de import/re-export
+*first-party* hasta agotar la clausura. Cubre por tanto los imports propios del
+barrel, cada target sancionado y todo lo que esos targets arrastran a cualquier
+profundidad. Consecuencias: un re-export añadido mañana entra solo al recorrido,
+y **un import local nuevo dentro de un componente ya sancionado también queda
+cubierto automáticamente**. Los specifiers bare (node_modules) no se siguen: la
+frontera gobierna arquitectura first-party.
+
+*Ciclos.* `visited: Set<string>` por recorrido; un ciclo local se absorbe sin
+colgar y sin fallar (control M3).
+
+*Aristas type-only.* Se recorren **todas** las aristas, incluidas las
+`import type`. Es la lectura deliberadamente más estricta: la regla es una
+frontera de dependencia de **arquitectura** sobre el grafo de módulos, y un
+`import type` sigue acoplando presentation a un módulo que posee un import de la
+capa de datos. Se verificó que no fabrica falsos positivos: recorrer con y sin
+aristas type-only produce **veredicto idéntico para los 15 roots actuales**
+(divergencia medida = 0), y los dos ciclos type-only preexistentes de
+`components/dashboard/` son ciclos, no rutas a la capa de datos, así que el
+visited set los absorbe.
+
+*Error accionable.* El fallo imprime la cadena completa, no "forbidden import
+somewhere":
+
+```text
+frontend/src/features/dashboard/presentation/navigation/index.ts
+     -> AdminMobileKebabMenu.tsx
+     -> DashboardNotificationsBell.tsx
+     -> @/lib/api
+```
+
 **Por qué no da falso verde.** Un barrel puede pasar un escaneo ingenuo de
 carpeta mientras re-exporta un componente legacy que sí llega a la capa de
-datos. Por eso el guard no se limita a recorrer `presentation/**`: **parsea los
-barrels, deriva los targets del propio source** y les aplica las mismas reglas.
-La lista de targets se descubre, nunca se declara como allowlist de escape, así
-que un re-export añadido en el futuro queda cubierto automáticamente. Los tests
-de conjunto vacío se protegen con aserciones anti-vacuas.
+datos, directamente o **a través de otro componente local**. Por eso el guard no
+se limita a recorrer `presentation/**` ni a mirar el target inmediato: **parsea
+los barrels, deriva los targets del propio source** y recorre su clausura
+completa. La lista de targets se descubre, nunca se declara como allowlist de
+escape. Los tests de conjunto vacío se protegen con aserciones anti-vacuas.
 
 **Falsos positivos evitados.** Los JSDoc de los 7 barrels contienen literalmente
 el texto `@/lib/api` al documentar la regla. Un `source.includes("@/lib/api")`
@@ -160,19 +237,25 @@ emparejamiento es exacto-o-subpath, de modo que `@/lib/api-error` no se barre po
 accidente. Sin dependencias de parser nuevas.
 
 **Verificación fail-closed.** El guard se validó por mutación sobre una copia
-aislada del árbol (fuera del repo, ningún archivo versionado tocado). Las 6
-mutaciones fueron detectadas y el baseline volvió a 8/8:
+aislada del árbol (fuera del repo, ningún archivo versionado tocado, sandbox
+eliminada al terminar). Los 6 controles del recorrido transitivo se comportaron
+como se exige y el baseline volvió a 8/8:
 
-| Mutación | Resultado |
-|---|---|
-| M1 · shell re-exporta `DashboardTopbar` (llega a `@/lib/api`) | FALLA (correcto) |
-| M2 · navigation re-exporta `AdminDashboardSidebar` | FALLA (correcto) |
-| M3 · shell omite `DashboardHubHeroStatusTone` | FALLA (correcto) |
-| M4 · navigation redeclara un literal de catálogo | FALLA (correcto) |
-| M5 · source de presentation importa `@/lib/api` | FALLA (correcto) |
-| M6 · escape relativo hacia `app/` | FALLA (correcto) |
+| Control | Esperado | Observado |
+|---|---|---|
+| M1 · root → componente local → `@/lib/api` (el falso verde de Codex) | FAIL | **FAIL** 7/1 — cadena `navigation/index.ts → AdminMobileKebabMenu → DashboardNotificationsBell → @/lib/api` |
+| M2 · profundidad 3: root → A → B → `@/lib/api` | FAIL | **FAIL** 7/1 — cadena de 8 saltos, desde `shell/index.ts` |
+| M3 · ciclo local limpio A ↔ B | PASS, sin colgar | **PASS** 8/0 en 168 ms |
+| M4 · escape relativo `../../app/layout` | FAIL | **FAIL** 7/1 |
+| M5 · alias `@/app/layout` | FAIL | **FAIL** 7/1 |
+| M6 · `@/lib/api-error` | PASS, sin falso positivo | **PASS** 8/0 |
+| baseline restaurado | PASS 8/8 | **PASS** 8/0 |
 
-M1 es exactamente el escenario de falso verde que el diseño debía impedir.
+M1 es exactamente el escenario que el diseño anterior no impedía. M2 demuestra
+que el recorrido no se detiene en el primer nivel: la cadena reportada atraviesa
+`shell → PrivateDashboardShell → DashboardShellRouter → AdminMobileBottomNav →
+AdminMobileModuleMenu → MutA → MutB → @/lib/api`. M3 prueba la terminación por
+visited set. M6 prueba el emparejamiento exacto-o-subpath.
 
 ## 11. Cero cambios de runtime
 
@@ -194,11 +277,16 @@ path de render, y los barrels no los importa nadie: ninguna cohorte de §7 aplic
 
 ## 13. Riesgos residuales
 
-1. `DashboardTopbar` sigue violando la frontera. Único hueco real; registrado por
-   el guard de forma auto-expirante. Cierre = PR separado (R2, auth-adjacent).
+1. Tres componentes vivos quedan fuera de la nueva superficie por alcanzar
+   `@/lib/api`: `DashboardTopbar` (directo) y `AdminMobileKebabMenu`
+   (transitivo, vía `DashboardLogoutControl` y `DashboardNotificationsBell`).
+   Los tres huecos comparten causa raíz —el logout/notificaciones acoplados a la
+   capa de datos dentro de `components/dashboard/`— y ninguno está congelado: el
+   guard aplica una regla genérica, nunca afirma que la violación persista.
+   Cierre = PR separado (R2, auth-adjacent).
 2. Los barrels quedan como superficie declarada que todavía nadie importa. Es el
    diseño previsto por §47.2/R14; el valor de B01 es el guard y habilitar B02+.
-3. `export` sobre 11 componentes `"use client"`: sin efecto hoy (nadie importa
+3. `export` sobre 10 componentes `"use client"`: sin efecto hoy (nadie importa
    los barrels), pero cuando un PR posterior migre el primer consumidor deberá
    vigilarse el arrastre del grafo client del barrel. El precedente PR-PRES-5 no
    cubre este caso: `StatusBadge` no es client component.
@@ -214,7 +302,14 @@ residual nulo".
 
 ## 15. Estado final
 
-B01 implementado localmente: 2 barrels poblados, 1 guard ejecutable (8/8), 1
-documento. Cero movimiento de runtime, cero migración de consumidores, cero
-cambios en los 15 componentes legacy. Pendiente de revisión y autorización git
-de Nico. **B02 no iniciado.**
+B01 implementado: 2 barrels poblados (5 + 9 módulos, 26 símbolos), 1 guard
+ejecutable con cierre transitivo (8/8), 1 documento. Cero movimiento de runtime,
+cero migración de consumidores, cero cambios en los componentes legacy, cero
+cambios de auth/API.
+
+Revisión de PR #1658: el hallazgo P2 de Codex sobre el alcance del guard fue
+confirmado y corregido en un commit adicional —recorrido transitivo de la
+clausura de imports y retirada del único root que fallaba
+(`AdminMobileKebabMenu`)—, sin refactorizar ningún componente runtime y sin
+salir de los 4 paths B01. Pendiente de autorización de merge de Nico.
+**B02 no iniciado.**

--- a/frontend/src/features/dashboard/presentation/navigation/index.ts
+++ b/frontend/src/features/dashboard/presentation/navigation/index.ts
@@ -3,7 +3,7 @@
  *
  * Home for the module navigation surfaces: DashboardHorizontalNav,
  * DashboardModuleRail, Admin/ClinicMobileBottomNav, the AdminMobile hub
- * launcher / pager / menus / kebab and the pagers (audit §6). These consume the
+ * launcher / pager / module menu and the pagers (audit §6). These consume the
  * `config` catalog and the `application` navigation helpers rather than
  * re-declaring module literals.
  *
@@ -19,10 +19,17 @@
  * `@/features/dashboard/config` and `@/features/dashboard/application`.
  *
  * Boundary rule: presentation does not reach the data layer. Neither this
- * barrel nor any module it re-exports may import `@/lib/api` or the `app/`
- * layer — enforced by
+ * barrel, nor any module it re-exports, nor anything those modules import at
+ * any depth may reach `@/lib/api` or the `app/` layer — enforced by
  * `test/architecture/dashboard-presentation-import-boundaries.test.ts`, which
- * follows every re-export into its legacy target.
+ * walks the whole first-party import closure, not just the immediate target.
+ *
+ * `AdminMobileKebabMenu` is deliberately absent: it is a live component, but it
+ * composes `DashboardLogoutControl` and `DashboardNotificationsBell`, and both
+ * import `@/lib/api` directly, so re-exporting it would carry the data layer
+ * across the boundary transitively. It is excluded from the barrel, not
+ * removed, not modified and not migrated; it is admitted automatically once
+ * those two imports are gone.
  *
  * `AdminDashboardSidebar` and `ClinicDashboardSidebar` are deliberately absent:
  * they have no runtime consumers and their disposition belongs to B02. B01
@@ -43,7 +50,6 @@ export { AdminMobileBottomNav } from "@/components/dashboard/AdminMobileBottomNa
 export { ClinicMobileBottomNav } from "@/components/dashboard/ClinicMobileBottomNav";
 export { AdminMobileHubLauncher } from "@/components/dashboard/AdminMobileHubLauncher";
 export { AdminMobileHubPager } from "@/components/dashboard/AdminMobileHubPager";
-export { AdminMobileKebabMenu } from "@/components/dashboard/AdminMobileKebabMenu";
 export { AdminMobileModuleMenu } from "@/components/dashboard/AdminMobileModuleMenu";
 export {
   DASHBOARD_INLINE_PAGER_RESERVATION,

--- a/frontend/src/features/dashboard/presentation/navigation/index.ts
+++ b/frontend/src/features/dashboard/presentation/navigation/index.ts
@@ -1,16 +1,58 @@
 /**
- * Dashboard · presentation/navigation (boundary placeholder).
+ * Dashboard · presentation/navigation (B01 re-export boundary).
  *
- * Intended home for module navigation surfaces: DashboardModuleRail,
- * Admin/ClinicMobileBottomNav, DashboardHorizontalNav,
- * Admin/ClinicDashboardSidebar, pagers, AdminMobile menus / hub launcher and
- * the kebab (audit §6). These consume the `config` catalog and the
- * `application` navigation hook rather than re-declaring module literals.
+ * Home for the module navigation surfaces: DashboardHorizontalNav,
+ * DashboardModuleRail, Admin/ClinicMobileBottomNav, the AdminMobile hub
+ * launcher / pager / menus / kebab and the pagers (audit §6). These consume the
+ * `config` catalog and the `application` navigation helpers rather than
+ * re-declaring module literals.
  *
- * Boundary rule: presentation does not import `@/lib/api` directly. Preserve
- * DOM nesting, class names and `data-*` contract attributes when relocating.
+ * B01 populates this barrel with **behaviour-preserving re-exports**: nothing is
+ * moved, reimplemented or renamed, and no consumer is migrated. The
+ * implementations stay pinned at `@/components/dashboard/*`, so DOM nesting,
+ * class names and `data-*` contract attributes are untouched. This is the
+ * sanctioned "reexportar durante la migración" step of audit §47.2 /
+ * mitigation R14.
  *
- * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
- * docs/implementation/dashboard-presentation-boundaries.md).
+ * Ownership rule: this barrel re-exports, it never becomes a new owner. Module
+ * ids, labels, storage keys and navigation tables stay single-owned by
+ * `@/features/dashboard/config` and `@/features/dashboard/application`.
+ *
+ * Boundary rule: presentation does not reach the data layer. Neither this
+ * barrel nor any module it re-exports may import `@/lib/api` or the `app/`
+ * layer — enforced by
+ * `test/architecture/dashboard-presentation-import-boundaries.test.ts`, which
+ * follows every re-export into its legacy target.
+ *
+ * `AdminDashboardSidebar` and `ClinicDashboardSidebar` are deliberately absent:
+ * they have no runtime consumers and their disposition belongs to B02. B01
+ * neither exposes nor removes them.
+ *
+ * @see docs/implementation/dashboard-presentation-shell-navigation-barrels.md
+ * @see docs/implementation/dashboard-presentation-boundaries.md
  */
-export {};
+export {
+  DashboardHorizontalNav,
+  type DashboardNavSurface,
+} from "@/components/dashboard/DashboardHorizontalNav";
+export {
+  CLINIC_MODULE_RAIL_ITEMS,
+  DashboardModuleRail,
+} from "@/components/dashboard/DashboardModuleRail";
+export { AdminMobileBottomNav } from "@/components/dashboard/AdminMobileBottomNav";
+export { ClinicMobileBottomNav } from "@/components/dashboard/ClinicMobileBottomNav";
+export { AdminMobileHubLauncher } from "@/components/dashboard/AdminMobileHubLauncher";
+export { AdminMobileHubPager } from "@/components/dashboard/AdminMobileHubPager";
+export { AdminMobileKebabMenu } from "@/components/dashboard/AdminMobileKebabMenu";
+export { AdminMobileModuleMenu } from "@/components/dashboard/AdminMobileModuleMenu";
+export {
+  DASHBOARD_INLINE_PAGER_RESERVATION,
+  DASHBOARD_PAGER_RESERVATION,
+  DASHBOARD_TOUCH_PAGER_RESERVATION,
+  DashboardPager,
+  type DashboardPagerProps,
+} from "@/components/dashboard/DashboardPager";
+export {
+  CompactPager,
+  type CompactPagerProps,
+} from "@/components/dashboard/CompactPager";

--- a/frontend/src/features/dashboard/presentation/shell/index.ts
+++ b/frontend/src/features/dashboard/presentation/shell/index.ts
@@ -1,15 +1,46 @@
 /**
- * Dashboard · presentation/shell (boundary placeholder).
+ * Dashboard · presentation/shell (B01 re-export boundary).
  *
- * Intended home for the persistent app-shell chrome: PrivateDashboardShell,
- * DashboardShellRouter, DashboardTopbar, DashboardModuleWorkspace,
- * DashboardModuleHub, DashboardHubHero and the module stage (audit §6).
+ * Home for the persistent app-shell chrome: PrivateDashboardShell,
+ * DashboardShellRouter, DashboardModuleWorkspace, DashboardModuleHub and
+ * DashboardHubHero (audit §6).
  *
- * Boundary rule: presentation does not import `@/lib/api` directly; it
- * receives data via props or via `application` hooks. Preserve DOM nesting,
- * class names and `data-*` contract attributes when relocating here.
+ * B01 populates this barrel with **behaviour-preserving re-exports**: nothing is
+ * moved, reimplemented or renamed, and no consumer is migrated. The
+ * implementations stay pinned at `@/components/dashboard/*` because their source
+ * is anchored by source-invariant guardrails, so the rendered DOM, class names
+ * and `data-*` contract attributes are untouched. This is the sanctioned
+ * "reexportar durante la migración" step of audit §47.2 / mitigation R14: the
+ * barrel becomes the declared import surface while both grammars coexist.
  *
- * Empty on purpose: PR-PRES-2 only draws the architecture boundary (see
- * docs/implementation/dashboard-presentation-boundaries.md).
+ * Boundary rule: presentation does not reach the data layer. Neither this
+ * barrel nor any module it re-exports may import `@/lib/api` or the `app/`
+ * layer — enforced by
+ * `test/architecture/dashboard-presentation-import-boundaries.test.ts`, which
+ * follows every re-export into its legacy target instead of only scanning this
+ * folder.
+ *
+ * `DashboardTopbar` is deliberately absent: it still imports `@/lib/api`
+ * directly, so exposing it here would launder that violation through the
+ * boundary. It is admitted automatically once that import is gone; B01 does not
+ * modify it.
+ *
+ * @see docs/implementation/dashboard-presentation-shell-navigation-barrels.md
+ * @see docs/implementation/dashboard-presentation-boundaries.md
  */
-export {};
+export { DashboardShellRouter } from "@/components/dashboard/DashboardShellRouter";
+export {
+  PrivateDashboardShell,
+  type PrivateDashboardShellProps,
+} from "@/components/dashboard/PrivateDashboardShell";
+export { DashboardModuleWorkspace } from "@/components/dashboard/DashboardModuleWorkspace";
+export {
+  DashboardModuleHub,
+  type DashboardModuleCard,
+} from "@/components/dashboard/DashboardModuleHub";
+export {
+  DashboardHubHero,
+  type DashboardHubHeroMetric,
+  type DashboardHubHeroProps,
+  type DashboardHubHeroStatusTone,
+} from "@/components/dashboard/DashboardHubHero";

--- a/frontend/src/features/dashboard/presentation/shell/index.ts
+++ b/frontend/src/features/dashboard/presentation/shell/index.ts
@@ -14,11 +14,11 @@
  * barrel becomes the declared import surface while both grammars coexist.
  *
  * Boundary rule: presentation does not reach the data layer. Neither this
- * barrel nor any module it re-exports may import `@/lib/api` or the `app/`
- * layer — enforced by
+ * barrel, nor any module it re-exports, nor anything those modules import at
+ * any depth may reach `@/lib/api` or the `app/` layer — enforced by
  * `test/architecture/dashboard-presentation-import-boundaries.test.ts`, which
- * follows every re-export into its legacy target instead of only scanning this
- * folder.
+ * walks the whole first-party import closure instead of only scanning this
+ * folder or checking the immediate re-export target.
  *
  * `DashboardTopbar` is deliberately absent: it still imports `@/lib/api`
  * directly, so exposing it here would launder that violation through the

--- a/test/architecture/dashboard-presentation-import-boundaries.test.ts
+++ b/test/architecture/dashboard-presentation-import-boundaries.test.ts
@@ -1,6 +1,6 @@
 import test from "node:test";
 import assert from "node:assert/strict";
-import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { existsSync, readdirSync, readFileSync, statSync } from "node:fs";
 import { dirname, relative, resolve, sep } from "node:path";
 
 // B01 (audit §49 / §54) — dashboard presentation import boundaries.
@@ -19,8 +19,22 @@ import { dirname, relative, resolve, sep } from "node:path";
 // dependency rules to every target it finds. A re-export added by a later PR is
 // checked automatically — the target list is discovered, never hardcoded as an
 // escape hatch.
+//
+// Transitive closure (review fix): checking only the immediate re-export target
+// was not enough. A sanctioned target can reach the data layer *through another
+// local component*, and a target-only check reports the boundary as clean while
+// the export still crosses it — a real false green, observed on
+// `AdminMobileKebabMenu -> DashboardLogoutControl -> @/lib/api`. The traversal
+// below therefore starts at the barrels and follows every local
+// import/re-export edge recursively until the closure is exhausted, so a
+// forbidden dependency is caught at any depth. A local import added tomorrow to
+// an already-sanctioned component is covered automatically.
 
 const SOURCE_ROOT = process.cwd();
+
+const SOURCE_ALIAS_PREFIX = "@/";
+const SOURCE_ALIAS_ROOT = "frontend/src";
+const MODULE_EXTENSIONS = [".ts", ".tsx"] as const;
 
 const PRESENTATION_ROOT = "frontend/src/features/dashboard/presentation";
 const SHELL_BARREL = `${PRESENTATION_ROOT}/shell/index.ts`;
@@ -61,7 +75,6 @@ const NAVIGATION_REQUIRED_EXPORTS: Record<string, readonly string[]> = {
   ClinicMobileBottomNav: ["ClinicMobileBottomNav"],
   AdminMobileHubLauncher: ["AdminMobileHubLauncher"],
   AdminMobileHubPager: ["AdminMobileHubPager"],
-  AdminMobileKebabMenu: ["AdminMobileKebabMenu"],
   AdminMobileModuleMenu: ["AdminMobileModuleMenu"],
   DashboardPager: [
     "DashboardPager",
@@ -205,6 +218,88 @@ function extractReexportTargets(barrelPath: string): string[] {
   return [...new Set(extractModuleSpecifiers(readSource(barrelPath)))];
 }
 
+// Minimal static resolver for the module styles this repo actually uses:
+// the `@/` alias (rooted at frontend/src, per frontend/tsconfig.json paths),
+// relative specifiers, the `.ts`/`.tsx` extensions and directory index modules.
+// Bare specifiers resolve into node_modules and are deliberately NOT followed:
+// the boundary governs first-party architecture, and walking dependencies would
+// be both meaningless here and unbounded. Returns undefined when the specifier
+// is not a resolvable first-party module.
+function resolveLocalModule(
+  specifier: string,
+  fromRelativeFile: string,
+): string | undefined {
+  let base: string;
+
+  if (specifier.startsWith(SOURCE_ALIAS_PREFIX)) {
+    base = `${SOURCE_ALIAS_ROOT}/${specifier.slice(SOURCE_ALIAS_PREFIX.length)}`;
+  } else if (specifier.startsWith(".")) {
+    base = relative(
+      SOURCE_ROOT,
+      resolve(dirname(resolve(SOURCE_ROOT, fromRelativeFile)), specifier),
+    )
+      .split(sep)
+      .join("/");
+  } else {
+    return undefined;
+  }
+
+  const candidates = [
+    base,
+    ...MODULE_EXTENSIONS.map((extension) => `${base}${extension}`),
+    ...MODULE_EXTENSIONS.map((extension) => `${base}/index${extension}`),
+  ];
+
+  return candidates.find((candidate) => {
+    const absolute = resolve(SOURCE_ROOT, candidate);
+    return existsSync(absolute) && statSync(absolute).isFile();
+  });
+}
+
+// Walks the first-party dependency closure of `entryPath` and returns the first
+// chain that reaches a forbidden dependency, or undefined when the closure is
+// clean.
+//
+// Every import/re-export edge is followed, type-only ones included. That is the
+// deliberately stricter reading: the rule is an *architecture* dependency
+// boundary over the module graph, and `import type` still couples presentation
+// to a module that owns a data-layer import. It was verified not to manufacture
+// false positives — traversing with and without type-only edges yields an
+// identical verdict for every current root, and the two pre-existing type-only
+// cycles inside components/dashboard/ are cycles, not data-layer paths, so the
+// visited set absorbs them.
+function findForbiddenChain(entryPath: string): string[] | undefined {
+  const visited = new Set<string>();
+  const stack: { file: string; chain: string[] }[] = [
+    { file: entryPath, chain: [entryPath] },
+  ];
+
+  while (stack.length > 0) {
+    const { file, chain } = stack.pop()!;
+    if (visited.has(file)) continue;
+    visited.add(file);
+
+    for (const specifier of extractModuleSpecifiers(readSource(file))) {
+      const forbidden = matchesForbidden(specifier);
+      if (forbidden) return [...chain, specifier];
+      if (resolvesIntoAppLayer(specifier, file)) return [...chain, specifier];
+
+      const next = resolveLocalModule(specifier, file);
+      if (next && !visited.has(next)) {
+        stack.push({ file: next, chain: [...chain, next] });
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function formatChain(chain: string[]): string {
+  return chain
+    .map((step) => step.replace(`${LEGACY_COMPONENT_ROOT}/`, ""))
+    .join("\n     -> ");
+}
+
 function legacyTargetPath(moduleName: string): string {
   return `${LEGACY_COMPONENT_ROOT}/${moduleName}.tsx`;
 }
@@ -313,23 +408,26 @@ test("B01 no presentation source imports the data layer or the app layer", () =>
   }
 });
 
-test("B01 no module re-exported through the presentation barrels reaches the data layer", () => {
-  const targets = new Set<string>();
-
+test("B01 nothing reachable from the presentation barrels reaches the data layer", () => {
   for (const barrel of [SHELL_BARREL, NAVIGATION_BARREL]) {
-    for (const specifier of extractReexportTargets(barrel)) {
-      if (!specifier.startsWith(LEGACY_ALIAS_PREFIX)) continue;
-      targets.add(legacyTargetPath(specifier.slice(LEGACY_ALIAS_PREFIX.length)));
-    }
-  }
+    const targets = extractReexportTargets(barrel);
 
-  assert.ok(
-    targets.size > 0,
-    "the presentation barrels must expose re-export targets; an empty set would pass vacuously",
-  );
+    assert.ok(
+      targets.length > 0,
+      `${barrel} must expose re-export targets; an empty closure would pass vacuously`,
+    );
 
-  for (const target of targets) {
-    assertNoForbiddenDependency(target, "sanctioned re-export target");
+    // Starting at the barrel itself, not at the target list, means the closure
+    // covers the barrel's own imports, every sanctioned target, and everything
+    // those targets pull in at any depth.
+    const chain = findForbiddenChain(barrel);
+    assert.equal(
+      chain,
+      undefined,
+      chain === undefined
+        ? ""
+        : `${barrel} reaches a forbidden dependency through its local import closure:\n     ${formatChain(chain)}\n   The dashboard presentation boundary forbids ${FORBIDDEN_DEPENDENCIES.join(" and ")}. Remove the re-export from the barrel, or remove the forbidden import from the chain.`,
+    );
   }
 });
 

--- a/test/architecture/dashboard-presentation-import-boundaries.test.ts
+++ b/test/architecture/dashboard-presentation-import-boundaries.test.ts
@@ -1,0 +1,379 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, relative, resolve, sep } from "node:path";
+
+// B01 (audit §49 / §54) — dashboard presentation import boundaries.
+//
+// B01 populates `presentation/shell` and `presentation/navigation` with
+// behaviour-preserving re-exports of the legacy `components/dashboard/*`
+// implementations. Nothing is moved and no consumer is migrated, so the only
+// thing that can regress is the *architecture*: this guard is the executable
+// form of the acceptance criterion "sin imports cruzados" (§54) and of the
+// architecture test plan of §56.1.
+//
+// Fail-closed design: a barrel could satisfy a naive folder scan while
+// re-exporting a legacy component that itself reaches the data layer. So the
+// guard does not only walk `presentation/**` physically; it parses the barrels,
+// derives the re-export targets from the source, and applies the same forbidden
+// dependency rules to every target it finds. A re-export added by a later PR is
+// checked automatically — the target list is discovered, never hardcoded as an
+// escape hatch.
+
+const SOURCE_ROOT = process.cwd();
+
+const PRESENTATION_ROOT = "frontend/src/features/dashboard/presentation";
+const SHELL_BARREL = `${PRESENTATION_ROOT}/shell/index.ts`;
+const NAVIGATION_BARREL = `${PRESENTATION_ROOT}/navigation/index.ts`;
+const LEGACY_COMPONENT_ROOT = "frontend/src/components/dashboard";
+const LEGACY_ALIAS_PREFIX = "@/components/dashboard/";
+const APP_LAYER_ROOT = "frontend/src/app";
+
+// Module specifiers presentation must never reach — directly, or through any
+// module it re-exports. `@/lib/api` is the data layer; `@/app` is the Next.js
+// app layer. Matching is exact-or-subpath, so sibling helpers such as
+// `@/lib/api-error` are not swept in by accident.
+const FORBIDDEN_DEPENDENCIES = ["@/lib/api", "@/app"] as const;
+
+// REQUIRED_EXPORTS — the B01 contract, keyed by legacy target module.
+// Semantics are "at least these": a later PR may add exports without editing
+// this guard, but may not silently drop one.
+const SHELL_REQUIRED_EXPORTS: Record<string, readonly string[]> = {
+  DashboardShellRouter: ["DashboardShellRouter"],
+  PrivateDashboardShell: [
+    "PrivateDashboardShell",
+    "PrivateDashboardShellProps",
+  ],
+  DashboardModuleWorkspace: ["DashboardModuleWorkspace"],
+  DashboardModuleHub: ["DashboardModuleHub", "DashboardModuleCard"],
+  DashboardHubHero: [
+    "DashboardHubHero",
+    "DashboardHubHeroMetric",
+    "DashboardHubHeroProps",
+    "DashboardHubHeroStatusTone",
+  ],
+};
+
+const NAVIGATION_REQUIRED_EXPORTS: Record<string, readonly string[]> = {
+  DashboardHorizontalNav: ["DashboardHorizontalNav", "DashboardNavSurface"],
+  DashboardModuleRail: ["DashboardModuleRail", "CLINIC_MODULE_RAIL_ITEMS"],
+  AdminMobileBottomNav: ["AdminMobileBottomNav"],
+  ClinicMobileBottomNav: ["ClinicMobileBottomNav"],
+  AdminMobileHubLauncher: ["AdminMobileHubLauncher"],
+  AdminMobileHubPager: ["AdminMobileHubPager"],
+  AdminMobileKebabMenu: ["AdminMobileKebabMenu"],
+  AdminMobileModuleMenu: ["AdminMobileModuleMenu"],
+  DashboardPager: [
+    "DashboardPager",
+    "DashboardPagerProps",
+    "DASHBOARD_PAGER_RESERVATION",
+    "DASHBOARD_TOUCH_PAGER_RESERVATION",
+    "DASHBOARD_INLINE_PAGER_RESERVATION",
+  ],
+  CompactPager: ["CompactPager", "CompactPagerProps"],
+};
+
+// FORBIDDEN_EXPORTS — a scope fence, not a permanent verdict. These components
+// have no runtime consumers and their disposition belongs to B02. B01 must not
+// hand them a public import surface it would immediately have to withdraw.
+//
+// `DashboardTopbar` is intentionally NOT listed here. Its exclusion is a
+// *consequence* of the forbidden-dependency rule below (it imports `@/lib/api`),
+// not a frozen fact: this guard never asserts that the violation persists, so
+// removing that import in a later PR makes the component admissible with no
+// change to this file.
+const NAVIGATION_FORBIDDEN_EXPORTS = [
+  "AdminDashboardSidebar",
+  "ClinicDashboardSidebar",
+] as const;
+
+function readSource(relativePath: string): string {
+  const absolute = resolve(SOURCE_ROOT, relativePath);
+  assert.ok(existsSync(absolute), `source not found: ${relativePath}`);
+  return readFileSync(absolute, "utf8").replace(/\r\n/g, "\n");
+}
+
+function listFilesRecursive(relativeDir: string): string[] {
+  const rootDir = resolve(SOURCE_ROOT, relativeDir);
+  if (!existsSync(rootDir)) {
+    return [];
+  }
+
+  const files: string[] = [];
+  const walk = (absoluteDir: string): void => {
+    for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+      const absolute = resolve(absoluteDir, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolute);
+      } else if (entry.isFile()) {
+        files.push(relative(SOURCE_ROOT, absolute).split(sep).join("/"));
+      }
+    }
+  };
+
+  walk(rootDir);
+  return files;
+}
+
+// Module specifiers are read from real import/export declarations only.
+//
+// This matters: the presentation barrels document the boundary in prose and
+// literally contain the text `@/lib/api` inside their JSDoc. A substring scan
+// over the whole file would flag every barrel in the tree. The static patterns
+// below are anchored to the start of a line, which a JSDoc continuation line
+// (" * ...") can never satisfy, and the dynamic pattern requires a call
+// expression.
+function extractModuleSpecifiers(source: string): string[] {
+  const specifiers: string[] = [];
+
+  // import ... from "spec";  /  export ... from "spec";  (single or multi-line)
+  for (const match of source.matchAll(
+    /^[ \t]*(?:import|export)\b[^;]*?\bfrom\s*["']([^"']+)["']/gm,
+  )) {
+    specifiers.push(match[1]);
+  }
+
+  // side-effect import "spec";
+  for (const match of source.matchAll(/^[ \t]*import\s*["']([^"']+)["']/gm)) {
+    specifiers.push(match[1]);
+  }
+
+  // dynamic import("spec") / require("spec")
+  for (const match of source.matchAll(
+    /\b(?:import|require)\s*\(\s*["']([^"']+)["']\s*\)/g,
+  )) {
+    specifiers.push(match[1]);
+  }
+
+  return specifiers;
+}
+
+function matchesForbidden(specifier: string): string | undefined {
+  return FORBIDDEN_DEPENDENCIES.find(
+    (dependency) =>
+      specifier === dependency || specifier.startsWith(`${dependency}/`),
+  );
+}
+
+// Relative specifiers are resolved too, so a hand-rolled "../../../app/..."
+// escape hatch is caught as well as the aliased "@/app" form.
+function resolvesIntoAppLayer(
+  specifier: string,
+  fromRelativeFile: string,
+): boolean {
+  if (!specifier.startsWith(".")) {
+    return false;
+  }
+
+  const resolved = relative(
+    SOURCE_ROOT,
+    resolve(dirname(resolve(SOURCE_ROOT, fromRelativeFile)), specifier),
+  )
+    .split(sep)
+    .join("/");
+
+  return (
+    resolved === APP_LAYER_ROOT || resolved.startsWith(`${APP_LAYER_ROOT}/`)
+  );
+}
+
+function assertNoForbiddenDependency(
+  relativePath: string,
+  reason: string,
+): void {
+  const source = readSource(relativePath);
+
+  for (const specifier of extractModuleSpecifiers(source)) {
+    const forbidden = matchesForbidden(specifier);
+    assert.equal(
+      forbidden,
+      undefined,
+      `${relativePath} (${reason}) must not import "${specifier}": the dashboard presentation boundary forbids "${forbidden}"`,
+    );
+    assert.equal(
+      resolvesIntoAppLayer(specifier, relativePath),
+      false,
+      `${relativePath} (${reason}) must not import "${specifier}": it resolves into the ${APP_LAYER_ROOT} layer`,
+    );
+  }
+}
+
+// Re-export targets are DISCOVERED from the barrel source, never assumed.
+// Everything a barrel exposes is subject to the dependency rules, including
+// exports added by a future PR.
+function extractReexportTargets(barrelPath: string): string[] {
+  return [...new Set(extractModuleSpecifiers(readSource(barrelPath)))];
+}
+
+function legacyTargetPath(moduleName: string): string {
+  return `${LEGACY_COMPONENT_ROOT}/${moduleName}.tsx`;
+}
+
+function assertBarrelExports(
+  barrelPath: string,
+  requiredExports: Record<string, readonly string[]>,
+): void {
+  const source = readSource(barrelPath);
+
+  for (const [moduleName, symbols] of Object.entries(requiredExports)) {
+    const specifier = `${LEGACY_ALIAS_PREFIX}${moduleName}`;
+    assert.ok(
+      source.includes(`from "${specifier}";`),
+      `${barrelPath} must re-export from ${specifier}`,
+    );
+
+    for (const symbol of symbols) {
+      const pattern = new RegExp(
+        `(?:^|[\\s{,])(?:type\\s+)?${symbol}\\s*[,}]`,
+        "m",
+      );
+      assert.ok(
+        pattern.test(source),
+        `${barrelPath} must re-export the symbol "${symbol}" from ${specifier}`,
+      );
+    }
+  }
+}
+
+// -- 1 - Barrels expose the declared B01 contract ---------------------------
+
+test("B01 presentation/shell re-exports the declared app-shell chrome", () => {
+  assertBarrelExports(SHELL_BARREL, SHELL_REQUIRED_EXPORTS);
+});
+
+test("B01 presentation/navigation re-exports the declared navigation surfaces", () => {
+  assertBarrelExports(NAVIGATION_BARREL, NAVIGATION_REQUIRED_EXPORTS);
+});
+
+// -- 2 - Every re-export target exists and really exports the symbol --------
+
+test("B01 every re-export target module exists at its pinned legacy path", () => {
+  for (const barrel of [SHELL_BARREL, NAVIGATION_BARREL]) {
+    const targets = extractReexportTargets(barrel);
+
+    assert.ok(
+      targets.length > 0,
+      `${barrel} must expose re-export targets; an empty barrel would pass vacuously`,
+    );
+
+    for (const specifier of targets) {
+      assert.ok(
+        specifier.startsWith(LEGACY_ALIAS_PREFIX),
+        `${barrel} may only re-export from ${LEGACY_COMPONENT_ROOT}; found "${specifier}"`,
+      );
+
+      const moduleName = specifier.slice(LEGACY_ALIAS_PREFIX.length);
+      assert.ok(
+        existsSync(resolve(SOURCE_ROOT, legacyTargetPath(moduleName))),
+        `${barrel} re-exports "${specifier}" but ${legacyTargetPath(moduleName)} does not exist`,
+      );
+    }
+  }
+});
+
+test("B01 every declared symbol is really exported by its legacy target", () => {
+  const contracts = [
+    [SHELL_BARREL, SHELL_REQUIRED_EXPORTS] as const,
+    [NAVIGATION_BARREL, NAVIGATION_REQUIRED_EXPORTS] as const,
+  ];
+
+  for (const [barrel, requiredExports] of contracts) {
+    for (const [moduleName, symbols] of Object.entries(requiredExports)) {
+      const targetPath = legacyTargetPath(moduleName);
+      const target = readSource(targetPath);
+
+      for (const symbol of symbols) {
+        const pattern = new RegExp(
+          `^export\\s+(?:function|const|let|class|type|interface)\\s+${symbol}\\b`,
+          "m",
+        );
+        assert.ok(
+          pattern.test(target),
+          `${barrel} declares "${symbol}" but ${targetPath} does not export it`,
+        );
+      }
+    }
+  }
+});
+
+// -- 3 - Forbidden dependencies: physical sources AND re-export targets -----
+
+test("B01 no presentation source imports the data layer or the app layer", () => {
+  const sources = listFilesRecursive(PRESENTATION_ROOT).filter((file) =>
+    /\.(ts|tsx)$/.test(file),
+  );
+
+  assert.ok(
+    sources.length > 0,
+    `${PRESENTATION_ROOT} must contain sources; an empty scan would pass vacuously`,
+  );
+
+  for (const file of sources) {
+    assertNoForbiddenDependency(file, "presentation source");
+  }
+});
+
+test("B01 no module re-exported through the presentation barrels reaches the data layer", () => {
+  const targets = new Set<string>();
+
+  for (const barrel of [SHELL_BARREL, NAVIGATION_BARREL]) {
+    for (const specifier of extractReexportTargets(barrel)) {
+      if (!specifier.startsWith(LEGACY_ALIAS_PREFIX)) continue;
+      targets.add(legacyTargetPath(specifier.slice(LEGACY_ALIAS_PREFIX.length)));
+    }
+  }
+
+  assert.ok(
+    targets.size > 0,
+    "the presentation barrels must expose re-export targets; an empty set would pass vacuously",
+  );
+
+  for (const target of targets) {
+    assertNoForbiddenDependency(target, "sanctioned re-export target");
+  }
+});
+
+// -- 4 - Scope fences -------------------------------------------------------
+
+test("B01 navigation barrel does not expose the B02 sidebar components", () => {
+  const source = readSource(NAVIGATION_BARREL);
+
+  for (const forbidden of NAVIGATION_FORBIDDEN_EXPORTS) {
+    const pattern = new RegExp(
+      `^export\\b[^;]*?\\b${forbidden}\\b[^;]*?from\\s*["']`,
+      "m",
+    );
+    assert.equal(
+      pattern.test(source),
+      false,
+      `${NAVIGATION_BARREL} must not re-export "${forbidden}": it has no runtime consumer and its disposition belongs to B02`,
+    );
+  }
+});
+
+// -- 5 - The barrels re-export; they never become owners --------------------
+
+test("B01 presentation barrels are pure re-export modules with no local declarations", () => {
+  for (const barrel of [SHELL_BARREL, NAVIGATION_BARREL]) {
+    const withoutComments = readSource(barrel)
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^[ \t]*\/\/.*$/gm, "");
+
+    // Remove every well-formed `export ... from "..."` statement. Whatever is
+    // left is, by definition, the barrel owning something it should not: module
+    // ids, labels, storage keys and navigation tables stay single-owned by
+    // @/features/dashboard/config and @/features/dashboard/application.
+    const residue = withoutComments
+      .replace(
+        /export\s*(?:\*(?:\s+as\s+[A-Za-z_$][\w$]*)?|\{[^}]*\})\s*from\s*["'][^"']+["']\s*;/g,
+        "",
+      )
+      .trim();
+
+    assert.equal(
+      residue,
+      "",
+      `${barrel} must only re-export; found a non re-export statement: ${residue.slice(0, 200)}`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Change type: refactor (import architecture, behaviour-preserving)
- Context / issue: Programa B - **B01** - Nivel 2, audit 47.2, 49, 54, 56.1, 59-62. Depends on A07 (`7ef58c1`, #1653); gate G3 satisfied.
- What changed:
  - Populates `frontend/src/features/dashboard/presentation/shell/index.ts` (previously `export {};`) with 5 legacy modules / 10 symbols.
  - Populates `frontend/src/features/dashboard/presentation/navigation/index.ts` (previously `export {};`) with 10 legacy modules / 17 symbols.
  - Adds `test/architecture/dashboard-presentation-import-boundaries.test.ts`, a fail-closed architecture guard (8 tests) that makes the presentation import boundary executable instead of JSDoc prose.
  - Adds the implementation document.

All exports are **behaviour-preserving re-exports** pinned at `@/components/dashboard/*`. Nothing is moved, renamed or reimplemented, and **no consumer is migrated**. This is the sanctioned "reexportar durante la migracion" step of 47.2 / mitigation R14, where both grammars coexist. Zero runtime movement: the barrels currently have zero importers (verified repo-wide), so DOM, CSS, geometry, zero-scroll, routing and navigation behaviour are bit-for-bit unchanged.

The guard is fail-closed by design: it parses the barrels, **derives** the re-export targets from source, and applies the forbidden-dependency rules (`@/lib/api`, `@/app`, including relative escapes) to every target it discovers. A naive folder scan would pass while a barrel launders a legacy component that reaches the data layer; that exact false-green scenario is mutation-tested (M1). Anti-vacuous assertions guard every set-based test. No hardcoded allowlist escape hatch, no new parser dependency.

Deliberate exclusions, both auto-expiring rather than frozen:
- **`DashboardTopbar`** still imports `@/lib/api` directly. It is excluded as a *consequence* of the generic rule, never asserted as a permanent fact; removing that import in a later PR admits it with no guard edit. Extracting logout is auth-adjacent (R2) and belongs in a separate PR. Not modified here.
- **`AdminDashboardSidebar` / `ClinicDashboardSidebar`** have zero runtime consumers; their disposition belongs to **B02**. Fenced by an explicit `FORBIDDEN_EXPORTS` documented as a scope fence. Neither exposed nor removed here.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [x] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

The changed paths classify as `frontend` (2 files), `tests` (1) and `documentation` (1). `tests` and `documentation` are SUPPORTING_CATEGORIES, so `derivePrimaryCategories` returns exactly `["frontend"]`. The architecture test is supporting architecture validation for the frontend change, and the document is supporting implementation documentation for the same change; neither is an independent primary scope. No mixed-scope exception is claimed or needed: one primary scope, one cause, one rollback.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference: Not applicable.
- Justification: The Architecture Decision gate does not trigger for this diff. It fires on `drizzle/`, `.github/workflows/` and `server/` paths, and this PR touches none of them. Substantively, B01 does not introduce a platform decision: it implements the presentation-layer boundary already approved and documented in the dashboard audit roadmap (47.2 sanctions re-exporting during migration; 49 schedules B01; 54 sets "sin imports cruzados" as the closure criterion) and previously drawn structurally by PR-PRES-2 in `docs/implementation/dashboard-presentation-boundaries.md`. It alters no architectural boundary, no data model, no composition and no governed workflow behaviour; it makes an already-decided boundary executable. The re-export pattern itself follows the precedent landed in PR-PRES-5.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [x] `pnpm --dir frontend lint` (if frontend affected)
- [x] `pnpm --dir frontend typecheck` (if frontend affected)
- [x] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Locally observed results (exit code 0 each), on base `8769f68`:

| Gate | State |
|---|---|
| Targeted B01 guard (`dashboard-presentation-import-boundaries`) | **PASSED** 8/8 |
| `test/unit/infrastructure/workflow-security-policy-contract` (base sanity after #1657) | **PASSED** 8/8 |
| `pnpm validate:local` (`typecheck` + `typecheck:test` + `test` + `build`) | **PASSED** 4219 pass / 0 fail / 1 skipped |
| `pnpm --dir frontend lint` | **PASSED** |
| `pnpm --dir frontend typecheck` | **PASSED** |
| `pnpm --dir frontend build` | **PASSED** |
| `pnpm security:public-surface` | **PASSED** |
| `git diff --check` | **PASSED** |
| `pnpm audit --prod` / `pnpm audit` | **NOT_RUN**, no dependency, manifest or lockfile change |
| Playwright (any cohort) | **NOT_RUN, justified** |

Playwright justification: B01 changes no consumer, no JSX, no DOM, no CSS, no geometry, no runtime navigation and no API; the barrels have zero importers, so no rendered surface can differ. No cohort in AGENTS.md 7 maps to this diff. `frontend/next-env.d.ts` verified unmodified; no `playwright-report/` or `test-results/` artefacts exist.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

Zero change to auth, cookies, sessions, roles, permissions, CSRF, rate limits, CSP, API, endpoints, query strings, handlers, DB or secrets. The `admin_session_id` and `app_session_id` boundaries are untouched: no file under `server/`, `shared/`, `frontend/src/app/`, `@/lib/api*` or `@/lib/auth*` is in the diff. The only occurrences of `@/lib/api` in the diff are JSDoc prose documenting the prohibition. No `data-*` attribute is introduced. `pnpm security:public-surface` PASSED. Migration/schema impact: not applicable, no `drizzle/` or schema path is touched.

## Rollback
- Trigger: any regression attributed to the presentation barrels or to the new architecture guard.
- Steps: single `git revert` of the B01 commit. Restores both barrels to `export {};` and removes the guard and the document. No follow-up, no sequencing, no migration to unwind. Matches audit 61: "B01-B02 - Revert restaura los barriles - riesgo residual nulo".
- Data impact: none. No schema, no migration, no persisted state, no runtime behaviour to undo.

## Out of scope (deliberate)
B02+, `DashboardTopbar` refactor, logout/auth extraction, dead component removal, `DashboardHorizontalNav` removal, `DashboardModuleRail` removal, WorkspaceAppBar, NavigationDrawer, NavigationRail, tokens, CSS, backend, DB, CI/workflows, dependencies, PWA, staging, production. Pre-existing type-only cycles inside `components/dashboard/` are neither aggravated nor corrected: every re-export points at a concrete file and never at another barrel, so B01 adds no edge to the graph.
