### PR TITLE
fix(ci): trigger PR Governance on pull_request edited

### DIFF
--- a/.github/workflows/pr-governance.yml
+++ b/.github/workflows/pr-governance.yml
@@ -4,6 +4,11 @@ on:
   pull_request:
     branches:
       - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
   workflow_dispatch:
 
 permissions:

--- a/docs/implementation/pr-governance-metadata-edited-event.md
+++ b/docs/implementation/pr-governance-metadata-edited-event.md
@@ -147,15 +147,20 @@ el bloque `types:` (diff revisado arriba) y que
 
 ## Desbloqueo de PR #1662
 
-**No se puede desbloquear con este fix por sí solo.** GitHub ejecuta el
-workflow `pull_request` con la versión del archivo en la rama **base**
-(`main`), no la del head branch, precisamente para que una PR no pueda
-alterar su propia validación. Este fix debe fusionarse a `main` primero.
+**El fix permanente debe fusionarse a `main` para que futuras ediciones del
+body disparen automáticamente un nuevo `pull_request.edited`.** La activación
+del workflow depende de la definición aplicable al evento, pero el paso
+`actions/checkout` trabaja sobre el merge ref de la PR; por tanto, el código
+relativo ejecutado después del checkout —incluido
+`scripts/governance/pr-governance-validator.mjs`— puede provenir del contenido
+candidato de la propia PR. El trigger y el código ejecutado después del
+checkout son fronteras distintas y no deben presentarse como una única barrera
+de confianza.
 
-Una vez en `main`, el evento mínimo correcto sobre #1662 es
-`pull_request.reopened` — **ya incluido en el set default actual**, sin
-necesitar este fix. Cerrar y reabrir la PR basta. **No ejecutado por Claude**
-(R2/write de GitHub); ver `[MANUAL-NICO]` del informe de esta tarea.
+Para la PR #1662 actual, `pull_request.reopened` ya pertenece al set default
+del workflow anterior, por lo que cerrar/reabrir puede generar el evento nuevo
+sin depender técnicamente de este fix. Operativamente se cierra primero #1663
+para dejar resuelta la causa sistémica antes de reactivar #1662.
 
 ## Exclusiones
 

--- a/docs/implementation/pr-governance-metadata-edited-event.md
+++ b/docs/implementation/pr-governance-metadata-edited-event.md
@@ -1,0 +1,182 @@
+# PR Governance — evento `edited` en el ciclo de vida del trigger
+
+## Objetivo
+
+Que corregir el body de una PR (metadata, no código) dispare un nuevo run de
+`PR Governance` que lea el body corregido, sin abrir una ruta de bypass ni
+debilitar el validador.
+
+## Incidente
+
+[PR #1662](https://github.com/LABVETNEB/PORTAL-VETNEB/pull/1662)
+(`feat/dashboard-b05-surface-inversion`, head
+`0e820061f54f8d2fa9c5b78ec75449c1e31e00b2`) nació con un body libre corto
+(`gh pr create --body "<texto libre>"`). El primer run de `PR Governance`
+(run `32213706227`, job `95951173865`, `run_attempt=1`, creado
+`2026-08-19T03:52:47Z`) falló con:
+
+```
+Missing required section(s): Summary, Scope, Validation, Rollback.
+Select at least one recognized scope checkbox in the Scope section.
+Exactly one scope checkbox must be selected when no mixed-scope exception is declared.
+```
+
+El body remoto se corrigió (`updatedAt` `2026-08-19T03:57:30Z`) para incluir
+las 6 secciones de `.github/PULL_REQUEST_TEMPLATE.md` con `[x] frontend
+runtime` como único scope. Se ejecutó **Re-run failed jobs** sobre el mismo
+run (`run_attempt=2`, job `95952168516`, creado `2026-08-19T03:58:54Z`,
+**después** de la edición) y el job **volvió a fallar con el mismo mensaje,
+byte a byte**.
+
+## Causa raíz
+
+`scripts/governance/pr-governance-validator.mjs` lee el body así:
+
+```js
+const EVENT_PATH = process.env.GITHUB_EVENT_PATH ?? "";
+...
+function readEvent() {
+  return EVENT_PATH ? JSON.parse(readFileSync(EVENT_PATH, "utf8")) : {};
+}
+...
+const body = event.pull_request?.body ?? "";
+```
+
+`GITHUB_EVENT_PATH` apunta a un JSON que GitHub Actions escribe **una sola
+vez, cuando el run se crea** — el snapshot del webhook que disparó ese run.
+**Re-run failed jobs** reejecuta el mismo `run_id` reusando ese mismo
+snapshot; no vuelve a consultar la API de GitHub ni regenera el evento. Por
+construcción, ningún re-run de un run `pull_request` puede ver un body
+editado después de que el run se creó.
+
+Evidencia que lo demuestra, no solo el código:
+
+| | Attempt 1 | Attempt 2 (rerun) |
+|---|---|---|
+| `run_attempt` | 1 | 2 |
+| `created_at` | `03:52:47Z` | `03:58:54Z` |
+| Mensaje de error | idéntico | idéntico, byte a byte |
+
+El body remoto cambió a las `03:57:30Z` — **entre** ambos attempts — y aun
+así el segundo attempt vio el body viejo. Esto sólo es posible si ambos
+attempts comparten el mismo `event.json`.
+
+La segunda causa, ya en `.github/workflows/pr-governance.yml`:
+
+```yaml
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+```
+
+Sin `types:`, GitHub aplica el default para `pull_request`: `opened`,
+`synchronize`, `reopened`. **`edited` no estaba incluido.** Aunque el
+snapshot del evento SÍ se regenera en cada evento `pull_request` nuevo
+(a diferencia de un rerun), editar el body de una PR nunca generaba ese
+evento nuevo porque el workflow no escuchaba `edited`.
+
+## Diagnóstico (§6 de la auditoría)
+
+| | Pregunta | Respuesta | Evidencia |
+|---|---|---|---|
+| D1 | ¿El rerun ve el payload original? | **SÍ** | `run_attempt` 1 vs 2, mismo mensaje de error byte a byte pese al body editado entre ambos |
+| D2 | ¿El body remoto actual satisface el validador? | **SÍ** | `gh pr view 1662` — 6 secciones completas, 1 checkbox de scope marcado |
+| D3 | ¿El workflow corre automáticamente ante `pull_request.edited`? | **NO** (antes del fix) | `on.pull_request` sin `types:` → default `opened`/`synchronize`/`reopened` |
+| D4 | ¿Rerun puede corregir un fallo cuyo único cambio fue metadata? | **NO** | Mismo `GITHUB_EVENT_PATH`, mismo body leído |
+| D5 | ¿Hace falta cambiar B05? | **NO** | B05 no toca CI/governance; incidente puramente de trigger metadata |
+
+## Cambio implementado
+
+`.github/workflows/pr-governance.yml` — único cambio semántico, metadata del
+trigger:
+
+```diff
+ on:
+   pull_request:
+     branches:
+       - main
++    types:
++      - opened
++      - synchronize
++      - reopened
++      - edited
+   workflow_dispatch:
+```
+
+Nada más se tocó: mismo job (`validate-pr-governance`), mismos permisos
+(`contents: read`), mismos pins de acciones, mismo comando del validador,
+misma `concurrency`. Verificado con `git diff` línea por línea antes de
+tocar el digest congelado.
+
+## Seguridad
+
+- **Sin ampliación de superficie de confianza.** El workflow sigue en
+  `pull_request` (código y contexto del fork/head branch), nunca
+  `pull_request_target` (que correría con secretos/permisos de `main` sobre
+  contenido de un head branch no confiable). Verificado: `node
+  scripts/governance/workflow-security-validator.mjs` → PASS antes y después.
+- **Permisos sin cambios**: `contents: read`, sin escritura.
+- **`workflow_dispatch` no es un bypass**: sigue dependiendo del mismo job y
+  el mismo paso `node scripts/governance/pr-governance-validator.mjs`, sin
+  condicional que salte la validación según el evento.
+- **`edited` no relaja ninguna regla del validador.** Un body inválido sigue
+  fallando; sólo cambia CUÁNDO se re-evalúa.
+
+## Validación
+
+| Comando | Estado |
+|---|---|
+| `node scripts/governance/workflow-security-validator.mjs` | PASSED |
+| `node --test test/unit/infrastructure/workflow-security-policy-contract.test.ts` | PASSED (8/8) |
+| `node --test test/unit/infrastructure/pr-governance-trigger-contract.test.ts` | PASSED (6/6, nuevo — incluye 3 mutaciones fail-closed) |
+| `node --test test/unit/infrastructure/pr-governance-*.test.ts` | PASSED |
+| `pnpm typecheck:test` | ver informe final |
+
+Digest congelado en `test/unit/infrastructure/workflow-security-policy-contract.test.ts`:
+
+```
+ANTERIOR = 4e0bf177a8581c9dd655f1ca6aa1510a823cdd976c885c4ba50b41129e4157d7
+NUEVO    = 8dc2bf50342db4e45c7bcb5eadbeeeae28b87ac7b766260b903253ca6ba13947
+```
+
+Realineado sólo después de confirmar que el único byte semántico distinto es
+el bloque `types:` (diff revisado arriba) y que
+`workflow-security-validator.mjs` sigue en PASS.
+
+## Desbloqueo de PR #1662
+
+**No se puede desbloquear con este fix por sí solo.** GitHub ejecuta el
+workflow `pull_request` con la versión del archivo en la rama **base**
+(`main`), no la del head branch, precisamente para que una PR no pueda
+alterar su propia validación. Este fix debe fusionarse a `main` primero.
+
+Una vez en `main`, el evento mínimo correcto sobre #1662 es
+`pull_request.reopened` — **ya incluido en el set default actual**, sin
+necesitar este fix. Cerrar y reabrir la PR basta. **No ejecutado por Claude**
+(R2/write de GitHub); ver `[MANUAL-NICO]` del informe de esta tarea.
+
+## Exclusiones
+
+- No se tocó `scripts/governance/pr-governance-validator.mjs` (semántica del
+  validador intacta).
+- No se tocó `.github/PULL_REQUEST_TEMPLATE.md` (ya exigía correctamente las
+  4 secciones).
+- No se tocó B05 ni ningún archivo de `feat/dashboard-b05-surface-inversion`.
+- No se ejecutó ningún GitHub write (`gh pr edit/close/reopen`, `gh run
+  rerun`, `gh workflow run`).
+- No se modificó branch protection ni required checks.
+
+## Riesgo residual
+
+- El mismo patrón de causa raíz (rerun ≠ evento nuevo) aplica a **cualquier**
+  workflow `pull_request` sin `edited` en sus `types` cuya validación dependa
+  del body/metadata de la PR. Sólo `pr-governance.yml` lee el body; los
+  demás workflows canónicos (`backend-ci`, `frontend-ci`, `e2e-completeness`,
+  `qga-governance`, `visual-regression-manual`,
+  `app-version-force-update`) validan código/impacto, no metadata de PR, así
+  que no comparten este riesgo — no se tocaron.
+- Regla operativa para prevenir la causa de origen (`gh pr create --body`
+  libre) documentada en el informe de esta tarea; su persistencia en
+  `AGENTS.md` requiere un PR separado si Nico lo autoriza.

--- a/test/unit/infrastructure/pr-governance-trigger-contract.test.ts
+++ b/test/unit/infrastructure/pr-governance-trigger-contract.test.ts
@@ -1,0 +1,246 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { load } from "js-yaml";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR Governance · trigger lifecycle contract.
+//
+// Incident #1662: GitHub Actions "Re-run failed jobs" reuses the ORIGINAL
+// event payload (the `GITHUB_EVENT_PATH` snapshot taken when the run was
+// first created), not a live re-fetch of the pull request. The validator
+// (`scripts/governance/pr-governance-validator.mjs`) reads
+// `event.pull_request.body` straight from that snapshot, so re-running a
+// governance failure can never see a body edited after the run started —
+// only a genuinely NEW `pull_request` event carries the current body.
+//
+// Before this fix, `on.pull_request` declared no `types:`, which defaults to
+// `opened` + `synchronize` + `reopened` only. Editing a PR's body/checkboxes
+// fires `pull_request.edited`, which was never in that set, so a corrected
+// body could never trigger a fresh validation run — the PR stayed blocked on
+// a stale failure until a new commit (`synchronize`) or a close/reopen
+// (`reopened`) forced a new event.
+//
+// This contract freezes the trigger lifecycle the fix establishes: the same
+// job, same permissions, same pinned actions, same validator command — the
+// only semantic change is which `pull_request` activity types start a run.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const WORKFLOW_PATH = ".github/workflows/pr-governance.yml";
+
+function readWorkflowSource(repoRelativePath: string): string {
+  return readFileSync(resolve(process.cwd(), repoRelativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+type WorkflowDocument = {
+  readonly on: {
+    readonly pull_request?: {
+      readonly branches?: readonly string[];
+      readonly types?: readonly string[];
+    };
+    readonly workflow_dispatch?: unknown;
+    readonly pull_request_target?: unknown;
+  };
+  readonly permissions?: Readonly<Record<string, string>>;
+  readonly jobs: Readonly<
+    Record<
+      string,
+      {
+        readonly name?: string;
+        readonly if?: string;
+        readonly steps: ReadonlyArray<{
+          readonly name?: string;
+          readonly run?: string;
+          readonly if?: string;
+        }>;
+      }
+    >
+  >;
+};
+
+function parseWorkflow(source: string): WorkflowDocument {
+  return load(source) as WorkflowDocument;
+}
+
+const REQUIRED_TYPES = ["opened", "synchronize", "reopened", "edited"] as const;
+
+/**
+ * Every assertion the fix must satisfy, run against a parsed workflow
+ * document. Shared between the real-file test and the mutation tests below so
+ * the two can never police different rules.
+ */
+function assertTriggerContract(doc: WorkflowDocument): void {
+  // 1. Still listens to pull_request.
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(doc.on, "pull_request"),
+    "PR Governance must still trigger on pull_request",
+  );
+
+  // 2. Target branch is still main.
+  assert.deepEqual(
+    doc.on.pull_request?.branches,
+    ["main"],
+    "PR Governance must still target only main",
+  );
+
+  // 3 & 4. edited is explicit, and opened/synchronize/reopened are not lost.
+  const types = doc.on.pull_request?.types ?? [];
+  for (const requiredType of REQUIRED_TYPES) {
+    assert.ok(
+      types.includes(requiredType),
+      `pull_request.types must include "${requiredType}"`,
+    );
+  }
+  assert.equal(
+    new Set(types).size,
+    REQUIRED_TYPES.length,
+    `pull_request.types must be exactly ${JSON.stringify(REQUIRED_TYPES)}, found ${JSON.stringify(types)}`,
+  );
+
+  // 5. Job name unchanged.
+  const job = doc.jobs["validate-pr-governance"];
+  assert.ok(job, "the validate-pr-governance job must still exist");
+  assert.equal(
+    job.name,
+    "validate-pr-governance",
+    "the job's display name must stay validate-pr-governance",
+  );
+
+  // 6. Permissions stay minimal (contents: read only).
+  assert.deepEqual(
+    doc.permissions,
+    { contents: "read" },
+    "permissions must stay exactly { contents: read }",
+  );
+
+  // 7. Validator command unchanged.
+  const validateStep = job.steps.find((step) =>
+    step.run?.includes("pr-governance-validator.mjs"),
+  );
+  assert.ok(validateStep, "a step invoking pr-governance-validator.mjs must exist");
+  assert.equal(
+    validateStep.run?.trim(),
+    "node scripts/governance/pr-governance-validator.mjs",
+    "the validator invocation must stay exactly this command, no flags or env overrides",
+  );
+
+  // 8. pull_request_target never appears.
+  assert.equal(
+    doc.on.pull_request_target,
+    undefined,
+    "pull_request_target must never be used — it runs with base-branch privileges against head-branch content",
+  );
+
+  // 9. No permission scope is write.
+  for (const [scope, level] of Object.entries(doc.permissions ?? {})) {
+    assert.notEqual(level, "write", `permission "${scope}" must not be write`);
+  }
+
+  // 10. workflow_dispatch exists as a manual escape hatch but is not a bypass:
+  // no job- or step-level `if` conditions on event name that would let a
+  // workflow_dispatch run skip validation while still reporting success.
+  assert.ok(
+    Object.prototype.hasOwnProperty.call(doc.on, "workflow_dispatch"),
+    "workflow_dispatch must remain available for manual re-validation",
+  );
+  assert.equal(job.if, undefined, "the job must not gate itself on event_name");
+  for (const step of job.steps) {
+    assert.equal(
+      step.if,
+      undefined,
+      `step "${step.name}" must not conditionally skip based on event_name`,
+    );
+  }
+}
+
+test("PR Governance workflow trigger lifecycle matches the frozen contract", () => {
+  const doc = parseWorkflow(readWorkflowSource(WORKFLOW_PATH));
+  assertTriggerContract(doc);
+});
+
+test("the real workflow source contains no pull_request_target string anywhere", () => {
+  // Belt-and-suspenders on top of the parsed check (9): a string scan catches
+  // a pull_request_target added as a SIBLING key under `on`, which the parsed
+  // check above would also catch, and one added inside a comment, which a
+  // parser would silently ignore but a human reading the file would not.
+  const source = readWorkflowSource(WORKFLOW_PATH);
+  assert.ok(
+    !source.includes("pull_request_target"),
+    "pull_request_target must not appear anywhere in the workflow, including comments",
+  );
+});
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mutation control — proves the contract above is fail-closed, entirely on
+// in-memory string fixtures. Never mutates the tracked workflow file.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const BASELINE_WORKFLOW = `name: PR Governance
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - edited
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pr-governance-\${{ github.workflow }}-\${{ github.event.pull_request.number || github.ref_name || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  validate-pr-governance:
+    name: validate-pr-governance
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
+        with:
+          node-version: 24
+
+      - name: Validate pull request governance
+        run: node scripts/governance/pr-governance-validator.mjs
+`;
+
+test("M4 — the baseline fixture itself satisfies the trigger contract", () => {
+  assert.doesNotThrow(() => assertTriggerContract(parseWorkflow(BASELINE_WORKFLOW)));
+});
+
+test("M1 — removing 'edited' from types fails closed", () => {
+  const mutated = BASELINE_WORKFLOW.replace("      - edited\n", "");
+  assert.throws(() => assertTriggerContract(parseWorkflow(mutated)), /types must include "edited"/);
+});
+
+test("M2 — widening permissions to write fails closed", () => {
+  const mutated = BASELINE_WORKFLOW.replace("  contents: read", "  contents: write");
+  assert.throws(
+    () => assertTriggerContract(parseWorkflow(mutated)),
+    /permissions must stay exactly/,
+  );
+});
+
+test("M3 — switching to pull_request_target fails closed", () => {
+  const mutated = BASELINE_WORKFLOW.replace("  pull_request:\n", "  pull_request_target:\n");
+  assert.throws(
+    () => assertTriggerContract(parseWorkflow(mutated)),
+    /PR Governance must still trigger on pull_request/,
+  );
+});

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -93,7 +93,7 @@ const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/backend-ci.yml", "ff7fca08d621e757c8aad6b71cbd4d6d48b8ebdff5113c5c29dd574102298a38"],
   [".github/workflows/e2e-completeness.yml", "a4fb65f47d4e7164b0517b9e38487391c5da5881479954f4effcf098a32b414d"],
   [".github/workflows/frontend-ci.yml", "4c062a444de53da74aa928906e828b4a6c94cc50433937c1ee99cff09cf76d8d"],
-  [".github/workflows/pr-governance.yml", "4e0bf177a8581c9dd655f1ca6aa1510a823cdd976c885c4ba50b41129e4157d7"],
+  [".github/workflows/pr-governance.yml", "8dc2bf50342db4e45c7bcb5eadbeeeae28b87ac7b766260b903253ca6ba13947"],
   [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],
   [".github/workflows/visual-regression-manual.yml", "86784fe26f1f15e2ae6fb60ee8c26ef050f311bcebab72a2e1732739e035fee9"],
 ]);


### PR DESCRIPTION
## Summary

- Change type: CI / PR Governance.
- Context / issue: PR #1662 demonstrated that correcting pull-request metadata after the original PR Governance failure does not make a rerun consume the updated PR body.
- What changed: PR Governance now explicitly listens to `opened`, `synchronize`, `reopened`, and `edited`, with a fail-closed trigger contract and the reviewed workflow-security digest realigned to the intentional workflow change.

## Scope

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [x] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Primary scope: `workflows/ci`. Tests and documentation only support this primary scope.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference: Not applicable.
- Justification: This change does not alter application architecture, data models, runtime composition, API boundaries, authentication, package boundaries, or deployment topology. It only corrects the lifecycle of the existing PR Governance workflow while preserving validator semantics, permissions, action pins, job identity, and required-check identity.

## Validation

- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected)
- [ ] `pnpm --dir frontend typecheck` (if frontend affected)
- [ ] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Observed locally:

- `node scripts/governance/workflow-security-validator.mjs`: PASSED.
- workflow-security policy contract: PASSED — 8/8.
- PR Governance trigger contract: PASSED — 6/6.
- Mutation without `edited`: FAIL-CLOSED.
- Mutation with `contents: write`: FAIL-CLOSED.
- Mutation using `pull_request_target`: FAIL-CLOSED.
- `pnpm typecheck`: PASSED.
- `pnpm typecheck:test`: PASSED.
- `pnpm test`: PASSED — 4234 passed / 1 skipped / 0 failed.
- `pnpm build`: PASSED.
- `pnpm validate:local`: PASSED — exit code 0.
- `git diff --check`: PASSED.
- `pnpm security:public-surface`: NOT_RUN — no frontend/public surface changed.
- dependency audits: NOT_RUN — no manifest, dependency, or lockfile changed.

## Security / Regression Checklist

- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

Workflow remains `pull_request`, never `pull_request_target`.
Permissions remain `contents: read`.
No write permissions or secret access were introduced.

## Rollback

- Trigger: PR Governance lifecycle regression, duplicate/unexpected behavior, or workflow-security policy regression attributable to this change.
- Steps: revert commit `6614fbc672f1b0464d7569a64aab1bb2a86f72e3` as one unit, restoring the previous trigger contract and canonical workflow-security digest.
- Data impact: none.

## Out of scope

PR #1662/B05 implementation, frontend runtime, backend runtime, DB/schema, auth, dependencies, branch protection, required-check configuration, secrets, staging, production, and PR-template semantics.
