### PR TITLE
fix(frontend): canonicalize globals opacity utilities

### DIFF
--- a/frontend/src/app/globals.css
+++ b/frontend/src/app/globals.css
@@ -1431,7 +1431,7 @@
   }
 
   .public-hero-action-tile {
-    @apply rounded-xl border border-white/28 bg-white/[0.08] p-4 text-left shadow-sm transition-[background-color,border-color,box-shadow,transform] duration-150 hover:border-white/55 hover:bg-white/[0.14] hover:shadow-[0_18px_44px_rgba(5,28,42,0.18)];
+    @apply rounded-xl border border-white/28 bg-white/8 p-4 text-left shadow-sm transition-[background-color,border-color,box-shadow,transform] duration-150 hover:border-white/55 hover:bg-white/[0.14] hover:shadow-[0_18px_44px_rgba(5,28,42,0.18)];
   }
 
   .public-hero-action-tile-label {
@@ -1455,7 +1455,7 @@
   }
 
   .public-hero-search-dock {
-    @apply mt-8 max-w-3xl rounded-2xl border border-white/20 bg-white/[0.10] p-3 shadow-[0_18px_54px_rgba(5,28,42,0.20)] backdrop-blur;
+    @apply mt-8 max-w-3xl rounded-2xl border border-white/20 bg-white/10 p-3 shadow-[0_18px_54px_rgba(5,28,42,0.20)] backdrop-blur;
   }
 
   .public-hero-search-inner {
@@ -1467,7 +1467,7 @@
   }
 
   .public-hero-scope-item {
-    @apply rounded-full border border-white/24 bg-white/[0.08] px-3 py-1.5 text-xs font-semibold tracking-[0.08em] text-primary-foreground/86;
+    @apply rounded-full border border-white/24 bg-white/8 px-3 py-1.5 text-xs font-semibold tracking-[0.08em] text-primary-foreground/86;
   }
 
   .public-contact-method-grid {
@@ -1475,7 +1475,7 @@
   }
 
   .public-contact-method {
-    @apply rounded-xl border border-white/24 bg-white/[0.08] p-4 text-primary-foreground shadow-sm transition-[background-color,border-color,box-shadow] duration-150 hover:border-white/50 hover:bg-white/[0.14];
+    @apply rounded-xl border border-white/24 bg-white/8 p-4 text-primary-foreground shadow-sm transition-[background-color,border-color,box-shadow] duration-150 hover:border-white/50 hover:bg-white/[0.14];
   }
 
   .public-contact-method-title {


### PR DESCRIPTION
## Summary
- Change type: frontend visual canonicalization.
- Context / issue: close four Tailwind canonical-class diagnostics in the shared public CSS without changing rendered opacity or runtime behavior.
- What changed: canonicalized three `bg-white/[0.08]` utilities to `bg-white/8` and one `bg-white/[0.10]` utility to `bg-white/10`. The non-equivalent `bg-gradient-to-r` suggestion and the two contextual `-webkit-line-clamp` diagnostics remain intentionally unchanged.

## Scope
- [ ] backend runtime
- [x] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception

## Validation
- [ ] `pnpm typecheck`
- [ ] `pnpm typecheck:test`
- [ ] `pnpm test`
- [ ] `pnpm build` (if backend affected)
- [x] `pnpm --dir frontend lint` (if frontend affected)
- [x] `pnpm --dir frontend typecheck` (if frontend affected)
- [x] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable)

Additional validation:
- `pnpm security:public-surface`: PASSED.
- `pnpm --dir frontend e2e:public-clinic`: PASSED — 117 passed.
- `git diff --check`: PASSED.
- `frontend/next-env.d.ts`: unchanged.
- No `playwright-report/` or `test-results/` in the diff.

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed.
- [x] Dependency and supply-chain impact reviewed.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact documented or explicitly not applicable.

## Out of scope
- `bg-gradient-to-r` remains unchanged because Tailwind 4.3.3 does not emit byte/semantic-equivalent fallback CSS for `bg-linear-to-r`.
- The two `-webkit-line-clamp: 1` declarations remain unchanged; adding the standard property only at those two sites would diverge from Tailwind 4.3.3 and six sibling WebKit-only declarations.
- `bg-white/[0.14]` hover states remain unchanged because `/[0.14]` and `/14` are not compile-equivalent.
- No dead-CSS removal, dashboard changes, dependency changes, or configuration changes.

## Rollback
- Trigger: any visual regression, unexpected CSS output, or frontend CI regression attributable to these four canonicalizations.
- Steps: revert the squash merge commit for this PR; no other files or state require rollback.
- Data impact: none.
