### PR TITLE
feat(dashboard): add B07 navigation drawer and rail

### DIFF
--- a/docs/implementation/dashboard-b07-navigation-drawer-rail.md
+++ b/docs/implementation/dashboard-b07-navigation-drawer-rail.md
@@ -1,0 +1,254 @@
+# B07 — NavigationDrawer (256 px) + NavigationRail (80 px)
+
+Nivel 4 del programa B (auditoría §49). Crea las dos primitivas de navegación lateral y su
+contrato geométrico. **No las monta**: esa es la frontera aprobada de este PR.
+
+## 1. Estado base
+
+```text
+rama            feat/dashboard-b07-navigation-drawer-rail
+HEAD            ffccb6a7678d8f61c8c96691885c759fe143e484
+base            origin/main = ffccb6a7 (0 0 respecto de main)
+dependencia     B06 — WorkspaceAppBar (PR #1665, d24c418b)
+prerequisito    PR #1669 — canonicalización de globals.css (GLOBALS_ZERO_DIAGNOSTICS)
+```
+
+`frontend/src/app/globals.css` es valla dura de este PR: quedó canonizado en #1669 y **no aparece
+en el diff de B07**.
+
+## 2. Scope
+
+**Incluido**
+
+- `NavigationDrawer` y `NavigationRail` como primitivas de presentación puras.
+- `dashboardModuleIcons.ts`: dueño único del mapa módulo → glifo.
+- Bloque de tokens geométricos B07 en `tokens.css` y su aplicación en `navigation.css`.
+- Reexports B07 en `presentation/navigation` y refuerzo del guard B01.
+- Contrato estático ejecutable `test/architecture/dashboard-b07-navigation-drawer-rail.test.ts`.
+
+**Excluido (no-alcance explícito)**
+
+- Montar las primitivas en el shell y retirar `DashboardHorizontalNav` / `DashboardModuleRail` → **B08**.
+- Navegación móvil `< 768 px` (dos bottom nav + kebab + module menu) → **B09**.
+- Unificación de los dos app shells de clínica → **B10**.
+- Degradar el hub a «Inicio» y consolidar los mapas de iconos legacy → **B13**.
+- Recaptura de A02 y de A03: sus fixtures no se tocan (delta 0).
+- Medición runtime 256/80 ±1 px → **B08** (§9).
+
+## 3. Decisión arquitectónica: `B07_MODE = G-1`
+
+```text
+B07  crea las primitivas, sus tokens, su CSS, su barrel y su guard.
+B08  las monta, migra los consumidores y retira la navegación legacy.
+B09  resuelve el modelo móvil (< 768 px).
+```
+
+Motivo de la frontera: montar un segundo modelo de navegación junto al vivo produciría **doble
+navegación** visible, movería `main` y re-paginaría los 15 consumidores adaptativos congelados por
+A03 (el margen medido en `admin-clinics @1280x720` es 0.016 px: cualquier delta positivo cuesta una
+fila). Separar creación de montaje deja B07 revertible de forma independiente.
+
+## 4. Arquitectura
+
+| Capa | Rol en B07 |
+|---|---|
+| `features/dashboard/config` | Dueño de ids, orden y labels. B07 no lo modifica. |
+| `features/dashboard/application` | Dueño de la gramática `?module=` (`buildDashboardModuleHref`). |
+| `components/dashboard/*` | **Ubicación física** de las primitivas y del dueño de iconos. |
+| `features/dashboard/presentation/navigation` | **Frontera de reexport**, nunca dueño (B01). |
+
+Las primitivas viven en `components/dashboard/` porque el barrel B01 es un módulo de reexport puro
+cuyos targets deben resolver a `@/components/dashboard/*.tsx`
+(`test/architecture/dashboard-presentation-import-boundaries.test.ts` lo verifica por path). Crear
+implementación física dentro de `presentation/navigation/` convertiría la frontera en un hogar.
+
+**Pureza de presentación.** El cierre de imports de primer orden de ambas primitivas
+(`PublicRouteControl`, `config`, `application`, `clinic-hub-reset`, `routes`, `utils`,
+`dashboardModuleIcons`) no alcanza `@/lib/api` ni la capa `app/` a ninguna profundidad. Por eso los
+dos targets entran en el barrel B01 **bajo el mismo cierre transitivo** que los targets legacy: no
+se añadió excepción, exclusión de path ni allowlist.
+
+## 5. Ownership
+
+```text
+ids / orden / labels        features/dashboard/config/dashboardModules.ts
+href `?module=`             features/dashboard/application/dashboardModuleNavigation.ts
+iconos (React)              components/dashboard/dashboardModuleIcons.ts   ← nuevo, B07
+geometría (px)              styles/dashboard/tokens.css (bloque B07)
+render                      NavigationDrawer.tsx · NavigationRail.tsx
+```
+
+`dashboardModuleIcons.ts` **no es un segundo catálogo**: no posee labels, ni orden, ni aliases, ni
+validación, ni construcción de href. Su exhaustividad es una propiedad de **tipos**
+(`Record<AdminModule, LucideIcon>`), de modo que agregar un módulo al catálogo sin su glifo rompe
+`typecheck`, no un test de censo. El motivo de que los iconos no vivan en `config/` es la regla de
+frontera de esa capa: **sin imports de React**.
+
+Los mapas de iconos legacy (`DashboardModuleRail`, `AdminMobileModuleMenu`, `ClinicMobileBottomNav`,
+el controller admin) **no se migran aquí**: son superficies que poseen B08/B09/B13. B07 no agrega
+una cuarta copia; el dueño nuevo sirve sólo a las primitivas nuevas.
+
+## 6. Matriz canónica (15 módulos)
+
+```text
+Admin   = 10   (ADMIN_MODULE_IDS)
+Clínica =  5   (CLINIC_MODULE_IDS)
+Total   = 15
+```
+
+Las cardinalidades se verifican derivándolas del catálogo, no hardcodeándolas en las primitivas: el
+test parsea `ADMIN_MODULE_IDS`/`CLINIC_MODULE_IDS` desde la fuente y exige 10 / 5 / 15 **antes** de
+iterar, y además falla si cualquiera de esos ids aparece como literal dentro de Drawer o Rail.
+
+## 7. Geometría
+
+| Elemento | Valor | Token |
+|---|---:|---|
+| NavigationDrawer (ancho) | 256 px ±1 | `--dash-nav-drawer-w` + `--dash-nav-band` |
+| NavigationRail (ancho) | 80 px ±1 | `--dash-nav-rail-w` + `--dash-nav-band` |
+| Ítem de drawer (alto) | 40 px | `--dash-nav-item-h` |
+| Ítem de rail (alto) | 56 px | `--dash-nav-rail-item-h` |
+| Radio ítem de rail | 16 px | `--dash-nav-rail-item-radius` |
+| Radio ítem de drawer | pill | `--dash-shape-full` |
+| Padding drawer / rail | 8 px / 8 px 0 | `--dash-space-2` |
+| Padding ítem de drawer | 0 12 px | `--dash-space-3` |
+| Borde derecho | 1 px | `--dash-color-outline-subtle` |
+| Radio contenedor | 0 | `--dash-shape-none` |
+| Sombra | none | `--dash-elevation-none` |
+
+El ancho se aplica como **banda** (`min-inline-size` / `max-inline-size` derivados del token), nunca
+como ancho fijo paralelo, y ningún `.tsx` restata 256/80/40/56/16.
+
+`--dash-nav-rail-item-radius` se declara porque la escala de shape B03 no tiene paso de 16 px
+(cluster en 0.85 rem = 13.6 px y 1.1 rem = 17.6 px): redondear al más cercano sería un cambio
+silencioso de geometría. El ítem de drawer sí usa la escala (`--dash-shape-full`), porque en una
+fila de 40 px un pill **es** el radio 20 px especificado.
+
+**Responsive**
+
+```text
+< 768 px        ninguna de las dos   (modelo móvil = B09)
+768 – 1279 px   NavigationRail
+>= 1280 px      NavigationDrawer
+```
+
+Las dos pueden coexistir en el DOM (es como B08 las montará) sin que se rendericen nunca a la vez:
+el estado base es `display: none` y cada rango de viewport revela exactamente una.
+
+**Sin estado persistido.** No hay `localStorage`, ni storage key nueva, ni botón de colapso manual,
+ni `useState`/`useEffect`: cuál primitiva se ve es función pura del viewport y la decide el CSS.
+
+## 8. Deep links y activación
+
+- Todo href se construye con `buildDashboardModuleHref(basePath, item.moduleId)`; ninguna primitiva
+  contiene `?module=` en código ejecutable.
+- `basePath` sale de `ROUTES.dashboardAdmin` / `ROUTES.dashboard`.
+- Clínica conserva `requestClinicModuleActivate(item.moduleId)` en el click, para que el controller
+  intercambie el módulo antes del commit asíncrono de la URL.
+- Navegación por `PublicRouteControl` (button + `router.push`). Prohibidos y verificados ausentes:
+  `next/link`, `<a>`, `window.location`, `location.href`.
+- Sólo el ítem activo lleva `aria-current="page"`.
+
+## 9. Accesibilidad
+
+```text
+landmark              <nav> con aria-label propio por rol y por primitiva
+                      (drawer: "Navegación lateral de…", rail: "Navegación lateral compacta de…")
+aria-current          únicamente el módulo activo
+drawer                label completo visible = nombre accesible
+rail                  shortLabel visible + aria-label con el label completo + title de apoyo
+iconos                aria-hidden="true" (decorativos)
+foco                  outline: 2px solid var(--dash-color-focus-ring) + outline-offset: 2px
+orden de tab          natural; sin roving tabindex, sin focus trap
+reduced motion        @media (prefers-reduced-motion: reduce) → transition: none
+forced colors         @media (forced-colors: active) → el activo se restata como outline
+```
+
+Dos decisiones que conviene no revertir sin leer esto:
+
+1. **Los landmarks no se llaman «Navegación principal».** La nav horizontal legacy sigue usando ese
+   nombre hasta B08; dos landmarks con el mismo nombre accesible son indistinguibles para un lector
+   de pantalla.
+2. **El bloque CSS de B07 es *unlayered*.** `PublicRouteControl` emite utilidades Tailwind
+   (`focus-visible:outline-none`, `focus-visible:ring-*`) que viven en `@layer utilities`; una regla
+   de foco dentro de `@layer components` perdería la cascada y el bloque sólo *parecería* accesible.
+   Es la misma disciplina que el bloque B06 de `layout.css`.
+
+Los objetivos táctiles `< 768 px` no se tocan: los posee B09.
+
+## 10. Vallas de scope (verificadas por test)
+
+| Valla | Contenido | Estado |
+|---|---|---|
+| B08 | `DashboardHorizontalNav.tsx`, `DashboardModuleRail.tsx` existen y siguen exportados por el barrel | intacto |
+| B09 | `AdminMobileBottomNav`, `ClinicMobileBottomNav`, `AdminMobileModuleMenu` | intacto |
+| B06 | `WorkspaceAppBar` + `--dash-app-bar-h: 56px` declarado una sola vez | intacto |
+| G-1 | ninguna superficie renderiza `<NavigationDrawer>` ni `<NavigationRail>` | verificado |
+
+## 11. Tests
+
+```text
+RED     test/architecture/dashboard-b07-navigation-drawer-rail.test.ts
+        ejecutado ANTES de implementar: 22 fail / 3 pass (las 3 verdes son las vallas
+        B08/B09/G-1, que describen estado preexistente), exit code 1
+GREEN   25 / 25 PASSED tras la implementación
+
+B01     test/architecture/dashboard-presentation-import-boundaries.test.ts   PASSED
+        (reforzado: NavigationDrawer y NavigationRail añadidos a
+        NAVIGATION_REQUIRED_EXPORTS, sin excepciones ni exclusiones de path)
+B06     test/architecture/dashboard-b06-workspace-app-bar.test.ts            PASSED (12/12)
+```
+
+Diseño fail-closed del contrato B07: cada censo comprueba su propia cardinalidad antes de iterar
+(cierre de imports > 1 archivo, 10/5/15 módulos, 6 tokens geométricos), y toda aserción negativa
+corre contra la fuente **sin comentarios**, porque las primitivas documentan deliberadamente los
+constructos que tienen prohibido usar.
+
+## 12. Runtime diferido
+
+```text
+B07_RUNTIME_GEOMETRY = DEFERRED_TO_B08
+B07_RUNTIME_E2E      = NOT_RUN
+```
+
+Motivo real, no administrativo: **bajo G-1 no existe superficie runtime B07**. Ningún consumidor
+monta las primitivas, ninguna clase nueva coincide con DOM existente, y `tokens.css` sólo agrega
+custom properties. Escribir un spec de Playwright para B07 exigiría montar artificialmente los
+componentes o invadir B08; fabricar esa cobertura sería peor que declararla ausente.
+
+Por eso tampoco se tocaron `frontend/e2e/suites/catalog.ts` ni sus censos de completitud: sin spec
+nuevo no hay conteo que realinear.
+
+**B08 hereda la medición.** Debe verificar, sobre superficie montada:
+
+```text
+Drawer 256 ±1 px · Rail 80 ±1 px · ítem drawer 40 px · ítem rail 56 px
+click · estado activo · ?module= · deep link directo · reload · Back · Forward
+desktop · tablet · light · dark-gray
+overflow horizontal = 0 · scroll vertical del documento = 0 · app bar B06 intacta
+```
+
+Ninguno de esos puntos se declara PASSED en B07.
+
+## 13. Riesgo residual
+
+1. **Orden divergente hasta B08.** `DashboardHorizontalNav` ordena los módulos admin por uso
+   (Resumen, Clínicas, Informes…), mientras las primitivas nuevas siguen el orden canónico del
+   catálogo. Conviven sin conflicto porque B07 no monta nada, pero B08 debe elegir explícitamente
+   uno de los dos órdenes al migrar.
+2. **Mapas de iconos legacy duplicados.** Siguen cuatro copias en las superficies de B08/B09/B13.
+   B07 no agrega una quinta, pero tampoco las consolida.
+3. **Tokens huérfanos 72/240.** `--dash-sidebar-rail` (4.5 rem) y `--dash-sidebar-expanded` (15 rem)
+   siguen en `responsive.css` como deuda del sidebar retirado por B02. B07 declara los suyos (80/256)
+   y verifica por test que **no** reutiliza los huérfanos; eliminarlos es limpieza aparte.
+4. **Geometría runtime sin medir.** Ver §12: el ±1 px sólo puede observarse con las primitivas
+   montadas.
+5. **Escala de state-layer sin consumir.** El estado activo usa roles de color (`surface-muted`,
+   `primary`) en vez de la escala `--dash-state-*`, que exigiría `color-mix()` — un mecanismo que
+   hoy no existe en el repo. Introducirlo es una decisión de B04/B12, no de B07.
+
+## 14. Rollback lógico
+
+B07 es revertible de forma independiente: no migra consumidores, no retira nada y no altera DOM
+existente. Revertir el PR elimina tres archivos nuevos, dos bloques CSS delimitados por sentinelas,
+seis líneas del barrel y seis del guard B01; ninguna superficie viva cambia de comportamiento.

--- a/frontend/src/components/dashboard/NavigationDrawer.tsx
+++ b/frontend/src/components/dashboard/NavigationDrawer.tsx
@@ -1,0 +1,122 @@
+"use client";
+
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+import {
+  ADMIN_MODULE_NAV_LABELS,
+  CLINIC_MODULE_NAV_LABELS,
+  type AdminModule,
+  type ClinicModule,
+} from "@/features/dashboard/config";
+import { buildDashboardModuleHref } from "@/features/dashboard/application";
+import {
+  ADMIN_MODULE_ICONS,
+  CLINIC_MODULE_ICONS,
+  type DashboardModuleIcon,
+} from "./dashboardModuleIcons";
+
+/**
+ * B07 - NavigationDrawer, the expanded lateral navigation (>=1280px).
+ *
+ * One vertical list of the modules the role actually has, with the glyph and
+ * the full label visible. Its geometry contract is `--dash-nav-drawer-w`
+ * (256px) with a +/-1px band and `--dash-nav-item-h` (40px) per item, authored
+ * in `styles/dashboard/tokens.css` and applied in
+ * `styles/dashboard/navigation.css` - never restated as a literal here.
+ *
+ * OWNERSHIP. The drawer renders; it owns nothing. Module ids, order and labels
+ * come from `features/dashboard/config`; the `?module=` grammar comes from
+ * `features/dashboard/application` (building "?module=" by hand here is what
+ * let the old surfaces drift); the glyphs come from `dashboardModuleIcons`.
+ *
+ * PRESENTATION-PURE and STATELESS by contract. Nothing in this module's import
+ * closure may reach `@/lib/api` or the `app/` layer, which is what lets it be
+ * re-exported from `features/dashboard/presentation/navigation`. There is no
+ * local state and no persisted expand/collapse preference either: which of the
+ * two primitives is visible is a pure function of the viewport, decided in CSS,
+ * so nothing here can desynchronise from the URL the controller reads.
+ *
+ * NOT MOUNTED YET. B07 creates the primitive; migrating the shell onto it and
+ * retiring `DashboardHorizontalNav`/`DashboardModuleRail` is B08, and the
+ * <768px model is B09. Mounting it now would render two navigation systems at
+ * once and move `main`, re-paging the 15 adaptive consumers frozen by A03.
+ *
+ * @see docs/implementation/dashboard-b07-navigation-drawer-rail.md
+ */
+
+export type NavigationDrawerProps =
+  | { readonly surface: "admin"; readonly activeModule: AdminModule }
+  | { readonly surface: "clinic"; readonly activeModule: ClinicModule };
+
+type NavigationDrawerItem = {
+  readonly moduleId: AdminModule | ClinicModule;
+  readonly label: string;
+  readonly icon: DashboardModuleIcon;
+};
+
+const ADMIN_ITEMS: readonly NavigationDrawerItem[] = ADMIN_MODULE_NAV_LABELS.map(
+  (entry) => ({
+    moduleId: entry.moduleId,
+    label: entry.label,
+    icon: ADMIN_MODULE_ICONS[entry.moduleId],
+  }),
+);
+
+const CLINIC_ITEMS: readonly NavigationDrawerItem[] = CLINIC_MODULE_NAV_LABELS.map(
+  (entry) => ({
+    moduleId: entry.moduleId,
+    label: entry.label,
+    icon: CLINIC_MODULE_ICONS[entry.moduleId],
+  }),
+);
+
+// Role-specific landmark names. Deliberately NOT "Navegación principal": the
+// legacy horizontal nav still carries that name until B08 retires it, and two
+// landmarks sharing one accessible name is a real screen-reader ambiguity.
+const ADMIN_LANDMARK = "Navegación lateral de administración";
+const CLINIC_LANDMARK = "Navegación lateral de clínica";
+
+export function NavigationDrawer({ surface, activeModule }: NavigationDrawerProps) {
+  const isAdmin = surface === "admin";
+  const items = isAdmin ? ADMIN_ITEMS : CLINIC_ITEMS;
+  const basePath = isAdmin ? ROUTES.dashboardAdmin : ROUTES.dashboard;
+
+  return (
+    <nav
+      aria-label={isAdmin ? ADMIN_LANDMARK : CLINIC_LANDMARK}
+      data-dashboard-navigation-drawer={surface}
+      className="dashboard-navigation-drawer"
+    >
+      {items.map((item) => {
+        const Icon = item.icon;
+        const isActive = item.moduleId === activeModule;
+
+        return (
+          <PublicRouteControl
+            key={item.moduleId}
+            href={buildDashboardModuleHref(basePath, item.moduleId)}
+            prefetch={false}
+            variant="bare"
+            aria-current={isActive ? "page" : undefined}
+            data-dashboard-navigation-item={item.moduleId}
+            onClick={() => {
+              // Clinic only: the controller swaps the active module on this
+              // signal, before the async URL commit lands.
+              if (isAdmin) return;
+              requestClinicModuleActivate(item.moduleId);
+            }}
+            className={cn(
+              "dashboard-navigation-drawer-item",
+              isActive && "dashboard-navigation-item-active",
+            )}
+          >
+            <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span className="dashboard-navigation-drawer-label">{item.label}</span>
+          </PublicRouteControl>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/dashboard/NavigationRail.tsx
+++ b/frontend/src/components/dashboard/NavigationRail.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { PublicRouteControl } from "@/components/public/PublicRouteControl";
+import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";
+import { ROUTES } from "@/lib/routes";
+import { cn } from "@/lib/utils";
+import {
+  ADMIN_MODULE_NAV_LABELS,
+  CLINIC_MODULE_NAV_LABELS,
+  type AdminModule,
+  type ClinicModule,
+} from "@/features/dashboard/config";
+import { buildDashboardModuleHref } from "@/features/dashboard/application";
+import {
+  ADMIN_MODULE_ICONS,
+  CLINIC_MODULE_ICONS,
+  type DashboardModuleIcon,
+} from "./dashboardModuleIcons";
+
+/**
+ * B07 - NavigationRail, the compact lateral navigation (768-1279px).
+ *
+ * The same module list as {@link NavigationDrawer} and the same grammar: glyph
+ * as the primary affordance, the catalog's `shortLabel` underneath. Its
+ * geometry contract is `--dash-nav-rail-w` (80px) with a +/-1px band and
+ * `--dash-nav-rail-item-h` (56px) per item, authored in
+ * `styles/dashboard/tokens.css` and applied in
+ * `styles/dashboard/navigation.css` - never restated as a literal here.
+ *
+ * ONE GRAMMAR. The rail this replaces (`DashboardModuleRail`) carries two
+ * navigation models at once - a tab track AND a prev/next pager with a
+ * "Módulo N de 5" counter - so the same intent has two affordances that can
+ * report different states. B07 ships the list and nothing else; the pager is
+ * not reproduced here.
+ *
+ * ACCESSIBLE NAME. The visible text is the compact `shortLabel` ("Manten."),
+ * which is not a usable name on its own, so every control carries the full
+ * `label` as `aria-label`; `title` is a sighted-user affordance on top of it,
+ * never the name itself. The glyph is decorative (`aria-hidden`).
+ *
+ * PRESENTATION-PURE, STATELESS and NOT MOUNTED YET - same B07/G-1 boundary as
+ * the drawer: B08 mounts both and retires the legacy navigation, B09 owns
+ * <768px.
+ *
+ * @see docs/implementation/dashboard-b07-navigation-drawer-rail.md
+ */
+
+export type NavigationRailProps =
+  | { readonly surface: "admin"; readonly activeModule: AdminModule }
+  | { readonly surface: "clinic"; readonly activeModule: ClinicModule };
+
+type NavigationRailItem = {
+  readonly moduleId: AdminModule | ClinicModule;
+  readonly label: string;
+  readonly shortLabel: string;
+  readonly icon: DashboardModuleIcon;
+};
+
+const ADMIN_ITEMS: readonly NavigationRailItem[] = ADMIN_MODULE_NAV_LABELS.map(
+  (entry) => ({
+    moduleId: entry.moduleId,
+    label: entry.label,
+    shortLabel: entry.shortLabel,
+    icon: ADMIN_MODULE_ICONS[entry.moduleId],
+  }),
+);
+
+const CLINIC_ITEMS: readonly NavigationRailItem[] = CLINIC_MODULE_NAV_LABELS.map(
+  (entry) => ({
+    moduleId: entry.moduleId,
+    label: entry.label,
+    shortLabel: entry.shortLabel,
+    icon: CLINIC_MODULE_ICONS[entry.moduleId],
+  }),
+);
+
+// Distinct from the drawer's landmark names on purpose: B08 may keep both
+// primitives in the DOM and let CSS choose, and two navigation landmarks with
+// the same accessible name are indistinguishable to a screen reader.
+const ADMIN_LANDMARK = "Navegación lateral compacta de administración";
+const CLINIC_LANDMARK = "Navegación lateral compacta de clínica";
+
+export function NavigationRail({ surface, activeModule }: NavigationRailProps) {
+  const isAdmin = surface === "admin";
+  const items = isAdmin ? ADMIN_ITEMS : CLINIC_ITEMS;
+  const basePath = isAdmin ? ROUTES.dashboardAdmin : ROUTES.dashboard;
+
+  return (
+    <nav
+      aria-label={isAdmin ? ADMIN_LANDMARK : CLINIC_LANDMARK}
+      data-dashboard-navigation-rail={surface}
+      className="dashboard-navigation-rail"
+    >
+      {items.map((item) => {
+        const Icon = item.icon;
+        const isActive = item.moduleId === activeModule;
+
+        return (
+          <PublicRouteControl
+            key={item.moduleId}
+            href={buildDashboardModuleHref(basePath, item.moduleId)}
+            prefetch={false}
+            variant="bare"
+            aria-label={item.label}
+            aria-current={isActive ? "page" : undefined}
+            title={item.label}
+            data-dashboard-navigation-item={item.moduleId}
+            onClick={() => {
+              // Clinic only: the controller swaps the active module on this
+              // signal, before the async URL commit lands.
+              if (isAdmin) return;
+              requestClinicModuleActivate(item.moduleId);
+            }}
+            className={cn(
+              "dashboard-navigation-rail-item",
+              isActive && "dashboard-navigation-item-active",
+            )}
+          >
+            <Icon className="h-5 w-5 shrink-0" aria-hidden="true" />
+            <span className="dashboard-navigation-rail-label">{item.shortLabel}</span>
+          </PublicRouteControl>
+        );
+      })}
+    </nav>
+  );
+}

--- a/frontend/src/components/dashboard/dashboardModuleIcons.ts
+++ b/frontend/src/components/dashboard/dashboardModuleIcons.ts
@@ -1,0 +1,70 @@
+import {
+  Activity,
+  Building2,
+  ClipboardPlus,
+  FileText,
+  KeyRound,
+  LayoutDashboard,
+  ReceiptText,
+  Route,
+  ScrollText,
+  Settings2,
+  ShieldCheck,
+  TicketCheck,
+  UsersRound,
+  type LucideIcon,
+} from "lucide-react";
+
+import type {
+  AdminModule,
+  ClinicModule,
+} from "@/features/dashboard/config";
+
+/**
+ * Dashboard · module icon owner (B07).
+ *
+ * The ONE place that maps a canonical module id to its glyph. Icons are React
+ * components, so they cannot live in `features/dashboard/config` — that layer
+ * is React-free by contract — but they were also the last piece of the module
+ * table still copied per component (`DashboardModuleRail`,
+ * `AdminMobileModuleMenu`, `ClinicMobileBottomNav`, the admin controller). B07
+ * adds NO fourth copy: the drawer and the rail read their glyphs from here.
+ *
+ * NOT a second catalog. This module owns no label, no order, no alias, no
+ * `?module=` grammar and no validation: those stay single-owned by
+ * `config/dashboardModules.ts` and `application/dashboardModuleNavigation.ts`.
+ * Its exhaustiveness is a TYPE property — `Record<AdminModule, LucideIcon>`
+ * fails typecheck the moment the catalog grows a module without a glyph — so
+ * the mapping cannot drift away from the registry it serves.
+ *
+ * Scope fence: the legacy copies in the components above are NOT migrated here.
+ * Retiring the horizontal nav and the clinic rail is B08, the mobile chrome is
+ * B09 and the hub is B13; rewriting their icon tables now would move surfaces
+ * those blocks own.
+ *
+ * @see docs/implementation/dashboard-b07-navigation-drawer-rail.md
+ */
+
+/** Glyph type for a dashboard module, so consumers never import lucide-react. */
+export type DashboardModuleIcon = LucideIcon;
+
+export const ADMIN_MODULE_ICONS: Record<AdminModule, LucideIcon> = {
+  admin: Settings2,
+  "admin-report-upload": ClipboardPlus,
+  "admin-health": Activity,
+  "admin-clinics": Building2,
+  "admin-particular-tokens": TicketCheck,
+  "admin-pricing": ReceiptText,
+  "admin-sessions": KeyRound,
+  "admin-users-roles": UsersRound,
+  "audit-log": ScrollText,
+  "admin-maintenance": ShieldCheck,
+};
+
+export const CLINIC_MODULE_ICONS: Record<ClinicModule, LucideIcon> = {
+  operaciones: LayoutDashboard,
+  informes: FileText,
+  logistica: Route,
+  perfil: Building2,
+  tokens: KeyRound,
+};

--- a/frontend/src/features/dashboard/presentation/navigation/index.ts
+++ b/frontend/src/features/dashboard/presentation/navigation/index.ts
@@ -31,6 +31,14 @@
  * removed, not modified and not migrated; it is admitted automatically once
  * those two imports are gone.
  *
+ * `NavigationDrawer` and `NavigationRail` are the B07 primitives. They are the
+ * first navigation surfaces here that are NOT legacy re-exports: they were
+ * created by B07, presentation-pure from the start, and no consumer renders
+ * them yet — mounting them and retiring `DashboardHorizontalNav` /
+ * `DashboardModuleRail` is B08. The ownership rule above still holds: their
+ * implementations live at `@/components/dashboard/*` like every other target,
+ * because this barrel is a boundary, not a home.
+ *
  * `AdminDashboardSidebar` and `ClinicDashboardSidebar` are absent because B02
  * retired them (audit §14.3): they had no runtime consumers, so the whole
  * sidebar chain was deleted rather than re-exported. The barrel must never
@@ -48,6 +56,14 @@ export {
   CLINIC_MODULE_RAIL_ITEMS,
   DashboardModuleRail,
 } from "@/components/dashboard/DashboardModuleRail";
+export {
+  NavigationDrawer,
+  type NavigationDrawerProps,
+} from "@/components/dashboard/NavigationDrawer";
+export {
+  NavigationRail,
+  type NavigationRailProps,
+} from "@/components/dashboard/NavigationRail";
 export { AdminMobileBottomNav } from "@/components/dashboard/AdminMobileBottomNav";
 export { ClinicMobileBottomNav } from "@/components/dashboard/ClinicMobileBottomNav";
 export { AdminMobileHubLauncher } from "@/components/dashboard/AdminMobileHubLauncher";

--- a/frontend/src/styles/dashboard/navigation.css
+++ b/frontend/src/styles/dashboard/navigation.css
@@ -278,6 +278,19 @@
   font-weight: var(--dash-text-body-strong-weight);
 }
 
+/* ACTIVE_WINS_OVER_HOVER. The generic :hover rule above outranks the single
+   class of the active rule, so pointing at the selected module would repaint it
+   with the inactive state layer - and on the rail the label owns its own
+   font-weight, leaving nothing to tell it apart. Restate the active colours at
+   a specificity hover cannot beat; no !important, no new token. */
+.dashboard-app-shell
+  .dashboard-navigation-drawer-item.dashboard-navigation-item-active:hover,
+.dashboard-app-shell
+  .dashboard-navigation-rail-item.dashboard-navigation-item-active:hover {
+  background-color: var(--dash-color-surface-muted);
+  color: var(--dash-color-primary);
+}
+
 /* FOCUS_INDICATOR. A real outline, not a suppressed one: the route control
    ships `focus-visible:outline-none`, and this unlayered rule is what restores
    a visible ring. Never replace it with `outline: none` plus a shadow. */

--- a/frontend/src/styles/dashboard/navigation.css
+++ b/frontend/src/styles/dashboard/navigation.css
@@ -160,3 +160,158 @@
   }
 }
 /* dashboard-workspace-layout-polish:end */
+
+/* dashboard-b07-navigation-drawer-rail:start */
+/*
+  B07 - NavigationDrawer (256px) and NavigationRail (80px).
+
+  Applies the geometry ledger of tokens.css to the two lateral primitives. Every
+  number resolves through a token: this block restates none of them.
+
+  UNLAYERED on purpose, like the B06 app-bar block in layout.css. The primitives
+  are authored with the shared route control, which ships Tailwind utilities
+  (`focus-visible:outline-none`, `focus-visible:ring-*`); a rule inside
+  `@layer components` loses to `@layer utilities`, so a layered focus rule here
+  would be silently cancelled and the block would only LOOK accessible.
+
+  ONE VISIBLE PRIMITIVE AT A TIME. Both are hidden by default and revealed by
+  exactly one viewport range each - rail 768-1279, drawer >=1280 - so the two
+  can coexist in the DOM (which is how B08 will mount them) without ever
+  rendering two lateral navigations at once. Below 768px neither exists: that
+  range belongs to the mobile model B09 unifies.
+
+  NO SIZE ANIMATION (R11/A03): nothing here transitions an inline-size, a
+  block-size or a flex-basis. A size transition feeds the ResizeObserver behind
+  the adaptive capacity engine, which makes `limit` oscillate and re-fetch.
+*/
+.dashboard-app-shell .dashboard-navigation-drawer,
+.dashboard-app-shell .dashboard-navigation-rail {
+  display: none;
+  box-sizing: border-box;
+  flex: 0 0 auto;
+  flex-direction: column;
+  block-size: 100%;
+  border-radius: var(--dash-shape-none);
+  border-inline-end: 1px solid var(--dash-color-outline-subtle);
+  box-shadow: var(--dash-elevation-none);
+  background-color: var(--dash-color-surface);
+}
+
+.dashboard-app-shell .dashboard-navigation-drawer {
+  min-inline-size: calc(var(--dash-nav-drawer-w) - var(--dash-nav-band));
+  max-inline-size: calc(var(--dash-nav-drawer-w) + var(--dash-nav-band));
+  gap: var(--dash-space-1);
+  padding: var(--dash-space-2);
+}
+
+.dashboard-app-shell .dashboard-navigation-rail {
+  min-inline-size: calc(var(--dash-nav-rail-w) - var(--dash-nav-band));
+  max-inline-size: calc(var(--dash-nav-rail-w) + var(--dash-nav-band));
+  gap: var(--dash-space-1);
+  padding-block: var(--dash-space-2);
+  padding-inline: 0;
+}
+
+/* Items stretch to the container's content box (column flex default), so their
+   width follows the band instead of being pinned a second time. */
+.dashboard-app-shell .dashboard-navigation-drawer-item,
+.dashboard-app-shell .dashboard-navigation-rail-item {
+  display: flex;
+  flex: 0 0 auto;
+  color: var(--dash-color-on-surface-muted);
+  font-family: var(--dash-text-family);
+  transition-property: background-color, color;
+  transition-duration: var(--dash-motion-fast);
+  transition-timing-function: var(--dash-motion-ease-standard);
+}
+
+.dashboard-app-shell .dashboard-navigation-drawer-item {
+  align-items: center;
+  gap: var(--dash-space-2);
+  min-block-size: var(--dash-nav-item-h);
+  max-block-size: var(--dash-nav-item-h);
+  padding-block: 0;
+  padding-inline: var(--dash-space-3);
+  border-radius: var(--dash-shape-full);
+  font-size: var(--dash-text-body-size);
+  font-weight: var(--dash-text-body-weight);
+}
+
+.dashboard-app-shell .dashboard-navigation-drawer-label {
+  min-inline-size: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.dashboard-app-shell .dashboard-navigation-rail-item {
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--dash-space-1);
+  min-block-size: var(--dash-nav-rail-item-h);
+  max-block-size: var(--dash-nav-rail-item-h);
+  padding-block: var(--dash-space-2);
+  padding-inline: 0;
+  border-radius: var(--dash-nav-rail-item-radius);
+}
+
+.dashboard-app-shell .dashboard-navigation-rail-label {
+  max-inline-size: 100%;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: var(--dash-text-label-size);
+  font-weight: var(--dash-text-label-weight);
+  line-height: var(--dash-text-label-leading);
+}
+
+.dashboard-app-shell .dashboard-navigation-drawer-item:hover,
+.dashboard-app-shell .dashboard-navigation-rail-item:hover {
+  background-color: var(--dash-color-surface-raised);
+  color: var(--dash-color-on-surface);
+}
+
+.dashboard-app-shell .dashboard-navigation-item-active {
+  background-color: var(--dash-color-surface-muted);
+  color: var(--dash-color-primary);
+  font-weight: var(--dash-text-body-strong-weight);
+}
+
+/* FOCUS_INDICATOR. A real outline, not a suppressed one: the route control
+   ships `focus-visible:outline-none`, and this unlayered rule is what restores
+   a visible ring. Never replace it with `outline: none` plus a shadow. */
+.dashboard-app-shell .dashboard-navigation-drawer-item:focus-visible,
+.dashboard-app-shell .dashboard-navigation-rail-item:focus-visible {
+  outline: 2px solid var(--dash-color-focus-ring);
+  outline-offset: 2px;
+}
+
+@media (min-width: 768px) and (max-width: 1279.98px) {
+  .dashboard-app-shell .dashboard-navigation-rail {
+    display: flex;
+  }
+}
+
+@media (min-width: 1280px) {
+  .dashboard-app-shell .dashboard-navigation-drawer {
+    display: flex;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .dashboard-app-shell .dashboard-navigation-drawer-item,
+  .dashboard-app-shell .dashboard-navigation-rail-item {
+    transition: none;
+  }
+}
+
+/* Forced colors replaces the state-layer background, so the active module
+   would become indistinguishable. Restate it as a border the OS preserves. */
+@media (forced-colors: active) {
+  .dashboard-app-shell .dashboard-navigation-item-active {
+    outline: 1px solid CanvasText;
+    outline-offset: -1px;
+  }
+}
+/* dashboard-b07-navigation-drawer-rail:end */

--- a/frontend/src/styles/dashboard/tokens.css
+++ b/frontend/src/styles/dashboard/tokens.css
@@ -395,3 +395,43 @@
   --dash-app-bar-band: 2px;
 }
 /* dashboard-app-bar-geometry:end */
+
+/* dashboard-b07-navigation-geometry:start
+ *
+ * B07 - NavigationDrawer / NavigationRail geometry ledger.
+ *
+ * ONE declaration of the lateral navigation contract for the whole dashboard:
+ * drawer 256px, rail 80px, drawer item 40px, rail item 56px, all with the
+ * +/-1px runtime band the audit specifies (audit 46/49, row B07). Both halves
+ * of each contract live here so no component and no CSS module can restate
+ * either number as a literal.
+ *
+ * BAND, not point - same discipline as the B06 app bar. The drawer and the rail
+ * are INLINE regions rather than height regions, so they do not sit in the
+ * shell height ledger A03 froze; the band is what lets the container keep its
+ * intrinsic box while still being enforceable in CSS, and it keeps the two
+ * primitives measurable by the runtime contract B08 owns.
+ *
+ * The rail item radius is declared here because the B03 shape scale has no
+ * 16px step: it clusters at 0.85rem (13.6px) and 1.1rem (17.6px), and rounding
+ * the audit value to either would be a silent geometry change. The drawer item
+ * uses `--dash-shape-full` instead - a pill on a 40px row IS the specified
+ * 20px radius, expressed through the scale.
+ *
+ * NOT REUSED: `--dash-sidebar-rail` (4.5rem = 72px) and `--dash-sidebar-expanded`
+ * (15rem = 240px) in responsive.css are orphan tokens from the pre-audit
+ * sidebar that B02 retired. They encode the OLD geometry, so B07 declares its
+ * own; removing them is separate cleanup, not this scope.
+ *
+ * Applied in styles/dashboard/navigation.css. Below 768px neither primitive
+ * exists: the admin/clinic mobile navigation keeps its own model until B09.
+ * See docs/implementation/dashboard-b07-navigation-drawer-rail.md. */
+.dashboard-app-shell {
+  --dash-nav-drawer-w: 256px;
+  --dash-nav-rail-w: 80px;
+  --dash-nav-item-h: 40px;
+  --dash-nav-rail-item-h: 56px;
+  --dash-nav-rail-item-radius: 16px;
+  --dash-nav-band: 1px;
+}
+/* dashboard-b07-navigation-geometry:end */

--- a/test/architecture/dashboard-b07-navigation-drawer-rail.test.ts
+++ b/test/architecture/dashboard-b07-navigation-drawer-rail.test.ts
@@ -1,0 +1,816 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// B07 · NavigationDrawer (256px) + NavigationRail (80px) static contract.
+//
+// B07 CREATES the two lateral navigation primitives and their geometry ledger.
+// It does NOT mount them: the shell keeps `DashboardHorizontalNav` and
+// `DashboardModuleRail` until B08 migrates the consumers, and mobile (<768px)
+// stays with B09. That boundary is deliberate — mounting a second navigation
+// model next to the live one would produce double navigation, move `main`, and
+// re-page the 15 adaptive consumers frozen by A03.
+//
+// Because nothing is mounted, there is no runtime surface to measure in B07:
+// the 256/80 ±1px runtime assertion is B08's. This file is therefore the WHOLE
+// executable contract for B07 and is written fail-closed — every census
+// asserts its own cardinality before iterating, so an empty scan or a renamed
+// path fails instead of passing vacuously.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const REPO_ROOT = process.cwd();
+
+const DRAWER_TSX = "frontend/src/components/dashboard/NavigationDrawer.tsx";
+const RAIL_TSX = "frontend/src/components/dashboard/NavigationRail.tsx";
+const ICONS_TS = "frontend/src/components/dashboard/dashboardModuleIcons.ts";
+const NAVIGATION_BARREL =
+  "frontend/src/features/dashboard/presentation/navigation/index.ts";
+const MODULE_CATALOG =
+  "frontend/src/features/dashboard/config/dashboardModules.ts";
+const TOKENS_CSS = "frontend/src/styles/dashboard/tokens.css";
+const NAVIGATION_CSS = "frontend/src/styles/dashboard/navigation.css";
+const RESPONSIVE_CSS = "frontend/src/styles/dashboard/responsive.css";
+const FRONTEND_SRC = "frontend/src";
+
+/** Legacy navigation B08 retires; B07 must leave it standing. */
+const B08_FENCE = [
+  "frontend/src/components/dashboard/DashboardHorizontalNav.tsx",
+  "frontend/src/components/dashboard/DashboardModuleRail.tsx",
+];
+
+/** Mobile navigation B09 unifies; B07 must not touch it. */
+const B09_FENCE = [
+  "frontend/src/components/dashboard/AdminMobileBottomNav.tsx",
+  "frontend/src/components/dashboard/ClinicMobileBottomNav.tsx",
+  "frontend/src/components/dashboard/AdminMobileModuleMenu.tsx",
+];
+
+const APP_BAR_TSX = "frontend/src/components/dashboard/WorkspaceAppBar.tsx";
+
+const DASHBOARD_CSS_FILES = [
+  "index.css",
+  "interactions.css",
+  "layout.css",
+  "mobile-admin.css",
+  "mobile-clinic.css",
+  "navigation.css",
+  "responsive.css",
+  "shell.css",
+  "surfaces.css",
+  "tables.css",
+  "tokens.css",
+  "zero-scroll.css",
+].map((name) => `frontend/src/styles/dashboard/${name}`);
+
+const TOKEN_BLOCK_START = "/* dashboard-b07-navigation-geometry:start";
+const TOKEN_BLOCK_END = "dashboard-b07-navigation-geometry:end */";
+const CSS_BLOCK_START = "/* dashboard-b07-navigation-drawer-rail:start */";
+const CSS_BLOCK_END = "/* dashboard-b07-navigation-drawer-rail:end */";
+
+/** The B07 geometry ledger: token name -> the literal it owns. */
+const GEOMETRY_TOKENS: Readonly<Record<string, string>> = {
+  "--dash-nav-drawer-w": "256px",
+  "--dash-nav-rail-w": "80px",
+  "--dash-nav-item-h": "40px",
+  "--dash-nav-rail-item-h": "56px",
+  "--dash-nav-rail-item-radius": "16px",
+  "--dash-nav-band": "1px",
+};
+
+/**
+ * Orphan sidebar tokens left in responsive.css by the pre-audit sidebar
+ * (4.5rem = 72px, 15rem = 240px). B07 targets 80/256, so reusing them would
+ * silently ship the OLD geometry. They are neither reused nor removed here.
+ */
+const LEGACY_SIDEBAR_TOKENS = [
+  "--dash-sidebar-rail",
+  "--dash-sidebar-expanded",
+];
+
+/** Layers the primitives must never reach, directly or transitively. */
+const FORBIDDEN_PRESENTATION_IMPORTS = ["@/lib/api", "@/app/", "@/app"] as const;
+
+function read(relativePath: string): string {
+  return readFileSync(resolve(REPO_ROOT, relativePath), "utf8").replace(
+    /\r\n/g,
+    "\n",
+  );
+}
+
+/**
+ * Executable projection. Every "must NOT contain" assertion runs against this:
+ * the primitives deliberately DOCUMENT the constructs they are forbidden to
+ * use (`?module=`, `next/link`, the legacy sidebar tokens), and failing on that
+ * prose would push the contract towards undocumented code.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ");
+}
+
+function sliceBlock(source: string, start: string, end: string): string {
+  const from = source.indexOf(start);
+  assert.ok(from !== -1, `missing block start ${start}`);
+  const to = source.indexOf(end, from + start.length);
+  assert.ok(to > from, `missing block end ${end}`);
+  return source.slice(from, to + end.length);
+}
+
+function resolveImport(fromFile: string, specifier: string): string | null {
+  let candidateBase: string;
+  if (specifier.startsWith("@/")) {
+    candidateBase = join(FRONTEND_SRC, specifier.slice(2));
+  } else if (specifier.startsWith(".")) {
+    candidateBase = join(dirname(fromFile), specifier);
+  } else {
+    return null;
+  }
+
+  for (const suffix of ["", ".ts", ".tsx", "/index.ts", "/index.tsx"]) {
+    const candidate = `${candidateBase}${suffix}`.split("\\").join("/");
+    const absolute = resolve(REPO_ROOT, candidate);
+    if (existsSync(absolute) && /\.(ts|tsx)$/.test(candidate)) {
+      return candidate;
+    }
+  }
+  return null;
+}
+
+function importSpecifiers(source: string): readonly string[] {
+  const found: string[] = [];
+  for (const match of source.matchAll(/from\s+"([^"]+)"/g)) {
+    found.push(match[1]);
+  }
+  for (const match of source.matchAll(/import\("([^"]+)"\)/g)) {
+    found.push(match[1]);
+  }
+  return found;
+}
+
+/** Whole first-party import closure of a file, repo-relative. */
+function importClosure(entry: string): {
+  readonly files: ReadonlySet<string>;
+  readonly rawSpecifiers: ReadonlyMap<string, readonly string[]>;
+} {
+  const files = new Set<string>();
+  const rawSpecifiers = new Map<string, readonly string[]>();
+  const queue = [entry];
+
+  while (queue.length > 0) {
+    const current = queue.pop() as string;
+    if (files.has(current)) continue;
+    files.add(current);
+
+    const specifiers = importSpecifiers(read(current));
+    rawSpecifiers.set(current, specifiers);
+
+    for (const specifier of specifiers) {
+      const resolved = resolveImport(current, specifier);
+      if (resolved && !files.has(resolved)) {
+        queue.push(resolved);
+      }
+    }
+  }
+
+  return { files, rawSpecifiers };
+}
+
+/** Ids of a `const NAME = [...] as const;` array in the catalog source. */
+function catalogIds(source: string, constantName: string): readonly string[] {
+  const match = source.match(
+    new RegExp(`export const ${constantName} = \\[([^\\]]*)\\] as const;`),
+  );
+  assert.ok(match, `${MODULE_CATALOG} must declare ${constantName}`);
+  return [...match[1].matchAll(/"([^"]+)"/g)].map((entry) => entry[1]);
+}
+
+const CATALOG = read(MODULE_CATALOG);
+const ADMIN_MODULE_IDS = catalogIds(CATALOG, "ADMIN_MODULE_IDS");
+const CLINIC_MODULE_IDS = catalogIds(CATALOG, "CLINIC_MODULE_IDS");
+
+// ── T1 · Existence, ownership and the client boundary ────────────────────────
+
+test("B07 · the two primitives and the icon owner exist at their canonical paths", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX, ICONS_TS]) {
+    assert.ok(
+      existsSync(resolve(REPO_ROOT, path)),
+      `${path} must exist — B07 has no alternative location. The physical implementation lives in components/dashboard so the B01 barrel can keep re-exporting from @/components/dashboard/*`,
+    );
+    assert.equal(
+      relative(REPO_ROOT, resolve(REPO_ROOT, path)).split("\\").join("/"),
+      path,
+      "contract paths are repo-relative and canonical",
+    );
+  }
+
+  assert.equal(
+    existsSync(
+      resolve(
+        REPO_ROOT,
+        "frontend/src/features/dashboard/presentation/navigation/NavigationDrawer.tsx",
+      ),
+    ),
+    false,
+    "presentation/navigation is a re-export boundary, never a physical owner (B01)",
+  );
+});
+
+test("B07 · both primitives are client components exporting their declared contract", () => {
+  const drawer = read(DRAWER_TSX);
+  assert.ok(drawer.startsWith('"use client";'), "the drawer is a client component");
+  assert.ok(drawer.includes("export function NavigationDrawer({"));
+  assert.ok(drawer.includes("export type NavigationDrawerProps ="));
+
+  const rail = read(RAIL_TSX);
+  assert.ok(rail.startsWith('"use client";'), "the rail is a client component");
+  assert.ok(rail.includes("export function NavigationRail({"));
+  assert.ok(rail.includes("export type NavigationRailProps ="));
+});
+
+test("B07 · both primitives carry the data contract markers a runtime spec can measure", () => {
+  const drawer = read(DRAWER_TSX);
+  assert.ok(drawer.includes("data-dashboard-navigation-drawer={surface}"));
+  assert.ok(drawer.includes("data-dashboard-navigation-item={item.moduleId}"));
+
+  const rail = read(RAIL_TSX);
+  assert.ok(rail.includes("data-dashboard-navigation-rail={surface}"));
+  assert.ok(rail.includes("data-dashboard-navigation-item={item.moduleId}"));
+
+  // A04 / security:public-surface — a data-* NAME may not carry a sensitive
+  // stem. `tokens` is a legitimate module id and travels as a VALUE.
+  for (const source of [drawer, rail]) {
+    for (const match of source.matchAll(/\bdata-([a-z0-9-]+)=/g)) {
+      assert.equal(
+        /(token|secret|password|session|cookie|jwt|email|private)/.test(match[1]),
+        false,
+        `data-${match[1]} carries a sensitive stem in its NAME`,
+      );
+    }
+  }
+});
+
+// ── T2 · The B01 barrel re-exports, it never owns ────────────────────────────
+
+test("B07 · presentation/navigation re-exports both primitives from components/dashboard", () => {
+  const barrel = read(NAVIGATION_BARREL);
+
+  assert.ok(
+    barrel.includes(
+      'export {\n  NavigationDrawer,\n  type NavigationDrawerProps,\n} from "@/components/dashboard/NavigationDrawer";',
+    ),
+    "the navigation barrel must re-export NavigationDrawer from components/dashboard",
+  );
+  assert.ok(
+    barrel.includes(
+      'export {\n  NavigationRail,\n  type NavigationRailProps,\n} from "@/components/dashboard/NavigationRail";',
+    ),
+    "the navigation barrel must re-export NavigationRail from components/dashboard",
+  );
+
+  // The icon owner is an implementation detail of presentation, not a
+  // navigation surface: exposing it through the barrel would invite consumers
+  // to build their own nav from the icon map.
+  assert.equal(
+    barrel.includes("dashboardModuleIcons"),
+    false,
+    "the icon owner is not a navigation surface and stays out of the barrel",
+  );
+});
+
+// ── T3 · Presentation purity, over the real import closure ───────────────────
+
+test("B07 · neither primitive reaches the data layer or the app layer at any depth", () => {
+  for (const entry of [DRAWER_TSX, RAIL_TSX]) {
+    const { files, rawSpecifiers } = importClosure(entry);
+
+    assert.ok(files.has(entry), "the closure must contain its own entry point");
+    assert.ok(
+      files.size > 1,
+      `${entry}: the closure resolved to a single file; a primitive that imports nothing first-party would pass this contract vacuously`,
+    );
+
+    const violations: string[] = [];
+    for (const [file, specifiers] of rawSpecifiers) {
+      for (const specifier of specifiers) {
+        for (const forbidden of FORBIDDEN_PRESENTATION_IMPORTS) {
+          if (specifier === forbidden || specifier.startsWith(`${forbidden}/`)) {
+            violations.push(`${file} imports ${specifier}`);
+          }
+        }
+      }
+    }
+
+    assert.deepEqual(
+      violations,
+      [],
+      `${entry} must stay presentation-pure so B01 can re-export it`,
+    );
+
+    for (const file of files) {
+      assert.ok(
+        file.startsWith(FRONTEND_SRC),
+        `${file} escaped the frontend source tree while walking the ${entry} closure`,
+      );
+    }
+  }
+});
+
+// ── T4 · The catalog owns ids, labels and order ──────────────────────────────
+
+test("B07 · both primitives derive their items from the canonical label tables", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const source = read(path);
+    assert.ok(source.includes("ADMIN_MODULE_NAV_LABELS"), `${path}: admin labels`);
+    assert.ok(source.includes("CLINIC_MODULE_NAV_LABELS"), `${path}: clinic labels`);
+    assert.ok(source.includes('from "@/features/dashboard/config"'));
+  }
+});
+
+test("B07 · no primitive re-declares a module id, label or order", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    // The `surface` discriminant is "admin" | "clinic", and "admin" is also a
+    // real module id. Those three forms are the discriminant, not a restated
+    // id, so they are removed before the census — every other occurrence of
+    // any module id still fails.
+    const executable = stripComments(read(path))
+      .replace(/\bsurface:\s*"(admin|clinic)"/g, "surface: <discriminant>")
+      .replace(/\bsurface\s*===\s*"(admin|clinic)"/g, "surface === <discriminant>");
+
+    for (const moduleId of [...ADMIN_MODULE_IDS, ...CLINIC_MODULE_IDS]) {
+      assert.equal(
+        executable.includes(`"${moduleId}"`),
+        false,
+        `${path} restates the module id "${moduleId}"; the catalog owns the id list, its order and its labels`,
+      );
+    }
+
+    // A local label table would be the H1 duplication the catalog exists to
+    // prevent, whatever it is called.
+    assert.equal(
+      /(label|shortLabel)\s*:\s*"/.test(executable),
+      false,
+      `${path} declares a literal label; labels come from the catalog`,
+    );
+  }
+});
+
+// ── T5 · Deep links go through the application grammar ───────────────────────
+
+test("B07 · every href is built with buildDashboardModuleHref", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const source = read(path);
+    const executable = stripComments(source);
+
+    assert.ok(source.includes("buildDashboardModuleHref"));
+    assert.ok(source.includes('from "@/features/dashboard/application"'));
+    assert.ok(
+      source.includes("buildDashboardModuleHref(basePath, item.moduleId)"),
+      `${path}: the href must be derived, not assembled`,
+    );
+
+    assert.equal(
+      executable.includes("?module="),
+      false,
+      `${path} assembles the query grammar by hand; MODULE_QUERY_PARAM is single-owned by the application layer`,
+    );
+    assert.ok(
+      source.includes("ROUTES.dashboardAdmin") && source.includes("ROUTES.dashboard"),
+      `${path}: base paths come from the route table`,
+    );
+  }
+});
+
+// ── T6 · Sanctioned navigation only ──────────────────────────────────────────
+
+test("B07 · navigation uses PublicRouteControl, never a link or a location write", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const source = read(path);
+    const executable = stripComments(source);
+
+    assert.ok(
+      source.includes(
+        'import { PublicRouteControl } from "@/components/public/PublicRouteControl";',
+      ),
+      `${path}: navigation must use the sanctioned route control`,
+    );
+    assert.ok(source.includes("<PublicRouteControl"));
+
+    for (const forbidden of [
+      'from "next/link"',
+      "window.location",
+      "location.href",
+      "location.assign",
+    ]) {
+      assert.equal(
+        executable.includes(forbidden),
+        false,
+        `${path} must not navigate with ${forbidden} (AGENTS.md §10, test/unit/ui)`,
+      );
+    }
+    assert.equal(
+      /<a[\s>]/.test(executable),
+      false,
+      `${path} must not use an anchor element to navigate`,
+    );
+  }
+});
+
+// ── T7 · Clinic optimistic activation is preserved ───────────────────────────
+
+test("B07 · clinic navigation keeps the optimistic activation signal", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const source = read(path);
+    assert.ok(
+      source.includes(
+        'import { requestClinicModuleActivate } from "@/lib/clinic-hub-reset";',
+      ),
+      `${path}: the clinic controller swaps on this signal before the URL commit lands`,
+    );
+    assert.ok(
+      source.includes("requestClinicModuleActivate(item.moduleId)"),
+      `${path}: the signal must fire on the clinic item click`,
+    );
+  }
+});
+
+// ── T8 · One owner for the 15 module icons ───────────────────────────────────
+
+test("B07 · the icon owner covers the canonical 10 admin + 5 clinic modules", () => {
+  assert.equal(ADMIN_MODULE_IDS.length, 10, "the admin catalog must carry 10 modules");
+  assert.equal(CLINIC_MODULE_IDS.length, 5, "the clinic catalog must carry 5 modules");
+  assert.equal(
+    ADMIN_MODULE_IDS.length + CLINIC_MODULE_IDS.length,
+    15,
+    "B07 covers the 15 canonical `?module=` surfaces",
+  );
+
+  const icons = read(ICONS_TS);
+  assert.ok(icons.includes("export const ADMIN_MODULE_ICONS: Record<AdminModule, LucideIcon> = {"));
+  assert.ok(icons.includes("export const CLINIC_MODULE_ICONS: Record<ClinicModule, LucideIcon> = {"));
+
+  // Exhaustiveness is a TYPE property (Record<AdminModule, …> fails typecheck
+  // on a missing id); this census proves the keys are really there today.
+  for (const moduleId of [...ADMIN_MODULE_IDS, ...CLINIC_MODULE_IDS]) {
+    const key = /^[a-z][a-z0-9]*$/.test(moduleId) ? moduleId : `"${moduleId}"`;
+    assert.ok(
+      new RegExp(`(^|[\\s{,])${key}:\\s*[A-Z]`, "m").test(icons),
+      `${ICONS_TS} has no icon for "${moduleId}"`,
+    );
+  }
+});
+
+test("B07 · the primitives consume the icon owner and declare no icon map", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const source = read(path);
+    const executable = stripComments(source);
+
+    assert.ok(
+      source.includes('from "./dashboardModuleIcons"'),
+      `${path}: icons come from the single owner`,
+    );
+    assert.equal(
+      executable.includes('from "lucide-react"'),
+      false,
+      `${path} imports icon components directly; a second icon map is exactly the duplication the owner exists to prevent`,
+    );
+    assert.equal(
+      /Record<\s*(Admin|Clinic)Module/.test(executable),
+      false,
+      `${path} declares a per-module map; that belongs to ${ICONS_TS}`,
+    );
+  }
+});
+
+test("B07 · the icon owner stays an icon owner (no labels, order, href or parsing)", () => {
+  const executable = stripComments(read(ICONS_TS));
+
+  for (const forbidden of [
+    "label",
+    "shortLabel",
+    "buildDashboardModuleHref",
+    "?module=",
+    "parseAdminModule",
+    "parseClinicModule",
+    "ROUTES",
+  ]) {
+    assert.equal(
+      executable.includes(forbidden),
+      false,
+      `${ICONS_TS} must not own "${forbidden}" — it maps module id -> icon and nothing else`,
+    );
+  }
+});
+
+// ── T9 · Geometry literals have exactly one owner ────────────────────────────
+
+test("B07 · the drawer/rail geometry is declared once, in the tokens ledger", () => {
+  const tokens = read(TOKENS_CSS);
+  const block = sliceBlock(tokens, TOKEN_BLOCK_START, TOKEN_BLOCK_END);
+
+  const entries = Object.entries(GEOMETRY_TOKENS);
+  assert.equal(entries.length, 6, "the B07 ledger declares six geometry tokens");
+
+  for (const [token, literal] of entries) {
+    assert.ok(
+      block.includes(`${token}: ${literal};`),
+      `the B07 token block must declare ${token}: ${literal};`,
+    );
+
+    const declarations = [...tokens.matchAll(new RegExp(`${token}:\\s*[^;]+;`, "g"))];
+    assert.equal(
+      declarations.length,
+      1,
+      `${token} must be declared exactly once in tokens.css`,
+    );
+
+    for (const cssFile of DASHBOARD_CSS_FILES) {
+      if (cssFile === TOKENS_CSS) continue;
+      assert.equal(
+        new RegExp(`${token}:\\s`).test(read(cssFile)),
+        false,
+        `${cssFile} re-declares ${token}; tokens.css is the single owner`,
+      );
+    }
+  }
+});
+
+test("B07 · no primitive restates a geometry literal the tokens own", () => {
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const executable = stripComments(read(path));
+    for (const literal of ["256px", "80px", "40px", "56px", "16px"]) {
+      assert.equal(
+        executable.includes(literal),
+        false,
+        `${path} restates "${literal}"; the geometry ledger in tokens.css owns it`,
+      );
+    }
+  }
+});
+
+test("B07 · the orphan 72/240 sidebar tokens are neither reused nor removed", () => {
+  const responsive = read(RESPONSIVE_CSS);
+  // Comments stripped: both blocks NAME these tokens to explain why they are
+  // not reused, and failing on that prose would forbid documenting the debt.
+  const b07Css = stripComments(
+    sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END),
+  );
+  const b07Tokens = stripComments(
+    sliceBlock(read(TOKENS_CSS), TOKEN_BLOCK_START, TOKEN_BLOCK_END),
+  );
+
+  for (const token of LEGACY_SIDEBAR_TOKENS) {
+    assert.ok(
+      responsive.includes(`${token}:`),
+      `${token} is pre-existing debt in ${RESPONSIVE_CSS}; B07 documents it, it does not delete it`,
+    );
+    for (const [label, source] of [
+      ["the B07 CSS block", b07Css],
+      ["the B07 token block", b07Tokens],
+    ] as const) {
+      assert.equal(
+        source.includes(token),
+        false,
+        `${label} reuses ${token} (72px/240px); B07 targets 80px/256px`,
+      );
+    }
+  }
+});
+
+// ── T10-T11 · Structural geometry, as a band ─────────────────────────────────
+
+test("B07 · both containers are bounded by the token band, with no radius or elevation", () => {
+  const block = sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END);
+
+  for (const [selector, token] of [
+    [".dashboard-navigation-drawer", "--dash-nav-drawer-w"],
+    [".dashboard-navigation-rail", "--dash-nav-rail-w"],
+  ] as const) {
+    assert.ok(
+      block.includes(`min-inline-size: calc(var(${token}) - var(--dash-nav-band));`),
+      `${selector}: the lower bound must be derived from ${token}`,
+    );
+    assert.ok(
+      block.includes(`max-inline-size: calc(var(${token}) + var(--dash-nav-band));`),
+      `${selector}: the upper bound must be derived from ${token}`,
+    );
+  }
+
+  assert.ok(block.includes("block-size: 100%;"), "the containers span the shell height");
+  assert.ok(block.includes("border-inline-end: 1px solid var(--dash-color-outline-subtle);"));
+  assert.ok(block.includes("border-radius: var(--dash-shape-none);"));
+  assert.ok(block.includes("box-shadow: var(--dash-elevation-none);"));
+
+  // A width pinned outside the band would make the token a decoration.
+  assert.equal(
+    /(^|[^-])(inline-size|width):\s/m.test(block.replace(/(min|max)-inline-size:/g, "")),
+    false,
+    "the B07 block must not pin a structural width outside the min/max band",
+  );
+
+  // An internal scroller is the forbidden primary solution (AGENTS.md §10).
+  assert.equal(
+    /overflow-y:\s*auto|overflow:\s*auto/.test(block),
+    false,
+    "the B07 block must not resolve height pressure with an internal scroller",
+  );
+});
+
+test("B07 · the item geometry follows the canonical 40 / 56 spec through tokens", () => {
+  const block = sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END);
+
+  for (const [selector, token] of [
+    [".dashboard-navigation-drawer-item", "--dash-nav-item-h"],
+    [".dashboard-navigation-rail-item", "--dash-nav-rail-item-h"],
+  ] as const) {
+    assert.ok(block.includes(selector), `the B07 block must style ${selector}`);
+    assert.ok(
+      block.includes(`min-block-size: var(${token});`),
+      `${selector}: item height comes from ${token}`,
+    );
+    assert.ok(
+      block.includes(`max-block-size: var(${token});`),
+      `${selector}: item height comes from ${token}`,
+    );
+  }
+
+  // Drawer item: 100% - 16, padding 0 12px, pill.
+  assert.ok(block.includes("padding-inline: var(--dash-space-3);"), "drawer item inset = 12px");
+  assert.ok(block.includes("border-radius: var(--dash-shape-full);"), "drawer item is a pill");
+  // Rail item: 100%, padding 8px 0, radius 16.
+  assert.ok(block.includes("padding-block: var(--dash-space-2);"), "rail item inset = 8px");
+  assert.ok(
+    block.includes("border-radius: var(--dash-nav-rail-item-radius);"),
+    "rail item radius comes from the ledger",
+  );
+});
+
+// ── T12 · Responsive contract ────────────────────────────────────────────────
+
+test("B07 · rail owns 768-1279, drawer owns >=1280, and neither exists below 768", () => {
+  const block = sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END);
+
+  const railQuery = "@media (min-width: 768px) and (max-width: 1279.98px)";
+  const drawerQuery = "@media (min-width: 1280px)";
+
+  assert.ok(block.includes(railQuery), "the rail breakpoint must be declared");
+  assert.ok(block.includes(drawerQuery), "the drawer breakpoint must be declared");
+
+  const railScope = block.slice(
+    block.indexOf(railQuery),
+    block.indexOf(drawerQuery) > block.indexOf(railQuery)
+      ? block.indexOf(drawerQuery)
+      : block.length,
+  );
+  assert.ok(
+    railScope.includes(".dashboard-navigation-rail {"),
+    "the 768-1279 scope must reveal the rail",
+  );
+  assert.equal(
+    railScope.includes(".dashboard-navigation-drawer {"),
+    false,
+    "the drawer must not appear in the rail scope: two lateral navs at once is double navigation",
+  );
+
+  const drawerScope = block.slice(block.indexOf(drawerQuery));
+  assert.ok(
+    drawerScope.includes(".dashboard-navigation-drawer {"),
+    ">=1280 must reveal the drawer",
+  );
+
+  // Base state: hidden. <768 is B09's mobile model, not B07's.
+  const baseScope = block.slice(0, block.indexOf(railQuery));
+  assert.ok(
+    /\.dashboard-navigation-drawer,\s*\n[^{]*\.dashboard-navigation-rail\s*\{[^}]*display:\s*none;/m.test(
+      baseScope,
+    ),
+    "both primitives must be hidden by default so <768px keeps the B09 mobile model",
+  );
+  assert.equal(
+    /max-width:\s*767/.test(block),
+    false,
+    "B07 must not author a <768px rule; mobile navigation belongs to B09",
+  );
+});
+
+test("B07 · the primitives ship no persisted expand/collapse state", () => {
+  const block = sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END);
+
+  for (const path of [DRAWER_TSX, RAIL_TSX]) {
+    const executable = stripComments(read(path));
+    for (const forbidden of ["localStorage", "sessionStorage", "useState", "useEffect"]) {
+      assert.equal(
+        executable.includes(forbidden),
+        false,
+        `${path} introduces "${forbidden}"; B07 is a stateless presentation primitive — the expanded/compact choice is the viewport's, not a persisted preference`,
+      );
+    }
+  }
+
+  assert.equal(
+    /data-\w*(collapsed|expanded)/.test(block),
+    false,
+    "the B07 block must not encode a manual collapse state",
+  );
+});
+
+// ── T13 · No structural size transitions ─────────────────────────────────────
+
+test("B07 · nothing in the block animates a structural size", () => {
+  const block = sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END);
+
+  for (const property of ["width", "inline-size", "height", "block-size", "flex-basis"]) {
+    assert.equal(
+      new RegExp(`transition[^;]*:(?![^;]*none)[^;]*\\b${property}\\b`).test(block),
+      false,
+      `the B07 block animates ${property}; a size transition feeds the ResizeObserver behind the adaptive capacity engine (R11/A03)`,
+    );
+  }
+
+  assert.ok(
+    block.includes("@media (prefers-reduced-motion: reduce)"),
+    "the block must honour reduced motion",
+  );
+  assert.ok(
+    block.includes("@media (forced-colors: active)"),
+    "the block must survive forced colors",
+  );
+  assert.ok(
+    block.includes("outline: 2px solid var(--dash-color-focus-ring);") &&
+      block.includes("outline-offset: 2px;"),
+    "focus must be a real, visible outline — never `outline-style: none`",
+  );
+  assert.equal(
+    /outline(-style)?:\s*none/.test(stripComments(block)),
+    false,
+    "the B07 block must not suppress the focus outline",
+  );
+});
+
+// ── T14-T16 · Scope fences: B08, B09 and B06 are untouched ───────────────────
+
+test("B07 · the legacy navigation B08 retires is still standing and still exported", () => {
+  const barrel = read(NAVIGATION_BARREL);
+
+  for (const path of B08_FENCE) {
+    assert.ok(
+      existsSync(resolve(REPO_ROOT, path)),
+      `${path} must survive B07: retiring it is B08 (audit §49, depends on B07 + A08). Removing it here would leave the shell with no mounted navigation`,
+    );
+  }
+
+  assert.ok(barrel.includes('from "@/components/dashboard/DashboardHorizontalNav";'));
+  assert.ok(barrel.includes('from "@/components/dashboard/DashboardModuleRail";'));
+});
+
+test("B07 · the mobile navigation B09 unifies is untouched", () => {
+  for (const path of B09_FENCE) {
+    assert.ok(
+      existsSync(resolve(REPO_ROOT, path)),
+      `${path} must survive B07: the <768px model belongs to B09`,
+    );
+  }
+});
+
+test("B07 · the B06 app bar keeps its own geometry ledger", () => {
+  const tokens = read(TOKENS_CSS);
+
+  assert.ok(existsSync(resolve(REPO_ROOT, APP_BAR_TSX)));
+  assert.ok(
+    tokens.includes("--dash-app-bar-h: 56px;"),
+    "B07 must not disturb the B06 band declaration",
+  );
+  assert.equal(
+    [...tokens.matchAll(/--dash-app-bar-h:\s*[^;]+;/g)].length,
+    1,
+    "--dash-app-bar-h stays declared exactly once",
+  );
+
+  const b07Block = sliceBlock(tokens, TOKEN_BLOCK_START, TOKEN_BLOCK_END);
+  assert.equal(
+    b07Block.includes("--dash-app-bar"),
+    false,
+    "the B07 ledger must not restate the B06 app-bar geometry",
+  );
+});
+
+// ── T17 · The primitives are not mounted: B07 is a creation PR ───────────────
+
+test("B07 · G-1 boundary: the primitives exist but no runtime surface mounts them", () => {
+  const consumers: string[] = [];
+
+  for (const path of [...B08_FENCE, ...B09_FENCE, APP_BAR_TSX]) {
+    const source = read(path);
+    if (/<NavigationDrawer[\s/>]|<NavigationRail[\s/>]/.test(source)) {
+      consumers.push(path);
+    }
+  }
+
+  assert.deepEqual(
+    consumers,
+    [],
+    "B07 creates the primitives; MOUNTING them and retiring the legacy navigation is B08. Rendering them now would ship double navigation and move `main` against the A03 freeze",
+  );
+});

--- a/test/architecture/dashboard-b07-navigation-drawer-rail.test.ts
+++ b/test/architecture/dashboard-b07-navigation-drawer-rail.test.ts
@@ -716,6 +716,57 @@ test("B07 · the primitives ship no persisted expand/collapse state", () => {
   );
 });
 
+test("B07 · active navigation keeps its active colors while hovered", () => {
+  // Whitespace-agnostic: the CSS file is CRLF and prettier may wrap the selector
+  // list, so the contract is read off a flattened copy of the B07 block.
+  const flat = stripComments(sliceBlock(read(NAVIGATION_CSS), CSS_BLOCK_START, CSS_BLOCK_END))
+    .replace(/\s+/g, " ")
+    .trim();
+
+  for (const primitive of ["drawer", "rail"]) {
+    assert.ok(
+      flat.includes(
+        `.dashboard-navigation-${primitive}-item.dashboard-navigation-item-active:hover`,
+      ),
+      `the B07 block must declare an active :hover rule for the ${primitive}: the generic ".dashboard-navigation-${primitive}-item:hover" outranks the single-class active rule and would repaint the selected module with the inactive state layer`,
+    );
+  }
+
+  const ACTIVE_HOVER_SELECTOR =
+    ".dashboard-app-shell .dashboard-navigation-drawer-item.dashboard-navigation-item-active:hover, .dashboard-app-shell .dashboard-navigation-rail-item.dashboard-navigation-item-active:hover {";
+  const ruleStart = flat.indexOf(ACTIVE_HOVER_SELECTOR);
+
+  assert.notEqual(
+    ruleStart,
+    -1,
+    "drawer and rail must share one active-:hover rule that restates the active colors",
+  );
+
+  const declarations = flat.slice(
+    ruleStart + ACTIVE_HOVER_SELECTOR.length,
+    flat.indexOf("}", ruleStart),
+  );
+
+  assert.ok(
+    declarations.includes("background-color: var(--dash-color-surface-muted);"),
+    "the hovered active item must keep the active background token, not the hover one",
+  );
+  assert.ok(
+    declarations.includes("color: var(--dash-color-primary);"),
+    "the hovered active item must keep the active foreground token, not the hover one",
+  );
+  assert.equal(
+    declarations.includes("!important"),
+    false,
+    "the active-:hover rule wins by specificity, never by !important",
+  );
+
+  assert.ok(
+    flat.indexOf(".dashboard-navigation-drawer-item:hover") < ruleStart,
+    "the active-:hover rule must follow the generic :hover rule it overrides",
+  );
+});
+
 // ── T13 · No structural size transitions ─────────────────────────────────────
 
 test("B07 · nothing in the block animates a structural size", () => {

--- a/test/architecture/dashboard-presentation-import-boundaries.test.ts
+++ b/test/architecture/dashboard-presentation-import-boundaries.test.ts
@@ -69,6 +69,12 @@ const SHELL_REQUIRED_EXPORTS: Record<string, readonly string[]> = {
 };
 
 const NAVIGATION_REQUIRED_EXPORTS: Record<string, readonly string[]> = {
+  // B07 primitives. They enter under the SAME closure rules as every legacy
+  // target — no exception, no path exclusion — which is the point: a primitive
+  // created inside the boundary must prove its purity exactly like one that was
+  // grandfathered into it.
+  NavigationDrawer: ["NavigationDrawer", "NavigationDrawerProps"],
+  NavigationRail: ["NavigationRail", "NavigationRailProps"],
   DashboardHorizontalNav: ["DashboardHorizontalNav", "DashboardNavSurface"],
   DashboardModuleRail: ["DashboardModuleRail", "CLINIC_MODULE_RAIL_ITEMS"],
   AdminMobileBottomNav: ["AdminMobileBottomNav"],


### PR DESCRIPTION
## Summary
- Adds the B07 presentation-pure NavigationDrawer (256 px) and NavigationRail (80 px) primitives.
- Derives module ids, labels, order, deep-link hrefs, and icon exhaustiveness from the existing dashboard contracts.
- Preserves the approved G-1 boundary: B07 does not mount the new navigation into the runtime shell; runtime geometry and migration remain B08.

## Scope
- [x] frontend runtime
- [ ] backend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception

Tests and documentation only support the frontend navigation architecture change and are not separate primary scopes.

## Validation
- B07 static contract: PASSED — 25/25
- B01 presentation import boundaries: PASSED
- B06 workspace app bar regression: PASSED — 12/12
- frontend lint: PASSED
- frontend typecheck: PASSED
- frontend build: PASSED
- security:public-surface: PASSED
- pnpm validate:local: PASSED
- B07 runtime E2E: NOT_RUN — approved G-1 has no runtime-mounted B07 surface
- e2e:full: NOT_RUN — not selected; no sufficient justification for full-suite execution

## Architecture
- Adds NavigationDrawer and NavigationRail under frontend/src/components/dashboard.
- Keeps frontend/src/features/dashboard/presentation/navigation as a pure re-export boundary.
- Uses the canonical dashboard module catalog for ids, labels, and ordering.
- Uses buildDashboardModuleHref for ?module= deep links.
- Preserves requestClinicModuleActivate for clinic navigation.
- Adds a typed exhaustive presentation-layer module icon owner.
- Adds tokenized 256/80/40/56 geometry and responsive visibility contracts.
- Does not mount the primitives into DashboardTopbar, DashboardShellRouter, or any runtime shell.

## G-1 Boundary
B07 creates the primitives and their executable static contracts only.

B07_RUNTIME_GEOMETRY = DEFERRED_TO_B08
B07_RUNTIME_E2E = NOT_RUN

B08 owns runtime mounting, legacy navigation retirement, 256/80 ±1 px measurements, deep-link runtime behavior, zero-scroll verification, and Back/Forward/reload coverage.

## No-touch confirmation
- frontend/src/app/globals.css unchanged
- DashboardHorizontalNav unchanged
- DashboardModuleRail unchanged
- mobile navigation unchanged
- WorkspaceAppBar unchanged
- A02/A03 baseline fixtures unchanged

## Rollback
- Trigger: regression in dashboard navigation architecture, presentation boundaries, canonical module ownership, or frontend validation.
- Steps: revert the B07 squash commit after merge.
- Data impact: none. No backend, database, schema, dependency, lockfile, workflow, auth, session, or migration changes.

## Residual
- Legacy desktop navigation remains active until B08.
- Legacy icon maps remain temporarily duplicated until their owning B08/B09/B13 migrations.
- Legacy 72/240 sidebar tokens remain untouched.
- Runtime geometry and navigation behavior are intentionally deferred to B08.