### PR TITLE
ci(e2e): raise completeness runtime budget

### DIFF
--- a/.github/workflows/e2e-completeness.yml
+++ b/.github/workflows/e2e-completeness.yml
@@ -35,7 +35,7 @@ jobs:
   e2e-full-completeness:
     name: e2e-full-completeness
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 55
 
     steps:
       - name: Checkout
@@ -111,7 +111,11 @@ jobs:
         env:
           # Budget for THIS workload only: the full catalog needs ~31m at --workers=2,
           # so the 30m default stopped guarding against hangs and began truncating
-          # healthy runs. 40m restores headroom and stays under the 45m job cap.
+          # healthy runs. 40m restores headroom. The 55m job cap keeps a 15m outer
+          # envelope for everything Playwright doesn't own — checkout, install,
+          # catalog verify, build, public-surface audit, browser install, and (on
+          # timeout) diagnostics upload, teardown and hygiene — so a healthy suite
+          # can't be cancelled by setup overhead eating into the job's hard cap.
           E2E_GLOBAL_TIMEOUT_MS: "2400000"
 
       - name: Upload Playwright diagnostics

--- a/.github/workflows/e2e-completeness.yml
+++ b/.github/workflows/e2e-completeness.yml
@@ -108,6 +108,11 @@ jobs:
       - name: Run complete cataloged E2E suite
         # Bounded retries rerun complete callbacks; they never skip or relax assertions.
         run: pnpm --dir frontend e2e:full -- --workers=2 --retries=2
+        env:
+          # Budget for THIS workload only: the full catalog needs ~31m at --workers=2,
+          # so the 30m default stopped guarding against hangs and began truncating
+          # healthy runs. 40m restores headroom and stays under the 45m job cap.
+          E2E_GLOBAL_TIMEOUT_MS: "2400000"
 
       - name: Upload Playwright diagnostics
         if: failure()

--- a/docs/ops/CI_PR_CHECKS_RUNBOOK.md
+++ b/docs/ops/CI_PR_CHECKS_RUNBOOK.md
@@ -250,14 +250,15 @@ ejecutar el callback y debe pasar sus assertions; no equivale a skip ni
 Ante fallo final sube `playwright-report` y `test-results`; luego verifica
 teardown, source hygiene y limpia esos outputs del checkout efímero.
 
-Presupuesto de runtime. El job tiene un tope duro de 45 minutos; dentro de
+Presupuesto de runtime. El job tiene un tope duro de 55 minutos; dentro de
 él, el paso `Run complete cataloged E2E suite` declara
 `E2E_GLOBAL_TIMEOUT_MS: "2400000"` (40 minutos) para el `globalTimeout` de
 Playwright:
 
 ```text
-job timeout-minutes            45m   (tope duro, sin cambios)
+job timeout-minutes            55m   (tope duro)
 globalTimeout de completeness  40m   (env del paso, sólo este workload)
+envelope exterior              15m   (job − Playwright; ver abajo)
 globalTimeout por defecto      30m   (frontend/playwright.config.ts, sin cambios)
 ```
 
@@ -266,14 +267,27 @@ El override vive en el paso, no en la configuración: toda otra cohorte —
 minutos. El motivo es capacidad del catálogo, no un defecto funcional: la
 suite completa pasó a necesitar ~31 minutos con `--workers=2`, de modo que 30
 minutos dejaron de detectar cuelgues y empezaron a truncar corridas sanas
-antes de llegar a los specs `visual-linux`. Los ~5 minutos restantes bajo el
-tope del job quedan para teardown, source hygiene y subida de diagnostics.
+antes de llegar a los specs `visual-linux`.
+
+Los 15 minutos de envelope exterior **no son "limpieza después de
+Playwright"**: son presupuesto para todo el trabajo del job que Playwright no
+posee, antes y después del paso — checkout, install de dependencias, verify
+del catálogo, build del frontend, auditoría de superficie pública, instalación
+de dependencias/Chromium, y, si el paso agota su propio `globalTimeout`,
+subida de diagnostics, `Verify E2E teardown` y `Verify source hygiene`. Sin
+ese margen, un setup lento puede cancelar el job por el tope duro antes de que
+una corrida sana termine, aunque Playwright nunca haya llegado a su propio
+límite. Un guard relacional (`test/unit/infrastructure/e2e-completeness-workflow.test.ts`)
+exige `job timeout-minutes − E2E_GLOBAL_TIMEOUT_MS >= 15m`, así que revertir
+el job a 45 minutos o subir el budget de Playwright sin ampliar el job rompe
+el test.
+
 `--workers=2`, `--retries=2`, el catálogo, las assertions y la cobertura no
 cambian; el fix no introduce skips ni retira specs.
 
-Rollback: retirar el bloque `env` del paso devuelve el workload al default de
-30 minutos. Hacerlo sólo cuando la cohorte demuestre headroom suficiente por
-medición, no por suposición.
+Rollback: retirar el bloque `env` del paso y devolver `timeout-minutes` a 45
+recupera el estado previo a este fix. Hacerlo sólo cuando la cohorte
+demuestre headroom suficiente por medición, no por suposición.
 
 `E2E Completeness` no es uno de los cuatro contextos required de `main`, pero
 sí es un check aplicable: mientras esté en `FAILURE` el PR no está READY

--- a/docs/ops/CI_PR_CHECKS_RUNBOOK.md
+++ b/docs/ops/CI_PR_CHECKS_RUNBOOK.md
@@ -250,6 +250,35 @@ ejecutar el callback y debe pasar sus assertions; no equivale a skip ni
 Ante fallo final sube `playwright-report` y `test-results`; luego verifica
 teardown, source hygiene y limpia esos outputs del checkout efímero.
 
+Presupuesto de runtime. El job tiene un tope duro de 45 minutos; dentro de
+él, el paso `Run complete cataloged E2E suite` declara
+`E2E_GLOBAL_TIMEOUT_MS: "2400000"` (40 minutos) para el `globalTimeout` de
+Playwright:
+
+```text
+job timeout-minutes            45m   (tope duro, sin cambios)
+globalTimeout de completeness  40m   (env del paso, sólo este workload)
+globalTimeout por defecto      30m   (frontend/playwright.config.ts, sin cambios)
+```
+
+El override vive en el paso, no en la configuración: toda otra cohorte —
+`e2e:ci` en Frontend CI y las corridas locales — conserva el guard de 30
+minutos. El motivo es capacidad del catálogo, no un defecto funcional: la
+suite completa pasó a necesitar ~31 minutos con `--workers=2`, de modo que 30
+minutos dejaron de detectar cuelgues y empezaron a truncar corridas sanas
+antes de llegar a los specs `visual-linux`. Los ~5 minutos restantes bajo el
+tope del job quedan para teardown, source hygiene y subida de diagnostics.
+`--workers=2`, `--retries=2`, el catálogo, las assertions y la cobertura no
+cambian; el fix no introduce skips ni retira specs.
+
+Rollback: retirar el bloque `env` del paso devuelve el workload al default de
+30 minutos. Hacerlo sólo cuando la cohorte demuestre headroom suficiente por
+medición, no por suposición.
+
+`E2E Completeness` no es uno de los cuatro contextos required de `main`, pero
+sí es un check aplicable: mientras esté en `FAILURE` el PR no está READY
+(AGENTS.md §5.8). "No required" no significa "ignorable en rojo".
+
 Un cambio E2E no está listo si `validate-frontend` pasa pero
 `e2e-full-completeness` falla. Para diagnosticar:
 

--- a/test/unit/infrastructure/e2e-completeness-workflow.test.ts
+++ b/test/unit/infrastructure/e2e-completeness-workflow.test.ts
@@ -275,6 +275,11 @@ test("completeness job preserves Linux baseline compatibility, build ordering an
     VETNEB_E2E_DISABLE_EXTERNAL_EMBEDS: "1",
   });
   assert.equal(runFull.run, "pnpm --dir frontend e2e:full -- --workers=2 --retries=2");
+  assert.deepEqual(
+    runFull.env,
+    { E2E_GLOBAL_TIMEOUT_MS: "2400000" },
+    "the full catalog exceeds Playwright's 30m default, so this step — and only this step — must carry the 40m budget",
+  );
   assert.equal(
     source.includes("VETNEB_E2E_PRODUCTION_RUNNER"),
     false,

--- a/test/unit/infrastructure/e2e-completeness-workflow.test.ts
+++ b/test/unit/infrastructure/e2e-completeness-workflow.test.ts
@@ -260,7 +260,7 @@ test("completeness job preserves Linux baseline compatibility, build ordering an
   const stepNames = steps.map((step) => String(step.name ?? ""));
 
   assert.equal(workflowJob["runs-on"], "ubuntu-latest");
-  assert.equal(workflowJob["timeout-minutes"], 45);
+  assert.equal(workflowJob["timeout-minutes"], 55);
   assert.deepEqual(document.permissions, { contents: "read" });
   assert.equal(mapping(document.concurrency, "concurrency")["cancel-in-progress"], true);
   assert.ok(stepNames.indexOf("Build frontend") < stepNames.indexOf("Run complete cataloged E2E suite"));
@@ -279,6 +279,14 @@ test("completeness job preserves Linux baseline compatibility, build ordering an
     runFull.env,
     { E2E_GLOBAL_TIMEOUT_MS: "2400000" },
     "the full catalog exceeds Playwright's 30m default, so this step — and only this step — must carry the 40m budget",
+  );
+  const jobTimeoutMs = Number(workflowJob["timeout-minutes"]) * 60_000;
+  const playwrightBudgetMs = Number(mapping(runFull.env, "runFull.env").E2E_GLOBAL_TIMEOUT_MS);
+  assert.ok(
+    jobTimeoutMs - playwrightBudgetMs >= 15 * 60_000,
+    "the job cap must reserve at least 15m outside Playwright's own budget for checkout, install, " +
+      "build, browser install and — on timeout — diagnostics, teardown and hygiene; otherwise setup " +
+      "overhead can cancel the job before a healthy suite finishes",
   );
   assert.equal(
     source.includes("VETNEB_E2E_PRODUCTION_RUNNER"),

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -91,7 +91,7 @@ const mutableActionReferences = [
 const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "ff7fca08d621e757c8aad6b71cbd4d6d48b8ebdff5113c5c29dd574102298a38"],
-  [".github/workflows/e2e-completeness.yml", "a4fb65f47d4e7164b0517b9e38487391c5da5881479954f4effcf098a32b414d"],
+  [".github/workflows/e2e-completeness.yml", "2de840c6d7abc4d500ce02fb38f0d6bbbb51639210cef9a094974218f840411b"],
   [".github/workflows/frontend-ci.yml", "4c062a444de53da74aa928906e828b4a6c94cc50433937c1ee99cff09cf76d8d"],
   [".github/workflows/pr-governance.yml", "8dc2bf50342db4e45c7bcb5eadbeeeae28b87ac7b766260b903253ca6ba13947"],
   [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],

--- a/test/unit/infrastructure/workflow-security-policy-contract.test.ts
+++ b/test/unit/infrastructure/workflow-security-policy-contract.test.ts
@@ -91,7 +91,7 @@ const mutableActionReferences = [
 const canonicalWorkflowDigests = new Map<string, string>([
   [".github/workflows/app-version-force-update.yml", "25c69fb58364b709395f0ee920560845a83941eeb86efdd759a69af5f880d701"],
   [".github/workflows/backend-ci.yml", "ff7fca08d621e757c8aad6b71cbd4d6d48b8ebdff5113c5c29dd574102298a38"],
-  [".github/workflows/e2e-completeness.yml", "2de840c6d7abc4d500ce02fb38f0d6bbbb51639210cef9a094974218f840411b"],
+  [".github/workflows/e2e-completeness.yml", "dc71f06c0e5acdfe7e7edd2828e1f2b6a42733d268141599f2f4d4abe8771c48"],
   [".github/workflows/frontend-ci.yml", "4c062a444de53da74aa928906e828b4a6c94cc50433937c1ee99cff09cf76d8d"],
   [".github/workflows/pr-governance.yml", "8dc2bf50342db4e45c7bcb5eadbeeeae28b87ac7b766260b903253ca6ba13947"],
   [".github/workflows/qga-governance.yml", "88ed322d67eda6fbec0a7ed0fa106625a43263a4d6998d6eceb24aeee389b393"],


### PR DESCRIPTION
## Summary
- Change type: CI / E2E Completeness runtime budget.
- Context / issue: the full E2E catalog outgrew Playwright's shared 30-minute global timeout, so healthy runs are truncated before reaching the Linux-only visual baselines.
- What changed: raises the E2E Completeness full-catalog Playwright budget from the shared 30-minute default to a workflow-local 40-minute override, and raises the GitHub Actions job cap from 45 to 55 minutes to preserve a 15-minute outer envelope around it, keeping 2 workers, 2 retries, the full E2E catalog, assertions, skips, permissions, and pinned actions.

Fixes deterministic catalog-capacity exhaustion observed while validating dashboard B06, without changing B06 or any frontend runtime behavior.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [ ] frontend runtime
- [ ] tests
- [x] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

Primary scope: `workflows/ci`. Tests and documentation only guard and document the CI workflow change; they are not separate primary scopes.

## Architecture Decision

- [ ] ADR/RFC linked
- [x] Not applicable

- Reference: Not applicable.
- Justification: This change does not alter application architecture, data models, runtime composition, API boundaries, authentication, package boundaries, or deployment topology. It only raises the Playwright global timeout for the existing E2E Completeness workload, while preserving job identity, required-check identity, permissions, pinned action references, worker and retry counts, and the complete E2E catalog.

## Root cause
E2E Completeness uses Playwright's shared 30-minute global timeout while the current full catalog already consumes approximately 30 minutes on Linux. Run 32315169188 reached the 1800-second limit with 878 passed, 1 skipped, and 57 tests not run. B06's own 24 tests completed successfully; the failure is catalog runtime capacity, not a B06 functional regression.

## Change
- Sets `E2E_GLOBAL_TIMEOUT_MS=2400000` only on the E2E Completeness full-suite step.
- Leaves Playwright's default 30-minute timeout unchanged for every other cohort.
- Raises the GitHub Actions job timeout from 45 to 55 minutes, preserving a 15-minute total non-Playwright envelope for setup, dependency/build overhead, browser installation, diagnostics, teardown, and source hygiene — not merely cleanup time after Playwright.
- Adds a parser-backed fail-closed guard for the exact workflow-local timeout value.
- Realigns the governed SHA-256 digest and documents the runtime-budget contract.

## Validation
- [x] `pnpm typecheck`
- [x] `pnpm typecheck:test`
- [x] `pnpm test`
- [x] `pnpm build` (if backend affected)
- [ ] `pnpm --dir frontend lint` (if frontend affected)
- [ ] `pnpm --dir frontend typecheck` (if frontend affected)
- [ ] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Observed locally:

- Directed workflow guards: PASSED — 14 tests, 0 failures.
- Guard fail-closure mutations: PASSED — wrong value and missing env both fail closed.
- `node scripts/governance/workflow-security-validator.mjs`: PASSED — QGA-4.2, 7 workflows.
- `pnpm validate:local`: PASSED — 4256 tests, 0 failures, 1 pre-existing skip, exit code 0.
- `git diff --check`: PASSED.
- `pnpm security:public-surface`: NOT_RUN — no frontend or public surface changed.
- dependency audits: NOT_RUN — no manifest, dependency, or lockfile changed.
- `e2e:full` on Win32: BLOCKED by Linux-only pixel baselines; the PR-triggered Linux E2E Completeness run is the authoritative runtime validation.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

Workflow remains `pull_request`, never `pull_request_target`.
Permissions remain `contents: read`.
No write permissions or secret access were introduced, and no action pin changed.

## Rollback
- Trigger: E2E Completeness regression attributable to the raised budget, or a workflow-security policy regression.
- Steps: revert this commit as one unit, restoring the previous step environment, workflow guard, canonical workflow digest, and runbook contract.
- Data impact: none. No runtime, schema, dependency, or frontend behavior is affected.

## Out of scope
- The full catalog remains a single 2-worker job; future catalog growth should be monitored against the 40-minute Playwright budget and 55-minute job cap.
- Pre-existing stale spec-count text elsewhere in the runbook is deliberately left untouched by this CI runtime-budget fix.
- Dashboard B06 and PR #1665 are untouched.

