### PR TITLE
feat(dashboard): establish B03 foundation tokens

### DIFF
--- a/docs/implementation/dashboard-b03-foundation-tokens.md
+++ b/docs/implementation/dashboard-b03-foundation-tokens.md
@@ -1,0 +1,293 @@
+# B03 — Dashboard foundation tokens
+
+**Base:** `5711145ab894f1756494e6c1a4b9dff41e923322` (`refactor(dashboard): retire B02 dead components (#1659)`)
+**Rama:** `feat/dashboard-b03-foundation-tokens`
+**Programa B, nivel 3.** Dependencia formal: B01 (cerrado). B02 cerrado.
+**Roadmap:** `docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md` §49, §54, §58 (G5), §59–§60 (R9), §61.
+
+## 1. Objetivo
+
+Completar el foundation de tokens del dashboard en
+`frontend/src/styles/dashboard/tokens.css` con ocho escalas explícitas — color,
+shape, elevation, state-layer, spacing, density, typography, motion — en tema
+claro y oscuro, y añadir un contrato ejecutable fail-closed que demuestre
+completitud y coherencia.
+
+**B03 define el foundation. B04 migra las superficies.** Esa separación es el
+criterio de cierre, no una preferencia de estilo: en cuanto una superficie
+consume un token, la definición y la migración quedan en un único diff
+indistinguible en revisión. Por eso el contrato exige **cero consumidores**.
+
+Después de B03 el dashboard vivo se ve exactamente igual.
+
+## 2. Punto de partida medido
+
+- `tokens.css` **no** era ya el placeholder de 514 B del audit original: contenía
+  el contrato `dashboard-row-pitch-contract` (A05–A07), 136 líneas, que la
+  capacity engine lee en runtime como literales px parseables.
+- El árbol `frontend/src/styles/dashboard/**` contenía **0** reglas `data-theme`.
+  El dashboard heredaba el tema exclusivamente de los flips de `globals.css`.
+  Esto es exactamente R9 («tema oscuro sin cubrir») verificado, no supuesto.
+- Namespace `--dash-*` ya poblado: 43 declaraciones en `responsive.css`,
+  28 en `tokens.css` (pitch), 19 en `surfaces.css` (accents), 13 en
+  `zero-scroll.css`. Todas estructurales o de runtime; ninguna de foundation.
+
+## 3. Mecanismo de tema real (no se introduce uno nuevo)
+
+| Pieza | Hecho verificado |
+|---|---|
+| `frontend/src/lib/theme.ts` | `DARK_GRAY_THEME_MODE = "dark-gray"`; `document.documentElement.dataset.theme = theme` |
+| `frontend/public/theme-init.js` | Mismo atributo, pre-paint, desde `vetneb-theme-mode` |
+| `frontend/src/app/globals.css` | Owner de la paleta oscura bajo `:root[data-theme="dark-gray"]` |
+
+B03 usa **ese** selector, derivado en el contrato desde `theme.ts` en vez de
+hardcodeado. No se introduce `.dark`, `[data-color-scheme]`,
+`data-dashboard-theme` ni `prefers-color-scheme` como owner.
+
+```css
+.dashboard-app-shell { /* light + invariantes */ }
+:root[data-theme="dark-gray"] .dashboard-app-shell { /* solo THEME_VARIANT */ }
+```
+
+## 4. Clasificación por tema
+
+El requisito era que el contrato falle si un token temático existe en claro pero
+no en oscuro. La lectura literal —restar cada token bajo el selector oscuro—
+produce una escala que *parece* cubierta y en realidad añade un segundo sitio
+donde divergir: la mayoría de los roles resuelven a través de tokens globales
+que `globals.css` **ya** re-escribe en oscuro, así que su duplicado sería
+textualmente idéntico y, por tanto, CSS muerto.
+
+Se adoptan tres clases explícitas, y el contrato prueba cada una:
+
+| Clase | Declaraciones | Cómo se prueba el valor oscuro | N |
+|---|---|---|---|
+| `THEME_INVARIANT` | 1 | Debe **no** aparecer en el scope oscuro **y** no referenciar ningún token que el tema oscuro reescriba (si lo hiciera, estaría mal clasificado) | 47 |
+| `THEME_ADAPTIVE` | 1 | Se **resuelve la referencia**: cada token global citado debe estar realmente redefinido bajo `:root[data-theme="dark-gray"]` en `globals.css` | 18 |
+| `THEME_VARIANT` | 2 (claro + oscuro) | Ambas deben existir **y sus valores deben diferir** | 8 |
+
+`THEME_ADAPTIVE` es una desviación deliberada respecto de la instrucción literal
+(«un token temático en light sin dark → FAIL») y se reporta como tal. Es más
+fuerte, no más débil: detecta el fallo real de R9 —un rol del dashboard sin
+valor oscuro definido— en lugar de contar líneas. Si `globals.css` dejara de
+reescribir `--card`, la duplicación textual seguiría en verde mientras el
+dashboard pierde su superficie oscura; esta comprobación falla.
+
+**Dark completeness: PASS.** 8 VARIANT con valores distintos + 18 ADAPTIVE con
+referencia resuelta + 47 INVARIANT justificados = 73 tokens, ninguno con tema
+indefinido.
+
+## 5. Las ocho escalas
+
+Namespace `--dash-<categoría>-<rol>`. Los diez prefijos usados
+(`--dash-color-`, `-shape-`, `-elevation-`, `-state-`, `-space-`, `-density-`,
+`-text-`, `-motion-`) se verificaron libres de colisión en `frontend/src`,
+`test/` y `docs/` antes de crearse.
+
+### 5.1 Color — 18 (15 ADAPTIVE, 3 VARIANT)
+
+| Token | Claro | Oscuro | Provenance |
+|---|---|---|---|
+| `--dash-color-canvas` | `hsl(var(--vetneb-surface))` | ADAPTIVE | 198 34% 96% → 210 8% 12% |
+| `--dash-color-surface` | `hsl(var(--card))` | ADAPTIVE | 190 33% 98% → 210 9% 16% |
+| `--dash-color-surface-raised` | `hsl(var(--vetneb-surface-raised))` | ADAPTIVE | flip global |
+| `--dash-color-surface-muted` | `hsl(var(--vetneb-surface-muted))` | ADAPTIVE | flip global |
+| `--dash-color-on-surface` | `hsl(var(--foreground))` | ADAPTIVE | flip global |
+| `--dash-color-on-surface-muted` | `hsl(var(--muted-foreground))` | ADAPTIVE | flip global |
+| `--dash-color-outline` | `hsl(var(--vetneb-line))` | ADAPTIVE | flip global |
+| `--dash-color-outline-subtle` | `hsl(var(--vetneb-line) / 0.42)` | ADAPTIVE | alpha 0.42 medida 3× en este árbol |
+| `--dash-color-primary` | `hsl(var(--primary))` | ADAPTIVE | flip global |
+| `--dash-color-on-primary` | `hsl(var(--primary-foreground))` | ADAPTIVE | flip global |
+| `--dash-color-accent` | `hsl(var(--vetneb-teal))` | ADAPTIVE | flip global |
+| `--dash-color-success` | `hsl(var(--vetneb-teal))` | ADAPTIVE | teal = positivo clínico |
+| `--dash-color-error` | `hsl(var(--destructive))` | ADAPTIVE | flip global |
+| `--dash-color-info` | `hsl(var(--vetneb-cyan))` | ADAPTIVE | flip global |
+| `--dash-color-focus-ring` | `var(--clinical-focus-ring)` | ADAPTIVE | PR-VIS-3, redefinido en oscuro |
+| `--dash-color-field` | `hsl(var(--vetneb-surface-muted) / 0.72)` | `… / 0.92` | ambas alphas son literales medidos aquí; objetivo B05 |
+| `--dash-color-warning` | `hsl(var(--vetneb-amber))` | `hsl(38 88% 64%)` | el valor oscuro es **verbatim** el override que `globals.css` ya aplica al ámbar en oscuro |
+| `--dash-color-overlay-scrim` | `hsl(var(--vetneb-ink) / 0.32)` | `hsl(210 15% 4% / 0.62)` | `--vetneb-ink` pasa de 15% a 90% de luminosidad: heredarlo pintaría un scrim **blanco** |
+
+`--dash-color-warning` y `--dash-color-overlay-scrim` son los dos casos donde
+heredar la paleta volteada da la respuesta *incorrecta* o *insuficiente*. Son la
+justificación material de la clase VARIANT.
+
+### 5.2 Shape — 8, INVARIANT
+
+`none: 0` · `xs: 0.45rem` · `sm: 0.5rem` · `md: 0.6rem` · `lg: 0.75rem` ·
+`xl: 0.85rem` · `2xl: 1.1rem` · `full: 9999px`
+
+Monotónica y derivada del censo real de `border-radius` del árbol dashboard
+(0.5rem es el literal más repetido y coincide con `--radius`; 0.6/0.75/0.85 son
+los siguientes clusters; 0.45 y 1.1 los extremos observados). `--radius` global
+no se toca.
+
+### 5.3 Elevation — 4 (1 INVARIANT, 3 ADAPTIVE)
+
+`none: none` · `raised: var(--clinical-shadow-sm)` ·
+`menu: var(--clinical-shadow-md)` · `dialog: var(--clinical-shadow-lg)`
+
+`--dash-elevation-none` existe para que B04 pueda afirmar la planitud del chrome
+persistente de forma positiva: «sin propiedad `box-shadow`» y «elevation: none»
+son afirmaciones distintas en revisión. Los tres niveles elevados son ADAPTIVE
+porque `globals.css` ya re-escribe esas sombras en oscuro (alpha 0.055→0.20,
+0.08→0.28, 0.10→0.34). **No se convierte ninguna sombra existente: eso es B04.**
+
+### 5.4 State-layer — 6 (5 VARIANT, 1 INVARIANT)
+
+| Token | Claro | Oscuro |
+|---|---|---|
+| `--dash-state-hover-opacity` | 0.06 | 0.10 |
+| `--dash-state-pressed-opacity` | 0.10 | 0.16 |
+| `--dash-state-selected-opacity` | 0.13 | 0.20 |
+| `--dash-state-focus-opacity` | 0.16 | 0.24 |
+| `--dash-state-layer-color` | `hsl(var(--vetneb-navy))` | `hsl(var(--vetneb-ink))` |
+| `--dash-state-disabled-opacity` | 0.45 | INVARIANT |
+
+Anclas claras medidas en el repo (wash navy 0.06; selección teal 0.13/0.16);
+los valores oscuros son una derivación documentada ×1.6, conservadora frente al
+×3.0–×3.6 que la paleta oscura ya aplica a sus propias sombras. `layer-color`
+expresa la inversión de dirección —oscurecer con tinte de marca en claro,
+aclarar en neutro en oscuro— que ningún token heredado puede expresar solo.
+`disabled` es INVARIANT porque atenúa el elemento, no pinta una capa: 0.45
+verbatim de `.dashboard-disabled-state`.
+
+### 5.5 Spacing — 7, INVARIANT
+
+`0` · `0.25rem` · `0.5rem` · `0.75rem` · `1rem` · `1.5rem` · `2rem`
+
+Ritmo 8 px con micro-paso de 4 px y el secundario de 12 px que midió la
+auditoría, acotado por los techos de clamp ya presentes en `responsive.css`.
+
+### 5.6 Density — 6, INVARIANT — y la frontera con el capacity contract
+
+`control-compact: 1.9rem` · `control-regular: 2.25rem` ·
+`control-comfortable: 2.5rem` · `inset-compact|regular|comfortable` →
+`--dash-space-1|2|3`
+
+**La altura de fila NO está aquí.** `--dash-row-pitch*` en el contrato de
+row-pitch es el único owner de cuán alta es una fila, y la capacity engine lee
+esos tokens en runtime. Un token de altura de fila en density sería un owner
+competidor aunque nada lo consumiera todavía. Density describe **chrome**:
+controles y sus insets. Límites medidos en `responsive.css` (`--dash-tab-h`
+recorre 1.9–2.25rem; `--dash-control-h` techo 2.5rem). El contrato asegura la
+separación por nombre.
+
+### 5.7 Typography — 19, INVARIANT
+
+Roles `label`, `body`, `body-strong`, `section`, `title`, `metric` sobre
+`--dash-text-family: var(--font-ui)` (Inter existente, **referenciado, nunca
+redeclarado**; sin `@font-face` nuevo, sin fuente nueva). Tamaños, pesos,
+leadings y tracking son literales ya medidos en el árbol (el peso 650 aparece
+diez veces; 0.8125rem, 1.08rem, 0.06em, 1.15 son medidos). `body-weight: 400` es
+el peso que el cuerpo hereda hoy, porque el CSS del dashboard no declara ninguno.
+
+### 5.8 Motion — 5, INVARIANT
+
+`fast → var(--motion-fast)` · `standard → var(--motion-base)` ·
+`slow → var(--motion-slow)` · `ease-standard → var(--ease-out-soft)` ·
+`ease-emphasized → var(--ease-in-out-soft)`
+
+Alias semánticos, no duraciones nuevas: el dashboard ya anima sobre esos tokens
+y duplicarlos daría dos fuentes de verdad a la misma transición.
+
+**R11:** ningún token existe para animar la altura de una región. Animar
+`block-size` alimenta el `ResizeObserver` que deriva capacidad y hace oscilar
+`limit`. El contrato lo prohíbe por nombre y por valor. `prefers-reduced-motion`
+existente no se toca.
+
+## 6. Preservación de A05–A07
+
+El bloque `dashboard-row-pitch-contract` no se reescribió, no se movió fuera de
+`tokens.css`, no se renombró y ningún literal px pasó a `rem`/`calc()`/`clamp()`.
+El foundation se insertó **antes** del bloque, de modo que el capacity owner
+conserva la última palabra en la cascada.
+
+```
+ROW_PITCH_HASH_BEFORE = f76d889cc2a19a10ac45abb7cb709ffaada744aca553c81e7010b3fd65044093
+ROW_PITCH_HASH_AFTER  = f76d889cc2a19a10ac45abb7cb709ffaada744aca553c81e7010b3fd65044093
+ROW_PITCH_CONTRACT_BYTE_IDENTICAL = YES
+```
+
+SHA-256 sobre el bloque delimitado por los marcadores `:start`/`:end`,
+normalizado a LF (136 líneas, 6015 B). El archivo completo conserva CRLF puro
+(356/356 líneas).
+
+## 7. Cero migración de consumidores
+
+| Invariante | Estado |
+|---|---|
+| DOM / JSX / rutas / API / auth diff | 0 |
+| Consumidores de los 73 tokens nuevos | 0 |
+| Sombras convertidas | 0 |
+| `globals.css`, `index.css`, `theme.ts`, `theme-init.js`, `surfaces.css` | sin cambios |
+| Reglas `data-theme` nuevas fuera de `tokens.css` | 0 |
+
+`index.css` no cambia: `@import "./tokens.css"` ya era el primer módulo.
+
+## 8. Contrato ejecutable
+
+`test/architecture/dashboard-foundation-tokens.test.ts` — 16 tests, descubre los
+tokens desde el CSS real y compara contra un esquema normativo **en ambas
+direcciones** (un rol que falta falla; un extra no declarado también).
+
+| # | Test |
+|---|---|
+| T1/T2 | Las ocho categorías existen y superan su cardinalidad mínima |
+| T5 | El conjunto físico es exactamente el normativo; sin duplicados por scope |
+| — | Los prefijos de categoría particionan el namespace |
+| T10 | El scope oscuro coincide con el mecanismo real, derivado de `theme.ts`; sin segundo mecanismo de tema |
+| T3 | Cada VARIANT existe en ambos temas **con valores distintos** |
+| — | El scope oscuro contiene exactamente los VARIANT y nada más |
+| — | Cada ADAPTIVE resuelve a un token que `globals.css` reescribe en oscuro |
+| T4 | Ningún INVARIANT está en el scope oscuro ni resuelve a un token que el oscuro reescriba |
+| T6 | Toda regla del foundation está scoped a `.dashboard-app-shell`; ningún token se declara fuera de `tokens.css` |
+| T8 | Cero consumidores en `frontend/src`; el foundation no referencia tokens de runtime |
+| T7 | El contrato de row-pitch sigue con literales px parseables y por detrás del foundation |
+| T9 | Los 4 tokens de capacidad conservan un único owner |
+| — | Density no declara altura de fila |
+| R11 | Ningún token de motion nombra o transporta una altura |
+
+## 9. Controles de mutación
+
+Sobre copia aislada en scratchpad; **el source trackeado nunca se muta**.
+
+| # | Mutación | Resultado | Detectada por |
+|---|---|---|---|
+| M1 | Eliminar token temático claro (`--dash-color-field`) | FAIL | conjunto físico ≠ normativo |
+| M2 | Eliminar su contraparte oscura | FAIL | VARIANT en ambos temas |
+| M3 | Duplicar un token en el mismo scope | FAIL | duplicado en scope |
+| M4 | Eliminar la categoría motion completa | FAIL | ocho escalas |
+| M5 | `--dash-row-pitch-regular: 44px` → `2.5rem` | FAIL | pitch parseable |
+| M6 | Segundo `--dash-row-pitch` fuera del bloque owner | FAIL | conjunto físico **y** owner único de capacidad |
+| M7 | Consumir `--dash-shape-md` desde `surfaces.css` | FAIL | cero consumidores |
+| — | Baseline restaurada | PASS | — |
+
+## 10. Fuera de alcance
+
+- **B04**: migrar superficies a estos tokens, eliminar la sombra del chrome
+  persistente, tocar `shell/layout/surfaces/interactions/tables/navigation/`
+  `responsive/zero-scroll/mobile-*` o `globals.css`.
+- **B05**: invertir la relación de superficie (tinte al campo, contenedor
+  transparente). `--dash-color-field` queda **declarado**, no aplicado.
+- Cambios de DOM, JSX, rutas, API, auth, sesiones, dependencias, CI.
+- Rebaseline visual A02/A03/A08: B03 no produce diferencia visual observable.
+
+## 11. Rollback
+
+Revert del commit. Restaura los valores CSS previos; como ningún consumidor
+adoptó los tokens, el riesgo residual es **nulo** (§61 del roadmap).
+
+## 12. Riesgos residuales
+
+1. **Deriva de provenance.** Los ADAPTIVE resuelven a tokens de `globals.css`.
+   Si esa paleta se retunea, el dashboard sigue el cambio — que es lo deseado —
+   pero un rol retirado de `globals.css` rompería el contrato antes que el
+   runtime. Mitigado: el contrato falla cerrado ante esa retirada.
+2. **Alphas oscuras derivadas.** Los cuatro valores de state-layer oscuros son
+   una derivación ×1.6 documentada, no una medición. Se validarán
+   perceptualmente cuando B04 los aplique, bajo regresión visual dual.
+3. **Desviación THEME_ADAPTIVE.** Documentada en §4; requiere confirmación de
+   Nico. Si se exige duplicación textual estricta, el cambio es mecánico: mover
+   los 18 ADAPTIVE al scope oscuro y relajar la aserción de «valores distintos».
+4. **Tamaño del foundation.** 73 tokens. Cada uno tiene provenance y rol para
+   B04–B06, pero cualquiera que B04 no consuma debe retirarse, no heredarse.

--- a/docs/implementation/dashboard-b03-foundation-tokens.md
+++ b/docs/implementation/dashboard-b03-foundation-tokens.md
@@ -62,20 +62,58 @@ Se adoptan tres clases explícitas, y el contrato prueba cada una:
 
 | Clase | Declaraciones | Cómo se prueba el valor oscuro | N |
 |---|---|---|---|
-| `THEME_INVARIANT` | 1 | Debe **no** aparecer en el scope oscuro **y** no referenciar ningún token que el tema oscuro reescriba (si lo hiciera, estaría mal clasificado) | 47 |
-| `THEME_ADAPTIVE` | 1 | Se **resuelve la referencia**: cada token global citado debe estar realmente redefinido bajo `:root[data-theme="dark-gray"]` en `globals.css` | 18 |
-| `THEME_VARIANT` | 2 (claro + oscuro) | Ambas deben existir **y sus valores deben diferir** | 8 |
+| `THEME_INVARIANT` | 1 | Su **fingerprint efectivo** —resuelto de forma transitiva por todo el árbol `var()`— es idéntico en ambos ambientes, y no está restatado en el scope oscuro | 48 |
+| `THEME_ADAPTIVE` | 1 | Su **fingerprint efectivo** —resuelto de forma transitiva— difiere entre ambos ambientes | 17 |
+| `THEME_VARIANT` | 2 (claro + oscuro) | Ambas declaraciones existen, sus valores directos difieren, **y** sus fingerprints efectivos también difieren | 8 |
 
 `THEME_ADAPTIVE` es una desviación deliberada respecto de la instrucción literal
 («un token temático en light sin dark → FAIL») y se reporta como tal. Es más
 fuerte, no más débil: detecta el fallo real de R9 —un rol del dashboard sin
-valor oscuro definido— en lugar de contar líneas. Si `globals.css` dejara de
-reescribir `--card`, la duplicación textual seguiría en verde mientras el
-dashboard pierde su superficie oscura; esta comprobación falla.
+valor oscuro definido— en lugar de contar líneas.
 
-**Dark completeness: PASS.** 8 VARIANT con valores distintos + 18 ADAPTIVE con
-referencia resuelta + 47 INVARIANT justificados = 73 tokens, ninguno con tema
-indefinido.
+**Corrección post-review (Codex, PR #1660, thread `PRRT_kwDOR5qlsc6aIIdk`, P2).**
+La primera versión de este contrato probaba únicamente que la **referencia
+directa** del token apareciera redeclarada en el bloque oscuro de
+`globals.css` — no que el **valor efectivo** cambiara. Eso dejó un agujero real:
+
+```
+--dash-color-focus-ring → --clinical-focus-ring → --ring
+```
+
+`--clinical-focus-ring` se declara `hsl(var(--ring) / 0.85)` en AMBOS temas —
+textualmente idéntico—; la adaptación real ocurre un nivel más abajo, en
+`--ring` (182 72% 34% en claro, 181 60% 50% en oscuro). El contrato anterior
+veía que `--clinical-focus-ring` "aparecía en el bloque oscuro" y daba el rol
+por cubierto sin mirar más allá. Retirar el override oscuro de `--ring`
+habría dejado el dashboard con el focus ring de tema claro en modo oscuro
+mientras este contrato fail-closed seguía en verde.
+
+El contrato ahora resuelve cada token en una **huella estructural** por todo
+el árbol `var()` (`resolveThemeFingerprint`), en dos ambientes construidos
+explícitamente: `LIGHT_ENV` (paleta clara de `globals.css` + foundation claro)
+y `DARK_ENV` (paleta clara sobreescrita por la oscura de `globals.css` +
+foundation claro sobreescrito por el foundation oscuro — exactamente lo que
+hace la cascada real). ADAPTIVE exige que las huellas difieran; INVARIANT
+exige que sean idénticas; VARIANT exige ambas cosas además de que los valores
+directos difieran. La resolución falla cerrado ante un ciclo (`--a → --b →
+--a`, mensaje con la cadena completa) y ante una referencia sin resolver — un
+`var()` roto nunca se trata como invariante.
+
+**Reclasificación consecuente.** Al resolver de forma transitiva,
+`--dash-color-on-primary` (`hsl(var(--primary-foreground))`) resultó
+INVARIANT, no ADAPTIVE: `--primary-foreground` es `190 36% 97%`, textualmente
+idéntico en `globals.css` claro y oscuro. Es el mismo tipo de hallazgo que el
+review señaló, detectado por el propio endurecimiento del contrato. Por
+AGENTS.md §4 («los ajustes que un cambio in-scope rompe legítimamente… se
+realinean en el mismo PR, nunca se debilitan ni se marcan como skip»), se
+realinea aquí: 17 ADAPTIVE + 48 INVARIANT (antes 18 + 47). El total de 73
+tokens y las 8 VARIANT no cambian; `tokens.css` tampoco — es una
+reclasificación del esquema normativo en el contrato, no un cambio de CSS.
+
+**Dark completeness: PASS.** 8 VARIANT con fingerprint efectivo distinto + 17
+ADAPTIVE con fingerprint efectivo distinto + 48 INVARIANT con fingerprint
+efectivo idéntico = 73 tokens, ninguno con tema indefinido ni con una
+adaptación fantasma.
 
 ## 5. Las ocho escalas
 
@@ -84,7 +122,7 @@ Namespace `--dash-<categoría>-<rol>`. Los diez prefijos usados
 `-text-`, `-motion-`) se verificaron libres de colisión en `frontend/src`,
 `test/` y `docs/` antes de crearse.
 
-### 5.1 Color — 18 (15 ADAPTIVE, 3 VARIANT)
+### 5.1 Color — 18 (14 ADAPTIVE, 1 INVARIANT, 3 VARIANT)
 
 | Token | Claro | Oscuro | Provenance |
 |---|---|---|---|
@@ -97,12 +135,12 @@ Namespace `--dash-<categoría>-<rol>`. Los diez prefijos usados
 | `--dash-color-outline` | `hsl(var(--vetneb-line))` | ADAPTIVE | flip global |
 | `--dash-color-outline-subtle` | `hsl(var(--vetneb-line) / 0.42)` | ADAPTIVE | alpha 0.42 medida 3× en este árbol |
 | `--dash-color-primary` | `hsl(var(--primary))` | ADAPTIVE | flip global |
-| `--dash-color-on-primary` | `hsl(var(--primary-foreground))` | ADAPTIVE | flip global |
+| `--dash-color-on-primary` | `hsl(var(--primary-foreground))` | INVARIANT | `--primary-foreground` es `190 36% 97%`, textualmente idéntico en claro y oscuro — reclasificado desde ADAPTIVE tras la resolución transitiva |
 | `--dash-color-accent` | `hsl(var(--vetneb-teal))` | ADAPTIVE | flip global |
 | `--dash-color-success` | `hsl(var(--vetneb-teal))` | ADAPTIVE | teal = positivo clínico |
 | `--dash-color-error` | `hsl(var(--destructive))` | ADAPTIVE | flip global |
 | `--dash-color-info` | `hsl(var(--vetneb-cyan))` | ADAPTIVE | flip global |
-| `--dash-color-focus-ring` | `var(--clinical-focus-ring)` | ADAPTIVE | PR-VIS-3, redefinido en oscuro |
+| `--dash-color-focus-ring` | `var(--clinical-focus-ring)` | ADAPTIVE | PR-VIS-3; `--clinical-focus-ring` es idéntico en ambos temas, la adaptación real está un nivel más abajo en `--ring` — probado por resolución transitiva, ver §4 |
 | `--dash-color-field` | `hsl(var(--vetneb-surface-muted) / 0.72)` | `… / 0.92` | ambas alphas son literales medidos aquí; objetivo B05 |
 | `--dash-color-warning` | `hsl(var(--vetneb-amber))` | `hsl(38 88% 64%)` | el valor oscuro es **verbatim** el override que `globals.css` ya aplica al ámbar en oscuro |
 | `--dash-color-overlay-scrim` | `hsl(var(--vetneb-ink) / 0.32)` | `hsl(210 15% 4% / 0.62)` | `--vetneb-ink` pasa de 15% a 90% de luminosidad: heredarlo pintaría un scrim **blanco** |
@@ -226,7 +264,7 @@ normalizado a LF (136 líneas, 6015 B). El archivo completo conserva CRLF puro
 
 ## 8. Contrato ejecutable
 
-`test/architecture/dashboard-foundation-tokens.test.ts` — 16 tests, descubre los
+`test/architecture/dashboard-foundation-tokens.test.ts` — 19 tests, descubre los
 tokens desde el CSS real y compara contra un esquema normativo **en ambas
 direcciones** (un rol que falta falla; un extra no declarado también).
 
@@ -236,10 +274,13 @@ direcciones** (un rol que falta falla; un extra no declarado también).
 | T5 | El conjunto físico es exactamente el normativo; sin duplicados por scope |
 | — | Los prefijos de categoría particionan el namespace |
 | T10 | El scope oscuro coincide con el mecanismo real, derivado de `theme.ts`; sin segundo mecanismo de tema |
-| T3 | Cada VARIANT existe en ambos temas **con valores distintos** |
+| T3 | Cada VARIANT existe en ambos temas con valores directos distintos **y** fingerprint efectivo distinto |
 | — | El scope oscuro contiene exactamente los VARIANT y nada más |
-| — | Cada ADAPTIVE resuelve a un token que `globals.css` reescribe en oscuro |
-| T4 | Ningún INVARIANT está en el scope oscuro ni resuelve a un token que el oscuro reescriba |
+| — | Cada ADAPTIVE resuelve, por todo el árbol `var()`, a un **fingerprint efectivo** que difiere entre ambientes claro/oscuro (fix post-review, §4) |
+| T4 | Ningún INVARIANT está en el scope oscuro; su fingerprint efectivo es idéntico entre ambientes (simétrico al fix de ADAPTIVE) |
+| — | La resolución de fingerprint falla cerrado ante un ciclo de custom properties, con la cadena completa en el mensaje |
+| — | La resolución de fingerprint falla cerrado ante una referencia sin resolver, en vez de tratarla como invariante |
+| — | Fixture sintética de cadena de tres niveles: prueba que la resolución transitiva detecta un cambio dos niveles abajo y no detecta uno donde no lo hay |
 | T6 | Toda regla del foundation está scoped a `.dashboard-app-shell`; ningún token se declara fuera de `tokens.css` |
 | T8 | Cero consumidores en `frontend/src`; el foundation no referencia tokens de runtime |
 | T7 | El contrato de row-pitch sigue con literales px parseables y por detrás del foundation |
@@ -260,7 +301,10 @@ Sobre copia aislada en scratchpad; **el source trackeado nunca se muta**.
 | M5 | `--dash-row-pitch-regular: 44px` → `2.5rem` | FAIL | pitch parseable |
 | M6 | Segundo `--dash-row-pitch` fuera del bloque owner | FAIL | conjunto físico **y** owner único de capacidad |
 | M7 | Consumir `--dash-shape-md` desde `surfaces.css` | FAIL | cero consumidores |
+| M8 | Eliminar sólo el override oscuro de `--ring`, dejando intacto el de `--clinical-focus-ring` (idéntico en ambos temas) | FAIL | fingerprint efectivo de `--dash-color-focus-ring` — reproduce exactamente el falso verde de Codex |
 | — | Baseline restaurada | PASS | — |
+
+Además, sobre fixtures sintéticas dentro del propio archivo de test (no requieren copia aislada, porque no ejercitan `tokens.css` ni `globals.css` reales): un ciclo `--a → --b → --a` falla con la cadena completa en el mensaje; una referencia sin resolver falla explícitamente en vez de tratarse como invariante; y una cadena de tres niveles (`--a → --b → --c`) prueba que un cambio en `--c` es visible en la huella de `--a`, y que la ausencia de cambio dentro de esa misma cadena deja la huella de `--a` sin alterar.
 
 ## 10. Fuera de alcance
 
@@ -286,8 +330,9 @@ adoptó los tokens, el riesgo residual es **nulo** (§61 del roadmap).
 2. **Alphas oscuras derivadas.** Los cuatro valores de state-layer oscuros son
    una derivación ×1.6 documentada, no una medición. Se validarán
    perceptualmente cuando B04 los aplique, bajo regresión visual dual.
-3. **Desviación THEME_ADAPTIVE.** Documentada en §4; requiere confirmación de
-   Nico. Si se exige duplicación textual estricta, el cambio es mecánico: mover
-   los 18 ADAPTIVE al scope oscuro y relajar la aserción de «valores distintos».
+3. **Desviación THEME_ADAPTIVE.** Documentada en §4; aprobada por Nico junto
+   con el fix de resolución transitiva (corrige el P2 de Codex en PR #1660).
+   La resolución ya prueba el valor efectivo, no sólo la presencia textual de
+   la referencia directa.
 4. **Tamaño del foundation.** 73 tokens. Cada uno tiene provenance y rol para
    B04–B06, pero cualquiera que B04 no consuma debe retirarse, no heredarse.

--- a/frontend/src/styles/dashboard/tokens.css
+++ b/frontend/src/styles/dashboard/tokens.css
@@ -1,12 +1,222 @@
 /* tokens.css — dashboard design tokens
- * Reserved composition slot for dashboard-scoped design tokens, imported
- * first by styles/dashboard/index.css so any tokens defined here are
- * available to every later module.
+ * Dashboard-scoped design tokens, imported first by styles/dashboard/index.css
+ * so every token defined here is available to every later module. The B03
+ * foundation block below declares the eight design-system scales; the
+ * row-pitch contract after it is the capacity owner and predates B03.
  *
  * Global design tokens (HSL palette, motion/easing, radii) live in
  * app/globals.css :root under @layer base. The dashboard runtime accent
  * tokens (--dash-accent-*) stay colocated with their consumers in
  * surfaces.css (premium grammar) to preserve that verbatim section. */
+
+/* dashboard-foundation-tokens:start
+ *
+ * B03 — dashboard design-system foundation.
+ *
+ * Eight scales (color, shape, elevation, state-layer, spacing, density,
+ * typography, motion) declared once, dashboard-scoped, and consumed by nobody
+ * yet. B03 DEFINES the foundation; B04 migrates the surfaces onto it. A token
+ * that already had a consumer would make that migration invisible, so
+ * `test/architecture/dashboard-foundation-tokens.test.ts` asserts the consumer
+ * count outside this block is zero.
+ *
+ * Theme classification is explicit, because "dark is covered" is exactly the
+ * claim the dashboard could not previously make: before B03 the whole
+ * `styles/dashboard` tree contained ZERO `data-theme` rules and inherited
+ * whatever globals.css happened to flip.
+ *
+ *   THEME_INVARIANT  One declaration; the value is the same in both themes by
+ *                    nature (a rem, a duration, a weight). Restating it under
+ *                    the dark scope would be noise, not coverage.
+ *   THEME_ADAPTIVE   One declaration whose value REFERENCES a global token that
+ *                    globals.css itself redefines under
+ *                    `:root[data-theme="dark-gray"]`. The dark value exists and
+ *                    is proven by resolving the reference; the contract checks
+ *                    that every referenced token is really redefined there, so
+ *                    a role whose dark value silently disappeared fails closed.
+ *   THEME_VARIANT    Two declarations, light and dark, with genuinely different
+ *                    values — the roles where inheriting the flipped palette
+ *                    gives the WRONG answer (a scrim built on `--vetneb-ink`
+ *                    turns WHITE in dark, because ink flips to 90% lightness)
+ *                    or an insufficient one (amber, which globals.css already
+ *                    overrides in dark for exactly that reason).
+ *
+ * Provenance: no value here was picked because it looked right. Each one is a
+ * global VETNEB token, a literal measured in dashboard CSS, or a derivation
+ * documented at its declaration.
+ *
+ * Unlayered, like the pitch contract below: these are foundation declarations
+ * that later dashboard modules read, and a layered token would lose to the
+ * unlayered overrides that already exist in this tree. */
+.dashboard-app-shell {
+  /* 1 — COLOR. Roles, not hues. Every entry is THEME_ADAPTIVE unless the dark
+     scope at the end of this block overrides it. */
+  --dash-color-canvas: hsl(var(--vetneb-surface));
+  --dash-color-surface: hsl(var(--card));
+  --dash-color-surface-raised: hsl(var(--vetneb-surface-raised));
+  --dash-color-surface-muted: hsl(var(--vetneb-surface-muted));
+  --dash-color-on-surface: hsl(var(--foreground));
+  --dash-color-on-surface-muted: hsl(var(--muted-foreground));
+  --dash-color-outline: hsl(var(--vetneb-line));
+  /* 0.42 is the hairline alpha already used three times in this tree; it holds
+     in dark because `--vetneb-line` itself drops from 80% to 30% lightness. */
+  --dash-color-outline-subtle: hsl(var(--vetneb-line) / 0.42);
+  --dash-color-primary: hsl(var(--primary));
+  --dash-color-on-primary: hsl(var(--primary-foreground));
+  --dash-color-accent: hsl(var(--vetneb-teal));
+  --dash-color-success: hsl(var(--vetneb-teal));
+  --dash-color-error: hsl(var(--destructive));
+  --dash-color-info: hsl(var(--vetneb-cyan));
+  --dash-color-focus-ring: var(--clinical-focus-ring);
+  /* THEME_VARIANT — overridden in the dark scope below.
+     field: the B05 target (tint moves to the field, container goes
+     transparent). Both alphas are literals measured in this tree: 0.72 reads
+     as a tint over a 96%-lightness canvas, 0.92 is what the same fill needs to
+     separate from a 12%-lightness one. */
+  --dash-color-field: hsl(var(--vetneb-surface-muted) / 0.72);
+  /* warning: NOT a bare `hsl(var(--vetneb-amber))`. The flipped amber
+     (38 84% 58%) is still too dim on the dark canvas, which is why globals.css
+     already ships a dark override at 38 88% 64% for amber text and the
+     critical KPI pill. The token adopts that decision instead of contradicting
+     it. */
+  --dash-color-warning: hsl(var(--vetneb-amber));
+  /* THEME_VARIANT. `--vetneb-ink` is a 15%-lightness ink in light and a
+     90%-lightness near-white in dark, so a scrim that inherited it would turn
+     the modal backdrop WHITE. This is the clearest case in the foundation for
+     declaring a dark value instead of inheriting one. */
+  --dash-color-overlay-scrim: hsl(var(--vetneb-ink) / 0.32);
+
+  /* 2 — SHAPE. THEME_INVARIANT. Monotonic, and derived from the radii this
+     tree actually uses rather than from a generic t-shirt scale: 0.5rem is
+     both the global `--radius` and the most repeated literal here; 0.6, 0.75
+     and 0.85 are the next three clusters; 0.45 and 1.1 are the observed
+     endpoints. `--radius` itself is untouched. */
+  --dash-shape-none: 0;
+  --dash-shape-xs: 0.45rem;
+  --dash-shape-sm: 0.5rem;
+  --dash-shape-md: 0.6rem;
+  --dash-shape-lg: 0.75rem;
+  --dash-shape-xl: 0.85rem;
+  --dash-shape-2xl: 1.1rem;
+  --dash-shape-full: 9999px;
+
+  /* 3 — ELEVATION. Semantic levels, not shadow recipes. `none` is declared so
+     B04 can state flatness positively — the roadmap retires the persistent
+     chrome's shadow, and "no box-shadow property" and "elevation: none" are
+     different claims in review. The three raised levels are THEME_ADAPTIVE via
+     the `--clinical-*` shadows, which globals.css already re-authors in dark
+     (alpha 0.055 -> 0.20, 0.08 -> 0.28, 0.10 -> 0.34). */
+  --dash-elevation-none: none;
+  --dash-elevation-raised: var(--clinical-shadow-sm);
+  --dash-elevation-menu: var(--clinical-shadow-md);
+  --dash-elevation-dialog: var(--clinical-shadow-lg);
+
+  /* 4 — STATE LAYER. Expressed as opacity so one overlay can serve every
+     state. THEME_VARIANT: the light anchors are measured here (a 0.06 navy
+     wash, 0.13/0.16 teal selection), and the dark values are a documented
+     x1.6 lift — conservative next to the x3.0-x3.6 the dark palette already
+     applies to its own shadows, and needed because an overlay reads weaker
+     against a 12%-lightness surface. */
+  --dash-state-hover-opacity: 0.06;
+  --dash-state-pressed-opacity: 0.10;
+  --dash-state-selected-opacity: 0.13;
+  --dash-state-focus-opacity: 0.16;
+  /* The tint the layer is painted in: brand-tinted DARKENING in light, neutral
+     LIGHTENING in dark. One inherited token cannot express that flip, because
+     the direction is a design decision, not a palette consequence. */
+  --dash-state-layer-color: hsl(var(--vetneb-navy));
+  /* THEME_INVARIANT: this one dims the element itself instead of painting a
+     layer over it, so it is theme-independent. 0.45 verbatim from
+     `.dashboard-disabled-state` in interactions.css. */
+  --dash-state-disabled-opacity: 0.45;
+
+  /* 5 — SPACING. THEME_INVARIANT. 8px rhythm with a 4px micro step and the
+     12px secondary the audit measured, bounded by the clamp ceilings already
+     in responsive.css (`--dash-gap` -> 1rem, `--dash-pad-x` -> 2rem). */
+  --dash-space-0: 0;
+  --dash-space-1: 0.25rem;
+  --dash-space-2: 0.5rem;
+  --dash-space-3: 0.75rem;
+  --dash-space-4: 1rem;
+  --dash-space-5: 1.5rem;
+  --dash-space-6: 2rem;
+
+  /* 6 — DENSITY. THEME_INVARIANT, and deliberately NARROW.
+     Row height is NOT here. `--dash-row-pitch*` in the contract below is the
+     single owner of how tall a row is, and the capacity engine reads those
+     tokens back at runtime; a second row-height token in this block would be a
+     competing owner even with nothing consuming it yet. Density here describes
+     CHROME — controls and their insets. The contract asserts that separation
+     by name, so the boundary cannot erode silently.
+     Bounds measured from responsive.css: `--dash-tab-h` spans 1.9-2.25rem and
+     `--dash-control-h` tops out at 2.5rem. */
+  --dash-density-control-compact: 1.9rem;
+  --dash-density-control-regular: 2.25rem;
+  --dash-density-control-comfortable: 2.5rem;
+  --dash-density-inset-compact: var(--dash-space-1);
+  --dash-density-inset-regular: var(--dash-space-2);
+  --dash-density-inset-comfortable: var(--dash-space-3);
+
+  /* 7 — TYPOGRAPHY. THEME_INVARIANT. Semantic roles over the existing Inter
+     stack: `--font-ui` is referenced, never redeclared, and no @font-face and
+     no font asset is introduced. Sizes, weights, leadings and tracking are the
+     literals already measured across this tree (weight 650 alone appears ten
+     times); body weight is 400 because dashboard CSS declares none and 400 is
+     what body copy inherits today. */
+  --dash-text-family: var(--font-ui);
+  --dash-text-label-size: 0.7rem;
+  --dash-text-label-weight: 650;
+  --dash-text-label-leading: 1.2;
+  --dash-text-label-tracking: 0.06em;
+  --dash-text-body-size: 0.8125rem;
+  --dash-text-body-weight: 400;
+  --dash-text-body-leading: 1.25;
+  --dash-text-body-strong-weight: 600;
+  --dash-text-section-size: 0.75rem;
+  --dash-text-section-weight: 650;
+  --dash-text-section-leading: 1.2;
+  --dash-text-section-tracking: 0.05em;
+  --dash-text-title-size: 1rem;
+  --dash-text-title-weight: 700;
+  --dash-text-title-leading: 1.15;
+  --dash-text-metric-size: 1.08rem;
+  --dash-text-metric-weight: 750;
+  --dash-text-metric-leading: 1;
+
+  /* 8 — MOTION. THEME_INVARIANT, and aliases rather than new durations: the
+     dashboard already animates on `--motion-fast|base|slow` and
+     `--ease-out-soft|in-out-soft`, so parallel durations would give the same
+     transition two sources of truth.
+     R11: NO token here may exist to animate a region's height. Animating
+     block-size feeds the ResizeObserver that derives capacity, which makes
+     `limit` oscillate and re-fetch. The contract enforces that absence by
+     name; existing `prefers-reduced-motion` handling stays where it is. */
+  --dash-motion-fast: var(--motion-fast);
+  --dash-motion-standard: var(--motion-base);
+  --dash-motion-slow: var(--motion-slow);
+  --dash-motion-ease-standard: var(--ease-out-soft);
+  --dash-motion-ease-emphasized: var(--ease-in-out-soft);
+}
+
+/* Dark scope. The selector matches the real theme mechanism verbatim: theme.ts
+   and public/theme-init.js both write `documentElement.dataset.theme`, and
+   globals.css already owns `:root[data-theme="dark-gray"]`. B03 introduces no
+   second theme mechanism — no `.dark`, no `prefers-color-scheme` owner, no
+   `data-dashboard-theme`.
+   Only THEME_VARIANT tokens appear here. Every other role is either invariant
+   or resolves through a global token that globals.css re-authors in this same
+   scope, so restating it would add a place to drift, not a value. */
+:root[data-theme="dark-gray"] .dashboard-app-shell {
+  --dash-color-field: hsl(var(--vetneb-surface-muted) / 0.92);
+  --dash-color-warning: hsl(38 88% 64%);
+  --dash-color-overlay-scrim: hsl(210 15% 4% / 0.62);
+  --dash-state-hover-opacity: 0.10;
+  --dash-state-pressed-opacity: 0.16;
+  --dash-state-selected-opacity: 0.20;
+  --dash-state-focus-opacity: 0.24;
+  --dash-state-layer-color: hsl(var(--vetneb-ink));
+}
+/* dashboard-foundation-tokens:end */
 
 /* dashboard-row-pitch-contract:start
  *

--- a/test/architecture/dashboard-foundation-tokens.test.ts
+++ b/test/architecture/dashboard-foundation-tokens.test.ts
@@ -85,7 +85,13 @@ const FOUNDATION_SCHEMA: Readonly<Record<string, CategorySchema>> =
         "--dash-color-outline": "ADAPTIVE",
         "--dash-color-outline-subtle": "ADAPTIVE",
         "--dash-color-primary": "ADAPTIVE",
-        "--dash-color-on-primary": "ADAPTIVE",
+        // globals.css declares --primary-foreground as the byte-identical
+        // "190 36% 97%" in both :root and :root[data-theme="dark-gray"], so
+        // the token's EFFECTIVE value never adapts — resolving it
+        // transitively (rather than checking that the direct reference merely
+        // appears under the dark selector) is what surfaces this: it is
+        // INVARIANT, not ADAPTIVE.
+        "--dash-color-on-primary": "INVARIANT",
         "--dash-color-accent": "ADAPTIVE",
         "--dash-color-success": "ADAPTIVE",
         "--dash-color-error": "ADAPTIVE",
@@ -291,19 +297,108 @@ function declarationsFor(selector: string): Map<string, string> {
 const LIGHT_DECLARATIONS = declarationsFor(LIGHT_SCOPE);
 const DARK_DECLARATIONS = declarationsFor(DARK_SCOPE);
 
-/** Global custom properties globals.css re-authors under the dark selector. */
-const DARK_REDEFINED_GLOBALS: ReadonlySet<string> = new Set(
-  parseDeclarations(
-    sliceBlock(
-      GLOBALS_CSS,
-      `:root[data-theme="${DARK_THEME_MODE}"] {`,
-      "}",
-    ),
-  ).map(([token]) => token),
-);
-
 function referencedTokens(value: string): string[] {
   return [...value.matchAll(/var\(\s*(--[a-z0-9-]+)/g)].map((match) => match[1]);
+}
+
+/**
+ * Every `selector { … }` rule in a stylesheet whose selector matches exactly.
+ * Collected as a list because globals.css opens `:root` more than once (the
+ * palette under `@layer base`, and a later unlayered `color-scheme` rule).
+ */
+function ruleBodies(source: string, selector: string): string[] {
+  const bodies: string[] = [];
+  for (const match of stripComments(source).matchAll(/([^{}]+)\{([^{}]*)\}/g)) {
+    if (match[1].trim().replace(/\s+/g, " ") === selector) bodies.push(match[2]);
+  }
+  return bodies;
+}
+
+function declarationEnv(sources: readonly string[]): Map<string, string> {
+  const env = new Map<string, string>();
+  for (const body of sources) {
+    for (const [token, value] of parseDeclarations(body)) env.set(token, value);
+  }
+  return env;
+}
+
+const GLOBALS_LIGHT = ruleBodies(GLOBALS_CSS, ":root");
+const GLOBALS_DARK = ruleBodies(
+  GLOBALS_CSS,
+  `:root[data-theme="${DARK_THEME_MODE}"]`,
+);
+
+/**
+ * The two environments a dashboard token actually resolves in. Dark is the
+ * light environment with the dark overrides applied on top, which is precisely
+ * what the cascade does: `:root[data-theme="dark-gray"]` re-declares a subset
+ * and everything else keeps its light declaration.
+ */
+const LIGHT_ENV: ReadonlyMap<string, string> = declarationEnv([
+  ...GLOBALS_LIGHT,
+  ...[...LIGHT_DECLARATIONS].map(([token, value]) => `${token}: ${value};`),
+]);
+
+const DARK_ENV: ReadonlyMap<string, string> = declarationEnv([
+  ...GLOBALS_LIGHT,
+  ...GLOBALS_DARK,
+  ...[...LIGHT_DECLARATIONS].map(([token, value]) => `${token}: ${value};`),
+  ...[...DARK_DECLARATIONS].map(([token, value]) => `${token}: ${value};`),
+]);
+
+/**
+ * Structural fingerprint of a custom property's EFFECTIVE value in one
+ * environment, resolved through the whole `var()` chain.
+ *
+ * Comparing declarations directly is not enough, and this is the exact hole the
+ * first version of this contract had: `--dash-color-focus-ring` points at
+ * `--clinical-focus-ring`, which globals.css re-declares under the dark
+ * selector as the byte-identical `hsl(var(--ring) / 0.85)`. The theme change
+ * happens one level deeper, in `--ring`. A check that stopped at "the directly
+ * referenced token appears in the dark block" therefore reported the role as
+ * covered while deleting the dark `--ring` override would have handed the
+ * dashboard its LIGHT focus ring in dark mode with the guard still green.
+ *
+ * The fingerprint carries each level's raw declaration plus its children, so
+ * two environments differ if ANY node along the chain differs — no CSS value
+ * engine required, and no colour arithmetic to get wrong.
+ */
+function resolveThemeFingerprint(
+  token: string,
+  env: ReadonlyMap<string, string>,
+  stack: readonly string[] = [],
+): string {
+  if (stack.includes(token)) {
+    // Deterministic failure, not a stack overflow: a cycle has no effective
+    // value, so neither theme can be proven and the contract must say so.
+    throw new Error(
+      `custom property cycle: ${[...stack, token].join(" -> ")}`,
+    );
+  }
+
+  const declaration = env.get(token);
+  if (declaration === undefined) {
+    // An unresolvable reference is NOT an invariant value. Treating it as one
+    // is how a typo would silently downgrade a themed role to "same in both".
+    throw new Error(
+      `unresolved custom property "${token}"${
+        stack.length > 0 ? ` (via ${stack.join(" -> ")})` : ""
+      }`,
+    );
+  }
+
+  const children = referencedTokens(declaration).map((reference) =>
+    resolveThemeFingerprint(reference, env, [...stack, token]),
+  );
+
+  return `${token}{${declaration}}[${children.join(",")}]`;
+}
+
+function fingerprints(token: string): { light: string; dark: string } {
+  return {
+    light: resolveThemeFingerprint(token, LIGHT_ENV),
+    dark: resolveThemeFingerprint(token, DARK_ENV),
+  };
 }
 
 function collectFilesRecursive(repoRelativeDir: string, extensions: RegExp): string[] {
@@ -460,6 +555,16 @@ test("every THEME_VARIANT token is declared in both themes, with different value
       light,
       `"${token}" declares an identical value in both themes — classify it ADAPTIVE or INVARIANT instead`,
     );
+
+    // Two declarations that read differently could still resolve to the same
+    // EFFECTIVE value if their own references converge — the direct-value
+    // check above would miss that. Fingerprints prove they genuinely diverge.
+    const { light: lightFp, dark: darkFp } = fingerprints(token);
+    assert.notEqual(
+      darkFp,
+      lightFp,
+      `"${token}" has different raw declarations but they resolve to the same effective value in both themes`,
+    );
   }
 });
 
@@ -477,7 +582,7 @@ test("the dark scope contains THEME_VARIANT tokens and nothing else", () => {
   );
 });
 
-test("every THEME_ADAPTIVE token resolves to a value the dark theme rewrites", () => {
+test("every THEME_ADAPTIVE token's effective value genuinely changes in dark", () => {
   const adaptive = SCHEMA_ENTRIES.filter(([, themeClass]) => themeClass === "ADAPTIVE");
   assert.ok(adaptive.length > 0, "the adaptive class must be populated or removed");
 
@@ -490,15 +595,23 @@ test("every THEME_ADAPTIVE token resolves to a value the dark theme rewrites", (
       references.length > 0,
       `"${token}" is THEME_ADAPTIVE but references no token — it cannot adapt`,
     );
-    // The claim "dark is covered by reference" is only true while the
-    // referenced global is genuinely re-authored under the dark selector.
-    // This is the assertion that makes R9 fail closed.
-    for (const reference of references) {
-      assert.ok(
-        DARK_REDEFINED_GLOBALS.has(reference),
-        `"${token}" is THEME_ADAPTIVE but "${reference}" is not redefined under the dark selector in globals.css — the role would have no dark value`,
-      );
-    }
+
+    // Checking that the DIRECT reference is redeclared under the dark
+    // selector is not enough to prove the role adapts: --dash-color-focus-ring
+    // references --clinical-focus-ring, and globals.css restates that wrapper
+    // as the byte-identical `hsl(var(--ring) / 0.85)` in both themes — the
+    // real change is one level deeper, in --ring. Deleting the dark --ring
+    // override would leave the dashboard with its LIGHT focus ring in dark
+    // mode while a direct-reference check stayed green. Resolving the full
+    // chain into an EFFECTIVE-value fingerprint is what catches that: the
+    // fingerprint differs only if some node in the chain actually differs.
+    const { light: lightFp, dark: darkFp } = fingerprints(token);
+    assert.notEqual(
+      darkFp,
+      lightFp,
+      `"${token}" is THEME_ADAPTIVE but its effective value — resolved through the full var() chain — is identical in both themes. ` +
+        `Either a referenced global stopped adapting in dark, or this role never adapted and belongs in THEME_INVARIANT.`,
+    );
   }
 });
 
@@ -513,13 +626,78 @@ test("no THEME_INVARIANT token is theme-dependent in disguise", () => {
 
     const value = LIGHT_DECLARATIONS.get(token);
     assert.ok(value !== undefined, `"${token}" is missing from the foundation scope`);
-    for (const reference of referencedTokens(value)) {
-      assert.ok(
-        !DARK_REDEFINED_GLOBALS.has(reference),
-        `"${token}" is classified THEME_INVARIANT but resolves through "${reference}", which the dark theme rewrites — it is ADAPTIVE`,
-      );
-    }
+
+    // Symmetric with the ADAPTIVE check: an invariant is only honest if its
+    // effective value is identical, not merely if its direct reference
+    // happens not to appear in the dark block. A chain that adapts two levels
+    // down would pass a shallow check while genuinely changing under the
+    // hood — the same class of gap the ADAPTIVE fix closes, mirrored.
+    const { light: lightFp, dark: darkFp } = fingerprints(token);
+    assert.equal(
+      darkFp,
+      lightFp,
+      `"${token}" is classified THEME_INVARIANT but its effective value differs between themes somewhere in its var() chain — it is ADAPTIVE or VARIANT`,
+    );
   }
+});
+
+test("fingerprint resolution fails closed on a custom-property cycle", () => {
+  // Synthetic fixture: the real tree has no cycle, so this proves the
+  // resolver's OWN behavior rather than anything about tokens.css.
+  const cyclicEnv = new Map([
+    ["--a", "var(--b)"],
+    ["--b", "var(--a)"],
+  ]);
+
+  assert.throws(
+    () => resolveThemeFingerprint("--a", cyclicEnv),
+    /cycle: --a -> --b -> --a/,
+    "a custom-property cycle must fail with the cycle chain in the message, not hang or resolve",
+  );
+});
+
+test("fingerprint resolution fails closed on a dangling reference", () => {
+  const danglingEnv = new Map([["--a", "var(--missing-token)"]]);
+
+  assert.throws(
+    () => resolveThemeFingerprint("--a", danglingEnv),
+    /unresolved custom property "--missing-token"/,
+    "an unresolvable var() must fail rather than being treated as an invariant value",
+  );
+});
+
+test("fingerprint resolution proves a transitive chain the way --dash-color-focus-ring needs", () => {
+  // --a -> --b -> --c, with --c the only node that actually changes in dark.
+  // This is the shape of the real bug: a wrapper (--b) that is textually
+  // identical between themes while its own dependency (--c) adapts.
+  const lightEnv = new Map([
+    ["--a", "var(--b)"],
+    ["--b", "var(--c)"],
+    ["--c", "1px"],
+  ]);
+  const darkEnvAdapting = new Map([
+    ["--a", "var(--b)"],
+    ["--b", "var(--c)"],
+    ["--c", "2px"],
+  ]);
+
+  assert.notEqual(
+    resolveThemeFingerprint("--a", darkEnvAdapting),
+    resolveThemeFingerprint("--a", lightEnv),
+    "a two-level-deep change in --c must be visible through --a's fingerprint",
+  );
+
+  const darkEnvFlat = new Map([
+    ["--a", "var(--b)"],
+    ["--b", "var(--c)"],
+    ["--c", "1px"],
+  ]);
+
+  assert.equal(
+    resolveThemeFingerprint("--a", darkEnvFlat),
+    resolveThemeFingerprint("--a", lightEnv),
+    "an unchanged --c must leave --a's fingerprint unchanged too",
+  );
 });
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/test/architecture/dashboard-foundation-tokens.test.ts
+++ b/test/architecture/dashboard-foundation-tokens.test.ts
@@ -1,0 +1,704 @@
+import assert from "node:assert/strict";
+import { readFileSync, readdirSync } from "node:fs";
+import { join, relative, resolve } from "node:path";
+import test from "node:test";
+
+// B03 · dashboard design-system foundation contract.
+//
+// B03 declares the foundation; B04 migrates the surfaces onto it. That split is
+// the whole reason this file exists: a foundation is only reviewable while the
+// scales are complete AND nothing consumes them yet, because the moment a
+// surface adopts a token the migration and the definition become one
+// indistinguishable diff.
+//
+// The contract is deliberately two-way. A schema on its own would pass while
+// the CSS drifted; a census on its own would pass while a required role
+// vanished. So the normative schema below is compared against the tokens
+// physically parsed out of tokens.css in BOTH directions — a missing role fails
+// and an undeclared extra fails.
+//
+// Dark completeness is asserted by resolution, not by counting lines. Before
+// B03 the entire styles/dashboard tree contained zero `data-theme` rules (R9:
+// "tema oscuro sin cubrir"), and the naive fix — restating every token under a
+// dark selector — would have produced a scale that looks covered and is in fact
+// a second place to drift. Instead each token declares how it reaches its dark
+// value, and the contract proves that claim:
+//
+//   INVARIANT  same value in both themes; must NOT appear in the dark scope,
+//              and must not secretly reference a token the dark theme rewrites.
+//   ADAPTIVE   one declaration referencing a global token that globals.css
+//              itself redefines under `:root[data-theme="dark-gray"]`. The
+//              reference is resolved here: if globals.css ever stops rewriting
+//              that token, the dashboard role silently loses its dark value and
+//              this fails.
+//   VARIANT    declared in BOTH scopes with values that must actually differ.
+
+const REPO_ROOT = process.cwd();
+
+const TOKENS_CSS_PATH = "frontend/src/styles/dashboard/tokens.css";
+const GLOBALS_CSS_PATH = "frontend/src/app/globals.css";
+const DASHBOARD_CSS_DIR = "frontend/src/styles/dashboard";
+const FRONTEND_SRC = "frontend/src";
+const THEME_MODULE_PATH = "frontend/src/lib/theme.ts";
+const THEME_INIT_PATH = "frontend/public/theme-init.js";
+
+const FOUNDATION_START = "/* dashboard-foundation-tokens:start";
+const FOUNDATION_END = "dashboard-foundation-tokens:end */";
+const PITCH_START = "/* dashboard-row-pitch-contract:start";
+const PITCH_END = "dashboard-row-pitch-contract:end */";
+
+const LIGHT_SCOPE = ".dashboard-app-shell";
+
+/** Capacity tokens owned by the pitch contract (A05–A07). Never re-owned here. */
+const CAPACITY_OWNED_TOKENS = [
+  "--dash-row-pitch",
+  "--dash-row-gap",
+  "--dash-canvas-reserved",
+  "--dash-table-head-h",
+] as const;
+
+type ThemeClass = "INVARIANT" | "ADAPTIVE" | "VARIANT";
+
+interface CategorySchema {
+  readonly prefix: string;
+  readonly minimum: number;
+  readonly tokens: Readonly<Record<string, ThemeClass>>;
+}
+
+/**
+ * The eight required scales. `minimum` is asserted separately from the roster
+ * so that trimming a category below a usable cardinality fails even if the
+ * roster was trimmed to match.
+ */
+const FOUNDATION_SCHEMA: Readonly<Record<string, CategorySchema>> =
+  Object.freeze({
+    color: {
+      prefix: "--dash-color-",
+      minimum: 12,
+      tokens: {
+        "--dash-color-canvas": "ADAPTIVE",
+        "--dash-color-surface": "ADAPTIVE",
+        "--dash-color-surface-raised": "ADAPTIVE",
+        "--dash-color-surface-muted": "ADAPTIVE",
+        "--dash-color-on-surface": "ADAPTIVE",
+        "--dash-color-on-surface-muted": "ADAPTIVE",
+        "--dash-color-outline": "ADAPTIVE",
+        "--dash-color-outline-subtle": "ADAPTIVE",
+        "--dash-color-primary": "ADAPTIVE",
+        "--dash-color-on-primary": "ADAPTIVE",
+        "--dash-color-accent": "ADAPTIVE",
+        "--dash-color-success": "ADAPTIVE",
+        "--dash-color-error": "ADAPTIVE",
+        "--dash-color-info": "ADAPTIVE",
+        "--dash-color-focus-ring": "ADAPTIVE",
+        "--dash-color-field": "VARIANT",
+        "--dash-color-warning": "VARIANT",
+        "--dash-color-overlay-scrim": "VARIANT",
+      },
+    },
+    shape: {
+      prefix: "--dash-shape-",
+      minimum: 6,
+      tokens: {
+        "--dash-shape-none": "INVARIANT",
+        "--dash-shape-xs": "INVARIANT",
+        "--dash-shape-sm": "INVARIANT",
+        "--dash-shape-md": "INVARIANT",
+        "--dash-shape-lg": "INVARIANT",
+        "--dash-shape-xl": "INVARIANT",
+        "--dash-shape-2xl": "INVARIANT",
+        "--dash-shape-full": "INVARIANT",
+      },
+    },
+    elevation: {
+      prefix: "--dash-elevation-",
+      minimum: 4,
+      tokens: {
+        "--dash-elevation-none": "INVARIANT",
+        "--dash-elevation-raised": "ADAPTIVE",
+        "--dash-elevation-menu": "ADAPTIVE",
+        "--dash-elevation-dialog": "ADAPTIVE",
+      },
+    },
+    "state-layer": {
+      prefix: "--dash-state-",
+      minimum: 5,
+      tokens: {
+        "--dash-state-hover-opacity": "VARIANT",
+        "--dash-state-pressed-opacity": "VARIANT",
+        "--dash-state-selected-opacity": "VARIANT",
+        "--dash-state-focus-opacity": "VARIANT",
+        "--dash-state-layer-color": "VARIANT",
+        "--dash-state-disabled-opacity": "INVARIANT",
+      },
+    },
+    spacing: {
+      prefix: "--dash-space-",
+      minimum: 6,
+      tokens: {
+        "--dash-space-0": "INVARIANT",
+        "--dash-space-1": "INVARIANT",
+        "--dash-space-2": "INVARIANT",
+        "--dash-space-3": "INVARIANT",
+        "--dash-space-4": "INVARIANT",
+        "--dash-space-5": "INVARIANT",
+        "--dash-space-6": "INVARIANT",
+      },
+    },
+    density: {
+      prefix: "--dash-density-",
+      minimum: 4,
+      tokens: {
+        "--dash-density-control-compact": "INVARIANT",
+        "--dash-density-control-regular": "INVARIANT",
+        "--dash-density-control-comfortable": "INVARIANT",
+        "--dash-density-inset-compact": "INVARIANT",
+        "--dash-density-inset-regular": "INVARIANT",
+        "--dash-density-inset-comfortable": "INVARIANT",
+      },
+    },
+    typography: {
+      prefix: "--dash-text-",
+      minimum: 10,
+      tokens: {
+        "--dash-text-family": "INVARIANT",
+        "--dash-text-label-size": "INVARIANT",
+        "--dash-text-label-weight": "INVARIANT",
+        "--dash-text-label-leading": "INVARIANT",
+        "--dash-text-label-tracking": "INVARIANT",
+        "--dash-text-body-size": "INVARIANT",
+        "--dash-text-body-weight": "INVARIANT",
+        "--dash-text-body-leading": "INVARIANT",
+        "--dash-text-body-strong-weight": "INVARIANT",
+        "--dash-text-section-size": "INVARIANT",
+        "--dash-text-section-weight": "INVARIANT",
+        "--dash-text-section-leading": "INVARIANT",
+        "--dash-text-section-tracking": "INVARIANT",
+        "--dash-text-title-size": "INVARIANT",
+        "--dash-text-title-weight": "INVARIANT",
+        "--dash-text-title-leading": "INVARIANT",
+        "--dash-text-metric-size": "INVARIANT",
+        "--dash-text-metric-weight": "INVARIANT",
+        "--dash-text-metric-leading": "INVARIANT",
+      },
+    },
+    motion: {
+      prefix: "--dash-motion-",
+      minimum: 4,
+      tokens: {
+        "--dash-motion-fast": "INVARIANT",
+        "--dash-motion-standard": "INVARIANT",
+        "--dash-motion-slow": "INVARIANT",
+        "--dash-motion-ease-standard": "INVARIANT",
+        "--dash-motion-ease-emphasized": "INVARIANT",
+      },
+    },
+  });
+
+const SCHEMA_ENTRIES: ReadonlyArray<readonly [string, ThemeClass]> =
+  Object.values(FOUNDATION_SCHEMA).flatMap((category) =>
+    Object.entries(category.tokens).map(
+      ([token, themeClass]) => [token, themeClass] as const,
+    ),
+  );
+
+const SCHEMA_TOKENS: readonly string[] = SCHEMA_ENTRIES.map(([token]) => token);
+
+function readSource(repoRelativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, repoRelativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+/**
+ * Strips comments so the contract is asserted against DECLARATIONS.
+ *
+ * tokens.css documents the very things it forbids — the density section names
+ * `--dash-row-pitch*` to explain why row height is not a density token, the
+ * motion section names the height properties R11 bans — so a naive text scan
+ * fails on the prose that exists to prevent the violation.
+ */
+function stripComments(source: string): string {
+  return source.replace(/\/\*[\s\S]*?\*\//g, " ");
+}
+
+function sliceBlock(source: string, startMarker: string, endMarker: string): string {
+  const start = source.indexOf(startMarker);
+  assert.ok(start >= 0, `missing block marker: ${startMarker}`);
+  // Searched from the opening marker, never from the file head: the dark
+  // palette block closes on a bare "}", and the first one in globals.css
+  // belongs to a rule hundreds of lines earlier.
+  const end = source.indexOf(endMarker, start + startMarker.length);
+  assert.ok(end > start, `missing block marker: ${endMarker}`);
+  return source.slice(start, end + endMarker.length);
+}
+
+const TOKENS_CSS = readSource(TOKENS_CSS_PATH);
+const GLOBALS_CSS = readSource(GLOBALS_CSS_PATH);
+
+const FOUNDATION_BLOCK = sliceBlock(TOKENS_CSS, FOUNDATION_START, FOUNDATION_END);
+const PITCH_BLOCK = sliceBlock(TOKENS_CSS, PITCH_START, PITCH_END);
+
+/** Rule bodies inside the foundation, keyed by selector, comments removed. */
+function parseRules(block: string): Map<string, string> {
+  const rules = new Map<string, string>();
+  for (const match of stripComments(block).matchAll(
+    /([^{}]+)\{([^{}]*)\}/g,
+  )) {
+    const selector = match[1].trim().replace(/\s+/g, " ");
+    assert.ok(
+      !rules.has(selector),
+      `the foundation declares the selector "${selector}" twice`,
+    );
+    rules.set(selector, match[2]);
+  }
+  return rules;
+}
+
+function parseDeclarations(body: string): Array<readonly [string, string]> {
+  return [...body.matchAll(/(--[a-z0-9-]+)\s*:\s*([^;]+);/g)].map(
+    (match) => [match[1], match[2].trim()] as const,
+  );
+}
+
+const FOUNDATION_RULES = parseRules(FOUNDATION_BLOCK);
+
+const DARK_THEME_MODE = (() => {
+  const match = readSource(THEME_MODULE_PATH).match(
+    /export const DARK_GRAY_THEME_MODE = "([^"]+)";/,
+  );
+  assert.ok(match, `${THEME_MODULE_PATH}: DARK_GRAY_THEME_MODE must stay identifiable`);
+  return match[1];
+})();
+
+const DARK_SCOPE = `:root[data-theme="${DARK_THEME_MODE}"] ${LIGHT_SCOPE}`;
+
+function declarationsFor(selector: string): Map<string, string> {
+  const body = FOUNDATION_RULES.get(selector);
+  assert.ok(body !== undefined, `the foundation must declare the scope "${selector}"`);
+  const map = new Map<string, string>();
+  for (const [token, value] of parseDeclarations(body)) {
+    assert.ok(
+      !map.has(token),
+      `"${token}" is declared twice inside the same scope "${selector}"`,
+    );
+    map.set(token, value);
+  }
+  return map;
+}
+
+const LIGHT_DECLARATIONS = declarationsFor(LIGHT_SCOPE);
+const DARK_DECLARATIONS = declarationsFor(DARK_SCOPE);
+
+/** Global custom properties globals.css re-authors under the dark selector. */
+const DARK_REDEFINED_GLOBALS: ReadonlySet<string> = new Set(
+  parseDeclarations(
+    sliceBlock(
+      GLOBALS_CSS,
+      `:root[data-theme="${DARK_THEME_MODE}"] {`,
+      "}",
+    ),
+  ).map(([token]) => token),
+);
+
+function referencedTokens(value: string): string[] {
+  return [...value.matchAll(/var\(\s*(--[a-z0-9-]+)/g)].map((match) => match[1]);
+}
+
+function collectFilesRecursive(repoRelativeDir: string, extensions: RegExp): string[] {
+  const absoluteDir = resolve(REPO_ROOT, repoRelativeDir);
+  const found: string[] = [];
+
+  for (const entry of readdirSync(absoluteDir, { withFileTypes: true })) {
+    const absoluteEntry = join(absoluteDir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(
+        ...collectFilesRecursive(
+          relative(REPO_ROOT, absoluteEntry).replace(/\\/g, "/"),
+          extensions,
+        ),
+      );
+      continue;
+    }
+    if (entry.isFile() && extensions.test(entry.name)) {
+      found.push(relative(REPO_ROOT, absoluteEntry).replace(/\\/g, "/"));
+    }
+  }
+
+  return found;
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T1–T2 · the eight scales exist and carry a usable cardinality.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the foundation declares all eight required scales", () => {
+  assert.deepEqual(
+    Object.keys(FOUNDATION_SCHEMA),
+    [
+      "color",
+      "shape",
+      "elevation",
+      "state-layer",
+      "spacing",
+      "density",
+      "typography",
+      "motion",
+    ],
+    "B03 requires exactly these eight categories",
+  );
+
+  for (const [name, category] of Object.entries(FOUNDATION_SCHEMA)) {
+    const declared = [...LIGHT_DECLARATIONS.keys()].filter((token) =>
+      token.startsWith(category.prefix),
+    );
+    assert.ok(
+      declared.length > 0,
+      `the "${name}" scale is empty — a declared-but-unpopulated category is not a scale`,
+    );
+    assert.ok(
+      declared.length >= category.minimum,
+      `the "${name}" scale declares ${declared.length} tokens, below its minimum of ${category.minimum}`,
+    );
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T5 + fail-closed census · schema and CSS agree in BOTH directions.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the physical token set is exactly the normative token set", () => {
+  const declared = [...LIGHT_DECLARATIONS.keys()].sort();
+  const expected = [...SCHEMA_TOKENS].sort();
+
+  assert.equal(
+    new Set(expected).size,
+    expected.length,
+    "the normative schema carries no duplicate token",
+  );
+  assert.deepEqual(
+    expected.filter((token) => !declared.includes(token)),
+    [],
+    "normative foundation tokens missing from tokens.css",
+  );
+  assert.deepEqual(
+    declared.filter((token) => !expected.includes(token)),
+    [],
+    "tokens declared in the foundation but absent from the schema — silent extras are not allowed",
+  );
+  assert.deepEqual(declared, expected);
+});
+
+test("every foundation token belongs to exactly one declared category", () => {
+  for (const token of SCHEMA_TOKENS) {
+    const owners = Object.entries(FOUNDATION_SCHEMA).filter(([, category]) =>
+      token.startsWith(category.prefix),
+    );
+    assert.equal(
+      owners.length,
+      1,
+      `"${token}" resolves to ${owners.length} categories; category prefixes must partition the namespace`,
+    );
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T3–T4 + T10 · light/dark completeness against the REAL theme mechanism.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the dark scope matches the theme mechanism the app actually ships", () => {
+  // Derived from theme.ts rather than hardcoded: a renamed mode must break the
+  // contract here instead of leaving a dark scope that never matches anything.
+  assert.ok(
+    FOUNDATION_RULES.has(DARK_SCOPE),
+    `the foundation's dark scope must be "${DARK_SCOPE}"`,
+  );
+  assert.match(
+    readSource(THEME_MODULE_PATH),
+    /document\.documentElement\.dataset\.theme = theme/,
+    "theme.ts must still write the mode onto documentElement.dataset.theme",
+  );
+  assert.match(
+    readSource(THEME_INIT_PATH),
+    /document\.documentElement\.dataset\.theme = theme/,
+    "the pre-paint init must still write the same attribute",
+  );
+  assert.ok(
+    GLOBALS_CSS.includes(`:root[data-theme="${DARK_THEME_MODE}"] {`),
+    "globals.css must remain the owner of the dark palette this foundation resolves against",
+  );
+
+  // No second theme mechanism. B03 integrates with the existing one.
+  for (const rival of [
+    /\.dark\b/,
+    /\[data-color-scheme/,
+    /data-dashboard-theme/,
+    /prefers-color-scheme/,
+  ]) {
+    assert.ok(
+      !rival.test(stripComments(FOUNDATION_BLOCK)),
+      `the foundation must not introduce a second theme mechanism (${rival})`,
+    );
+  }
+});
+
+test("every THEME_VARIANT token is declared in both themes, with different values", () => {
+  const variants = SCHEMA_ENTRIES.filter(([, themeClass]) => themeClass === "VARIANT");
+  assert.ok(variants.length > 0, "a foundation with no theme-variant role proves nothing");
+
+  for (const [token] of variants) {
+    const light = LIGHT_DECLARATIONS.get(token);
+    const dark = DARK_DECLARATIONS.get(token);
+
+    assert.ok(light !== undefined, `"${token}" is THEME_VARIANT but has no light value`);
+    assert.ok(dark !== undefined, `"${token}" is THEME_VARIANT but has no dark value`);
+    // A dark block that restates the light value is duplication wearing the
+    // costume of coverage: it reads as "dark is handled" while changing nothing.
+    assert.notEqual(
+      dark,
+      light,
+      `"${token}" declares an identical value in both themes — classify it ADAPTIVE or INVARIANT instead`,
+    );
+  }
+});
+
+test("the dark scope contains THEME_VARIANT tokens and nothing else", () => {
+  const expectedDark = SCHEMA_ENTRIES.filter(
+    ([, themeClass]) => themeClass === "VARIANT",
+  )
+    .map(([token]) => token)
+    .sort();
+
+  assert.deepEqual(
+    [...DARK_DECLARATIONS.keys()].sort(),
+    expectedDark,
+    "the dark scope must carry exactly the theme-variant roles",
+  );
+});
+
+test("every THEME_ADAPTIVE token resolves to a value the dark theme rewrites", () => {
+  const adaptive = SCHEMA_ENTRIES.filter(([, themeClass]) => themeClass === "ADAPTIVE");
+  assert.ok(adaptive.length > 0, "the adaptive class must be populated or removed");
+
+  for (const [token] of adaptive) {
+    const value = LIGHT_DECLARATIONS.get(token);
+    assert.ok(value !== undefined, `"${token}" is missing from the foundation scope`);
+
+    const references = referencedTokens(value);
+    assert.ok(
+      references.length > 0,
+      `"${token}" is THEME_ADAPTIVE but references no token — it cannot adapt`,
+    );
+    // The claim "dark is covered by reference" is only true while the
+    // referenced global is genuinely re-authored under the dark selector.
+    // This is the assertion that makes R9 fail closed.
+    for (const reference of references) {
+      assert.ok(
+        DARK_REDEFINED_GLOBALS.has(reference),
+        `"${token}" is THEME_ADAPTIVE but "${reference}" is not redefined under the dark selector in globals.css — the role would have no dark value`,
+      );
+    }
+  }
+});
+
+test("no THEME_INVARIANT token is theme-dependent in disguise", () => {
+  for (const [token, themeClass] of SCHEMA_ENTRIES) {
+    if (themeClass !== "INVARIANT") continue;
+
+    assert.ok(
+      !DARK_DECLARATIONS.has(token),
+      `"${token}" is THEME_INVARIANT and must not be restated in the dark scope`,
+    );
+
+    const value = LIGHT_DECLARATIONS.get(token);
+    assert.ok(value !== undefined, `"${token}" is missing from the foundation scope`);
+    for (const reference of referencedTokens(value)) {
+      assert.ok(
+        !DARK_REDEFINED_GLOBALS.has(reference),
+        `"${token}" is classified THEME_INVARIANT but resolves through "${reference}", which the dark theme rewrites — it is ADAPTIVE`,
+      );
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T6 · the foundation stays dashboard-scoped.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("every foundation rule is scoped to the dashboard shell", () => {
+  for (const selector of FOUNDATION_RULES.keys()) {
+    assert.ok(
+      selector.includes(LIGHT_SCOPE),
+      `"${selector}" escapes the dashboard scope — foundation tokens must not leak onto the public surface`,
+    );
+    assert.ok(
+      !/^:root\s*\{?$/.test(selector.trim()),
+      `"${selector}" would declare dashboard tokens globally`,
+    );
+  }
+});
+
+test("no foundation token is declared outside tokens.css", () => {
+  const cssFiles = collectFilesRecursive(FRONTEND_SRC, /\.css$/).filter(
+    (path) => path !== TOKENS_CSS_PATH,
+  );
+  assert.ok(cssFiles.length > 0, "the CSS census must find files");
+
+  for (const path of cssFiles) {
+    const source = stripComments(readSource(path));
+    for (const token of SCHEMA_TOKENS) {
+      assert.ok(
+        !new RegExp(`${token}\\s*:`).test(source),
+        `${path}: declares the foundation token "${token}" — tokens.css is its only owner`,
+      );
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T8 · B03 defines; B04 migrates. Nothing consumes the foundation yet.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the foundation has zero consumers outside its own declaration", () => {
+  const sourceFiles = collectFilesRecursive(
+    FRONTEND_SRC,
+    /\.(css|ts|tsx)$/,
+  ).filter((path) => path !== TOKENS_CSS_PATH);
+
+  for (const path of sourceFiles) {
+    const source = stripComments(readSource(path));
+    for (const token of SCHEMA_TOKENS) {
+      assert.ok(
+        !source.includes(token),
+        `${path}: consumes "${token}". B03 declares the foundation; migrating surfaces onto it is B04, and a consumer here makes that migration invisible in review`,
+      );
+    }
+  }
+});
+
+test("foundation cross-references stay inside the foundation", () => {
+  // The density insets intentionally resolve through the spacing scale. That is
+  // fine — it is one scale composing another inside the same block — but a
+  // foundation token pointing at a RUNTIME dashboard token would make B03 a
+  // consumer of the surfaces it is supposed to precede.
+  const RUNTIME_DASH_TOKENS = [
+    "--dash-accent",
+    "--dash-gap",
+    "--dash-pad-x",
+    "--dash-pad-y",
+    "--dash-rhythm",
+    "--dash-control-h",
+    "--dash-tab-h",
+    "--dash-row-h",
+    "--dash-header-h",
+    "--dash-card-pad",
+    "--dash-secondary-font",
+  ];
+
+  for (const [token, value] of LIGHT_DECLARATIONS) {
+    for (const reference of referencedTokens(value)) {
+      if (reference.startsWith("--dash-")) {
+        assert.ok(
+          SCHEMA_TOKENS.includes(reference),
+          `"${token}" resolves through "${reference}", which is not part of the B03 foundation`,
+        );
+      }
+      assert.ok(
+        !RUNTIME_DASH_TOKENS.includes(reference),
+        `"${token}" resolves through the runtime token "${reference}" — the foundation must not depend on the surfaces it precedes`,
+      );
+    }
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// T7 + T9 · A05–A07 preservation. B03 must not touch the capacity contract.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("the row pitch contract survives B03 intact and parseable", () => {
+  // Restated here rather than delegated: the capacity guard proves the pitch is
+  // readable, and this proves B03 did not become the thing that broke it.
+  const declarations = [
+    ...PITCH_BLOCK.matchAll(/--dash-row-pitch-([a-z]+):\s*([^;]+);/g),
+  ];
+  assert.ok(declarations.length > 0, "the pitch tiers must still be declared");
+
+  for (const [, tier, value] of declarations) {
+    assert.match(
+      value.trim(),
+      /^\d+(?:\.\d+)?px$/,
+      `--dash-row-pitch-${tier} must stay a plain px literal, got "${value.trim()}"`,
+    );
+  }
+
+  for (const [, value] of PITCH_BLOCK.matchAll(/--dash-table-head-h:\s*([^;]+);/g)) {
+    assert.match(
+      value.trim(),
+      /^\d+(?:\.\d+)?px$/,
+      `--dash-table-head-h must stay a plain px literal, got "${value.trim()}"`,
+    );
+  }
+
+  assert.ok(
+    TOKENS_CSS.indexOf(FOUNDATION_END) < TOKENS_CSS.indexOf(PITCH_START),
+    "the foundation must sit before the pitch contract so the capacity owner keeps the last word",
+  );
+});
+
+test("the capacity tokens keep exactly one owner", () => {
+  const outsidePitchContract = stripComments(
+    TOKENS_CSS.replace(PITCH_BLOCK, " "),
+  );
+
+  for (const token of CAPACITY_OWNED_TOKENS) {
+    assert.ok(
+      !new RegExp(`${token}\\s*:`).test(outsidePitchContract),
+      `"${token}" is declared outside the row-pitch contract — B03 must not become a second capacity owner`,
+    );
+  }
+
+  const dashboardCss = collectFilesRecursive(DASHBOARD_CSS_DIR, /\.css$/).filter(
+    (path) => path !== TOKENS_CSS_PATH,
+  );
+  for (const path of dashboardCss) {
+    const source = stripComments(readSource(path));
+    for (const token of CAPACITY_OWNED_TOKENS) {
+      assert.ok(
+        !new RegExp(`${token}\\s*:`).test(source),
+        `${path}: declares "${token}"; the pitch contract in tokens.css is its only owner`,
+      );
+    }
+  }
+});
+
+test("the density scale declares no row height", () => {
+  // Density and row pitch are different owners answering different questions.
+  // A `--dash-density-row-*` here would be a second answer to "how tall is a
+  // row", which is the exact failure the capacity contract was built to end.
+  for (const token of Object.keys(FOUNDATION_SCHEMA.density.tokens)) {
+    assert.ok(
+      !/\b(row|pitch)\b/.test(token.replace(/-/g, " ")),
+      `"${token}" claims row geometry, which belongs to the pitch contract`,
+    );
+  }
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// R11 · motion must not be able to animate a region's height.
+// ─────────────────────────────────────────────────────────────────────────────
+
+test("no motion token exists to animate a region's height", () => {
+  for (const [token, value] of LIGHT_DECLARATIONS) {
+    if (!token.startsWith(FOUNDATION_SCHEMA.motion.prefix)) continue;
+
+    assert.ok(
+      !/height|block-size|inline-size/.test(token),
+      `"${token}" names a size — animating region height thrashes the ResizeObserver that derives capacity (R11)`,
+    );
+    assert.ok(
+      !/height|block-size/.test(value),
+      `"${token}" carries a size in its value; motion tokens are durations and easings only`,
+    );
+  }
+});


### PR DESCRIPTION
## Summary
- Change type: feature (design-system foundation, no runtime consumers)
- Context / issue: Programa B, B03 (nivel 3) del roadmap `docs/audit/AUDITORIA_GLOBAL_DASHBOARD_VETNEB_VS_DRIVE.md` §49. Dependencia formal B01; B01 y B02 cerrados. Cierre exigido por §54 («escalas completas, claro y oscuro»), G5 (§58) y mitigación de R9 (§59–§60).
- What changed: se completa el foundation de tokens dashboard-scoped en `frontend/src/styles/dashboard/tokens.css` con **73 tokens en 8 categorías**, en claro y oscuro, más un contrato ejecutable fail-closed y su documento de implementación. Commit `6013aa45` incorpora la corrección del review de Codex (thread `PRRT_kwDOR5qlsc6aIIdk`, P2): el contrato ahora resuelve las referencias de tema **transitivamente** en vez de comprobar sólo la referencia directa; ver «Modelo de tema» más abajo.

**B03 define el foundation. B04 migra las superficies.** Esa separación es el criterio de cierre, no una preferencia de estilo: en cuanto una superficie consume un token, la definición y la migración quedan en un único diff indistinguible en revisión. Por eso el contrato exige **cero consumidores** y falla si aparece uno.

### Categorías

| Categoría | Tokens |
|---|---|
| color | 18 |
| shape | 8 |
| elevation | 4 |
| state-layer | 6 |
| spacing | 7 |
| density | 6 |
| typography | 19 |
| motion | 5 |
| **Total** | **73** |

Namespace `--dash-<categoría>-<rol>`. Los 8 prefijos se verificaron libres de colisión en `frontend/src`, `test/` y `docs/` antes de crearse. Ningún valor se eligió por criterio estético: cada uno es un token global VETNEB existente, un literal medido en el CSS del dashboard, o una derivación documentada en su propia declaración.

### Modelo de tema

Punto de partida verificado: el árbol `frontend/src/styles/dashboard/**` contenía **0** reglas `data-theme`. El dashboard heredaba el tema exclusivamente de los flips de `globals.css` — que es exactamente R9 («tema oscuro sin cubrir») comprobado, no supuesto.

B03 se integra con el mecanismo real (`:root[data-theme="dark-gray"]`, escrito por `lib/theme.ts` y `public/theme-init.js`); el contrato **deriva el selector desde `theme.ts`** en vez de hardcodearlo. No se introduce `.dark`, `[data-color-scheme]`, `data-dashboard-theme` ni `prefers-color-scheme` como owner.

| Clase | N | Cómo se prueba el valor oscuro |
|---|---|---|
| `THEME_VARIANT` | 8 | Declarado en ambos scopes, valores directos **distintos**, y su fingerprint efectivo también difiere |
| `THEME_ADAPTIVE` | 17 | Se resuelve **transitivamente** todo el árbol `var()` en dos ambientes efectivos (claro/oscuro); el fingerprint resultante debe diferir |
| `THEME_INVARIANT` | 48 | No aparece en el scope oscuro **y** su fingerprint efectivo resuelto transitivamente es idéntico en ambos ambientes |

`THEME_ADAPTIVE` es una variante temática **por indirección**, revisada y aprobada. Completitud claro/oscuro no implica que todos los tokens deban tener valores textualmente distintos: duplicar en oscuro 17 declaraciones idénticas produciría CSS muerto y un segundo sitio donde divergir.

**Corrección post-review (Codex, thread `PRRT_kwDOR5qlsc6aIIdk`, P2, commit `6013aa45`).** La primera versión de este contrato probaba sólo que la **referencia directa** del token apareciera redeclarada en el bloque oscuro — no que el **valor efectivo** cambiara. Eso dejó un agujero real:

```
--dash-color-focus-ring → --clinical-focus-ring → --ring
```

`--clinical-focus-ring` se declara `hsl(var(--ring) / 0.85)` textualmente idéntico en ambos temas; la adaptación real ocurre un nivel más abajo, en `--ring` (182 72% 34% claro, 181 60% 50% oscuro). El contrato anterior veía que `--clinical-focus-ring` "aparecía en el bloque oscuro" y daba el rol por cubierto sin mirar más allá — retirar el override oscuro de `--ring` habría dejado el dashboard con el focus ring de tema claro en modo oscuro mientras el contrato fail-closed seguía en verde.

El contrato ahora resuelve cada token en una **huella estructural** (`resolveThemeFingerprint`) por todo el árbol `var()`, bajo dos ambientes construidos explícitamente (paleta clara/oscura de `globals.css` + foundation claro/oscuro, replicando la cascada real). Falla cerrado ante un ciclo (`--a → --b → --a`, con la cadena completa en el mensaje) y ante una referencia sin resolver — un `var()` roto nunca se trata como invariante. La semántica se aplica simétricamente a ADAPTIVE e INVARIANT.

**Reclasificación consecuente.** El propio endurecimiento del contrato detectó que `--dash-color-on-primary` (`hsl(var(--primary-foreground))`) es genuinamente `THEME_INVARIANT`, no `ADAPTIVE`: `--primary-foreground` es `190 36% 97%`, textualmente idéntico en claro y oscuro. Realineado en el mismo PR (AGENTS.md §4); no toca `tokens.css`, sólo la clasificación en el esquema normativo del test. Conteo resultante: 17 ADAPTIVE + 48 INVARIANT (antes 18 + 47); total 73 y 8 VARIANT sin cambio.

**DARK COMPLETENESS: PASS.**

### Preservación A05–A07

El bloque `dashboard-row-pitch-contract` queda **byte-idéntico**. No se reescribió, no se movió fuera de `tokens.css`, no se renombró, y ningún literal px pasó a `rem`/`calc()`/`clamp()` — la capacity engine los lee en runtime y un `rem` los volvería ilegibles.

```
ROW_PITCH_HASH_BEFORE = f76d889cc2a19a10ac45abb7cb709ffaada744aca553c81e7010b3fd65044093
ROW_PITCH_HASH_AFTER  = f76d889cc2a19a10ac45abb7cb709ffaada744aca553c81e7010b3fd65044093
BYTE_IDENTICAL = YES
```

SHA-256 del bloque delimitado por sus marcadores, normalizado a LF (136 líneas, 6015 B). Ninguno de `--dash-row-pitch-*`, `--dash-row-gap`, `--dash-table-head-h`, `--dash-canvas-reserved` cambió. El foundation se insertó **antes** del bloque, de modo que el capacity owner conserva la última palabra en la cascada.

La escala `density` describe deliberadamente sólo **chrome** (controles e insets): la altura de fila no está ahí, porque un segundo token de altura de fila sería un owner competidor aunque nada lo consumiera todavía. El contrato asegura esa frontera por nombre.

### Contrato ejecutable

`test/architecture/dashboard-foundation-tokens.test.ts` — **19 tests**. Descubre los tokens desde el CSS real y compara contra un esquema normativo **en ambas direcciones**: `EXPECTED ⊆ ACTUAL` y `ACTUAL ⊆ EXPECTED`. Sin extras silenciosos.

Verifica: las 8 categorías y su cardinalidad mínima · THEME_VARIANT con valores directos distintos **y** fingerprint efectivo distinto · THEME_ADAPTIVE con fingerprint efectivo resuelto transitivamente por todo el árbol `var()` · THEME_INVARIANT con fingerprint efectivo idéntico (simétrico) · resolución de fingerprint fail-closed ante ciclo y ante referencia sin resolver · selector oscuro derivado del mecanismo real · scoping a `.dashboard-app-shell` sin invadir el namespace público · cero consumer migration · literales px del row-pitch · owner único de los 4 tokens de capacidad · R11 (ningún token de motion nombra o transporta una altura).

### Controles de mutación

Sobre copia aislada; **el source trackeado nunca se muta**.

| # | Mutación | Resultado |
|---|---|---|
| M1 | Falta token temático claro | FAIL-CLOSED |
| M2 | Falta su contraparte oscura | FAIL-CLOSED |
| M3 | Token duplicado en el mismo scope | FAIL-CLOSED |
| M4 | Categoría completa ausente | FAIL-CLOSED |
| M5 | Row-pitch px → rem | FAIL-CLOSED |
| M6 | Segundo owner de capacidad | FAIL-CLOSED |
| M7 | Consumer migration prematura | FAIL-CLOSED |
| M8 | Eliminar sólo el override oscuro de `--ring`, dejando intacto el de `--clinical-focus-ring` (idéntico en ambos temas) | FAIL-CLOSED — reproduce exactamente el falso verde de Codex sobre `--dash-color-focus-ring` |
| — | Baseline restaurada | PASS |

Además, fixtures sintéticas dentro del propio test prueban el resolver en sí: cadena de 3 niveles (`--a → --b → --c`) con cambio detectado y cambio ausente detectado como tal, ciclo con mensaje limpio, y referencia terminal inexistente con fallo limpio.

### Impacto visual y de seguridad

**EXPECTED VISUAL DIFF: NONE.** Los 73 tokens tienen **0 consumidores**. Sin cambio de DOM, JSX, rutas, layout, geometría, navegación, API, auth ni row-capacity. B04 será el PR que migre superficies.

**SECURITY IMPACT: NONE.** Cero cambios en auth, cookies, sesiones, roles, permisos, API, endpoints, handlers, DB, schema, secretos, dependencias o workflows.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [x] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Único primary scope: `frontend`. `test/architecture/dashboard-foundation-tokens.test.ts` y `docs/implementation/dashboard-b03-foundation-tokens.md` son categorías de soporte de ese mismo scope primario.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference:
- Justification: El cambio no altera fronteras arquitectónicas, modelo de datos, composición ni comportamiento de workflows gobernados. Añade declaraciones CSS custom-property dashboard-scoped sin consumidores, un guard de arquitectura y documentación. No toca `server/`, `drizzle/` ni `.github/workflows/`, y el contrato de capacidad A05–A07 permanece byte-idéntico, por lo que la composición runtime del dashboard es exactamente la anterior.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [x] `pnpm --dir frontend lint` (if frontend affected)
- [x] `pnpm --dir frontend typecheck` (if frontend affected)
- [x] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [x] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Resultados locales observados:

| Gate | Estado |
|---|---|
| B03 contract (19 tests) | PASSED |
| Capacity owner + B01 boundaries + B02 retirement (28 tests) | PASSED |
| `pnpm validate:local` | PASSED — 4214 pass, 0 fail, 1 skip preexistente |
| `pnpm --dir frontend lint` | PASSED |
| `pnpm --dir frontend typecheck` | PASSED |
| `pnpm --dir frontend build` | PASSED |
| `pnpm security:public-surface` | PASSED |
| `git diff --check` | PASSED |

E2E: `pnpm --dir frontend e2e:smoke` (48 passed) corrió sobre el commit inicial del PR, cuando el CSS del dashboard se completó. El commit `6013aa45` (fix del review P2) sólo toca `test/` y `docs/` — `tokens.css` queda **byte-idéntico** al commit anterior (`git diff` vacío sobre ese archivo) — por lo que E2E no se volvió a ejecutar: el runtime que `e2e:smoke` ya validó no cambió. `pnpm audit` no aplica: el PR no toca dependencias ni lockfiles.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

Sin impacto en AuthN/AuthZ ni acceso a datos: el diff sólo añade custom properties CSS sin consumidores, un test de arquitectura y un documento. Sin cambios de dependencias ni lockfiles. Sin migraciones ni schema.

## Rollback
- Trigger: regresión visual inesperada, fallo de contrato en `main`, o decisión de reformular la taxonomía antes de B04.
- Steps: `git revert` de los 2 commits de este PR (`3a35c184`, `6013aa45`).
- Data impact: ninguno. Sin migraciones, sin cambios de schema, sin cambios de API. Como ningún consumidor adoptó los tokens, el revert restaura los valores CSS previos con riesgo residual nulo (§61 del roadmap). El contrato de row-pitch A05–A07 queda idéntico porque B03 nunca lo modifica.

