### PR TITLE
fix(dashboard): preserve full detail text

### DIFF
--- a/frontend/e2e/clinic/reports/clinic-informes-zero-internal-scroll.spec.ts
+++ b/frontend/e2e/clinic/reports/clinic-informes-zero-internal-scroll.spec.ts
@@ -24,8 +24,30 @@ type InternalScroller = {
   delta: number;
 };
 
+/**
+ * PR-TRUNC · the one sanctioned in-`main` scroll owner of this route.
+ *
+ * Until PR-TRUNC the detail canvas kept itself inside its bounded grid track by
+ * TRUNCATING every value in it — the report title, the clinic, the patient, the
+ * study type and the file name were all `truncate` — and the surplus that did
+ * not fit was swallowed by `overflow: hidden`. That is invisible to the census
+ * below, which only counts `auto|scroll` elements: a box that CLIPS 156px of a
+ * clinical record reads as "zero internal scrollers" exactly like a box that
+ * fits. The route was green while the record was unreadable, and the detail
+ * panel is the terminal surface for those fields — there is nothing deeper to
+ * open.
+ *
+ * The values now wrap and the surplus is scrolled inside this ONE owner instead
+ * of being destroyed. It is exempted here by its explicit anchor — never by its
+ * class list — and the exemption is paid for immediately: `assertDetailScrollOwner`
+ * asserts there is at most one, and that its end is actually reachable, so the
+ * exemption cannot become a new place for content to hide.
+ */
+const SANCTIONED_DETAIL_SCROLL_OWNER =
+  '[data-informes-detail-scroll-owner="true"]';
+
 async function readCoreInternalScrollers(page: Page): Promise<InternalScroller[]> {
-  return page.evaluate(() => {
+  return page.evaluate((sanctionedSelector) => {
     const root = document.querySelector<HTMLElement>("main.dashboard-main");
     if (!root) {
       return [];
@@ -34,8 +56,13 @@ async function readCoreInternalScrollers(page: Page): Promise<InternalScroller[]
     const candidates = [root, ...Array.from(root.querySelectorAll<HTMLElement>("*"))];
 
     return candidates.flatMap((element) => {
-      // Dialog bodies are the only sanctioned internal scroll containers and
-      // they are portaled outside main, so everything found here is core.
+      // Dialog bodies are portaled outside main, and the informes detail owner
+      // is the single sanctioned in-main scroller; everything else found here
+      // is core and forbidden.
+      if (element.matches(sanctionedSelector)) {
+        return [];
+      }
+
       const style = window.getComputedStyle(element);
       const scrollableY =
         ["auto", "scroll"].includes(style.overflowY) &&
@@ -60,7 +87,45 @@ async function readCoreInternalScrollers(page: Page): Promise<InternalScroller[]
         },
       ];
     });
-  });
+  }, SANCTIONED_DETAIL_SCROLL_OWNER);
+}
+
+/**
+ * The price of the exemption above: the sanctioned owner must be unique, and
+ * when it does overflow its end must be reachable. A scroller nobody can drive
+ * to the bottom is the same data loss the truncation was.
+ */
+async function assertDetailScrollOwner(page: Page, label: string) {
+  const owners = page.locator(SANCTIONED_DETAIL_SCROLL_OWNER);
+  const count = await owners.count();
+  expect(
+    count,
+    `${label}: exactly one sanctioned detail scroll owner (found ${count})`,
+  ).toBe(1);
+
+  const reachable = await page.evaluate(
+    ({ selector, tolerance }) => {
+      const owner = document.querySelector<HTMLElement>(selector);
+      if (!owner) return { present: false, overflowing: false, reachedEnd: false };
+      if (owner.scrollHeight - owner.clientHeight <= tolerance) {
+        return { present: true, overflowing: false, reachedEnd: true };
+      }
+      owner.scrollTop = owner.scrollHeight;
+      return {
+        present: true,
+        overflowing: true,
+        reachedEnd:
+          owner.scrollTop + owner.clientHeight >= owner.scrollHeight - tolerance,
+      };
+    },
+    { selector: SANCTIONED_DETAIL_SCROLL_OWNER, tolerance: TOLERANCE },
+  );
+
+  expect(reachable.present, `${label}: detail scroll owner present`).toBe(true);
+  expect(
+    reachable.reachedEnd,
+    `${label}: the end of the detail scroll owner must be reachable`,
+  ).toBe(true);
 }
 
 test.describe("clinic informes full route — zero internal core scroll", () => {
@@ -123,6 +188,8 @@ test.describe("clinic informes full route — zero internal core scroll", () => 
         await expect(
           page.locator('[data-informes-detail-action-dock="true"]'),
         ).toBeVisible();
+
+        await assertDetailScrollOwner(page, viewport.name);
       } else {
         // Mobile: compact selected summary + dialog-based detail.
         await expect(
@@ -158,6 +225,7 @@ test.describe("clinic informes full route — zero internal core scroll", () => 
       await detail.getByRole("tab", { name: section }).click();
       const scrollers = await readCoreInternalScrollers(page);
       expect(scrollers, `section ${section}: no core internal scroller`).toEqual([]);
+      await assertDetailScrollOwner(page, `section ${section}`);
       const external = await page.evaluate(
         () => document.documentElement.scrollHeight - document.documentElement.clientHeight,
       );

--- a/frontend/e2e/fixtures/admin-populated-api-server.mjs
+++ b/frontend/e2e/fixtures/admin-populated-api-server.mjs
@@ -1,5 +1,17 @@
 import { createServer } from "node:http";
 
+// PR-TRUNC · Deliberately long text dataset (additive, opt-in, test-only).
+// The truncation audit must observe what a LONG clinical value does to the
+// clinic report surfaces, and those two (/dashboard and /dashboard/informes)
+// are rendered by SERVER components: their payload never leaves the Next
+// process, so Playwright's `page.route` cannot substitute it. The gate is
+// `hasLongTextDataset` below, strictly conjunctive like the A03 one.
+import {
+  LONG_TEXT_CLINIC_REPORT,
+  LONG_TEXT_COOKIE_NAME,
+  LONG_TEXT_COOKIE_VALUE,
+} from "../helpers/long-text-dataset.mjs";
+
 const HOST = "127.0.0.1";
 const PORT = 3107;
 const POPULATED_ADMIN_SESSION = "e2e_populated_admin_session";
@@ -823,6 +835,50 @@ function hasA03AdaptiveDataset(request) {
 }
 
 /**
+ * PR-TRUNC opt-in gate. Conjunctive exactly like {@link hasA03AdaptiveDataset}:
+ * the auxiliary cookie ALONE never activates the long-text dataset.
+ */
+function hasLongTextDataset(request) {
+  if (!hasPopulatedClinicSession(request)) {
+    return false;
+  }
+
+  return (request.headers.cookie ?? "")
+    .split(";")
+    .map((cookie) => cookie.trim())
+    .includes(`${LONG_TEXT_COOKIE_NAME}=${LONG_TEXT_COOKIE_VALUE}`);
+}
+
+/**
+ * Rewrites the FIRST report of a page with the long synthetic values. Only the
+ * first item changes, so row count, pagination totals and every adaptive
+ * capacity the A03 baseline measures stay exactly as they are: this dataset
+ * makes text long, never longer lists.
+ */
+function withLongClinicReportText(page) {
+  if (!Array.isArray(page.reports) || page.reports.length === 0) {
+    return page;
+  }
+
+  const [first, ...rest] = page.reports;
+
+  return {
+    ...page,
+    reports: [
+      {
+        ...first,
+        patientName: LONG_TEXT_CLINIC_REPORT.patientName,
+        studyType: LONG_TEXT_CLINIC_REPORT.studyType,
+        clinicName: LONG_TEXT_CLINIC_REPORT.clinicName,
+        fileName: LONG_TEXT_CLINIC_REPORT.fileName,
+        hasFile: true,
+      },
+      ...rest,
+    ],
+  };
+}
+
+/**
  * Pagination semantics of the A03 datasets, mirroring what the real logistics
  * endpoints do (`server/routes/logistics-field-visits.fastify.ts`:
  * `parsePositiveInt(request.query.limit, 50, 100)`):
@@ -1029,7 +1085,12 @@ const server = createServer((request, response) => {
       url.searchParams.has("studyType")
         ? filterClinicReports(url)
         : CLINIC_REPORTS;
-    sendJson(response, 200, paginateClinicReports(reports, url));
+    const page = paginateClinicReports(reports, url);
+    sendJson(
+      response,
+      200,
+      hasLongTextDataset(request) ? withLongClinicReportText(page) : page,
+    );
     return;
   }
 
@@ -1037,10 +1098,13 @@ const server = createServer((request, response) => {
     hasPopulatedClinicSession(request) &&
     url.pathname === "/api/reports/search"
   ) {
+    const searchPage = paginateClinicReports(filterClinicReports(url), url);
     sendJson(
       response,
       200,
-      paginateClinicReports(filterClinicReports(url), url),
+      hasLongTextDataset(request)
+        ? withLongClinicReportText(searchPage)
+        : searchPage,
     );
     return;
   }

--- a/frontend/e2e/helpers/long-text-dataset.mjs
+++ b/frontend/e2e/helpers/long-text-dataset.mjs
@@ -1,0 +1,66 @@
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-TRUNC · Shared long-text dataset (test-only, side-effect free).
+//
+// The truncation contract has two consumers that must agree byte-for-byte on
+// the same strings:
+//
+//   1. `frontend/e2e/fixtures/admin-populated-api-server.mjs`, which serves
+//      them to the SERVER-rendered clinic report surfaces (/dashboard and
+//      /dashboard/informes) — Playwright's `page.route` cannot reach those,
+//      because their fetch never leaves the Next process.
+//   2. `frontend/e2e/platform/app-shell/dashboard-detail-text-integrity.spec.ts`,
+//      which asserts the FULL string is present in the DOM.
+//
+// It lives here rather than in the fixture because importing the fixture would
+// execute it, and the fixture calls `server.listen(3107)` at module scope.
+//
+// Every value is synthetic and deliberately hostile to a one-line box: long
+// prose, an unbroken identifier and a long file name with no spaces. None of
+// them is a real patient, tutor, clinic, email or document (AGENTS §9).
+// ─────────────────────────────────────────────────────────────────────────────
+
+/** Auxiliary opt-in cookie. Conjunctive with a populated clinic session. */
+export const LONG_TEXT_COOKIE_NAME = "e2e_long_text_overflow";
+export const LONG_TEXT_COOKIE_VALUE = "1";
+
+export const LONG_TEXT_CLINIC_REPORT = Object.freeze({
+  patientName:
+    "Maximiliano Bartolome de la Concepcion Rodriguez Etchegaray Villalobos Jauregui",
+  studyType:
+    "Histopatologia dermatologica con evaluacion de margenes quirurgicos ampliados y estudio inmunohistoquimico complementario",
+  fileName:
+    "informe-anatomopatologico-completo-con-inmunohistoquimica-2026-06-18-revision-final-v3-definitivo.pdf",
+  clinicName:
+    "Centro Veterinario Integral de Diagnostico y Seguimiento Los Arrayanes Sede Norte",
+});
+
+/**
+ * A realistic-length user agent. The admin failed-login row truncates it by
+ * design (pitch-locked table); the assertion is that its detail dialog renders
+ * it whole. Synthetic build numbers, no real device fingerprint.
+ */
+export const LONG_TEXT_USER_AGENT =
+  "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/000.0.0000.000 Safari/537.36 Edg/000.0.0000.000";
+
+/**
+ * Admin users/roles. The row truncates both of these by design (pitch-locked
+ * table); the assertion is that the detail dialog renders them whole.
+ */
+export const LONG_TEXT_USER_ROLE = Object.freeze({
+  username: "operador.administracion.regional.zona.norte.suplente.e2e",
+  clinicName:
+    "Centro Veterinario Integral de Diagnostico y Seguimiento Los Arrayanes Sede Norte",
+});
+
+/** Client-fetched surfaces (admin tokens, admin reports, clinic tokens). */
+export const LONG_TEXT_TOKEN = Object.freeze({
+  petName:
+    "Maximiliano Bartolome de la Concepcion Rodriguez Etchegaray Villalobos Jauregui",
+  petBreed: "TKN-00000000000000000000000000000000000000000042",
+  sampleLocation:
+    "Region dorsolumbar paravertebral izquierda, cuadrante craneal profundo, plano subcutaneo",
+  sampleEvolution:
+    "Doce semanas de evolucion progresiva con incremento sostenido del tamano lesional",
+  detailsLesion:
+    "Lesion nodular ulcerada de bordes irregulares con areas de necrosis central, extension subcutanea y compromiso de planos profundos; se solicita evaluacion anatomopatologica con margenes quirurgicos y tinciones especiales complementarias.",
+});

--- a/frontend/e2e/platform/app-shell/dashboard-detail-text-integrity.spec.ts
+++ b/frontend/e2e/platform/app-shell/dashboard-detail-text-integrity.spec.ts
@@ -1,0 +1,687 @@
+import { expect, test, type Page } from "@playwright/test";
+
+import {
+  LONG_TEXT_CLINIC_REPORT,
+  LONG_TEXT_COOKIE_NAME,
+  LONG_TEXT_COOKIE_VALUE,
+  LONG_TEXT_TOKEN,
+  LONG_TEXT_USER_AGENT,
+  LONG_TEXT_USER_ROLE,
+} from "../../helpers/long-text-dataset.mjs";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-TRUNC — Terminal-surface text integrity (admin + clinic).
+//
+// A DETAIL / DIALOG / INSPECTOR is the LAST surface a datum is rendered on:
+// there is nothing deeper to open, so anything hidden there is hidden for good.
+// The shipped build hid a great deal. Measured against the same long synthetic
+// values this spec injects, at 360x800:
+//
+//   admin token detail   "Muestra"           scrollWidth 528 / clientWidth 137
+//   admin token detail   "Detalle de lesión" scrollHeight  96 / clientHeight 32
+//   admin report detail  "Estudio"           scrollWidth 805 / clientWidth 124
+//   clinic token detail  "Evolución"         scrollWidth 489 / clientWidth 137
+//   admin token dialog   panel               scrollWidth 364 / clientWidth 326
+//
+// This spec blinda the corrected contract on both roles and both mechanisms —
+// the shared `ModuleDialog` and the informes master-detail panel:
+//
+//   1. FULL TEXT PRESENT — the complete string is in the accessibility tree,
+//      not a prefix of it.
+//   2. NO HIDDEN TEXT — no element inside the detail hides part of its OWN text
+//      (scrollWidth ≤ clientWidth AND scrollHeight ≤ clientHeight), unless it
+//      is the ONE sanctioned local scroll owner, whose end must be reachable.
+//   3. NO HORIZONTAL OVERFLOW and NO DOCUMENT SCROLL — the fix wraps text, it
+//      does not push the shell (A08 stays at zero).
+//
+// The long values are synthetic (AGENTS §9): no real patient, tutor, clinic,
+// email or document. Client-fetched surfaces get them through `page.route`; the
+// SERVER-rendered clinic report surfaces get them through the fixture's
+// conjunctive `e2e_long_text_overflow` opt-in, which leaves every other
+// consumer's payload byte-identical.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TOLERANCE = 2;
+
+/** Canonical matrix ends plus the 768 boundary (frontend/e2e/helpers/dashboard-geometry-matrix.ts). */
+const VIEWPORTS = [
+  { slug: "w1920x1080", width: 1920, height: 1080 },
+  { slug: "w1366x768", width: 1366, height: 768 },
+  { slug: "w768x1024", width: 768, height: 1024 },
+  { slug: "w390x844", width: 390, height: 844 },
+  { slug: "w360x800", width: 360, height: 800 },
+] as const;
+
+const ORIGIN = "http://127.0.0.1:3000";
+
+async function setSession(page: Page, role: "admin" | "clinic") {
+  await page.context().addCookies([
+    role === "admin"
+      ? {
+          name: "admin_session_id",
+          value: "e2e_populated_admin_session",
+          url: ORIGIN,
+        }
+      : {
+          name: "app_session_id",
+          value: "e2e_populated_clinic_session",
+          url: ORIGIN,
+        },
+  ]);
+}
+
+async function enableLongTextFixture(page: Page) {
+  await page.context().addCookies([
+    { name: LONG_TEXT_COOKIE_NAME, value: LONG_TEXT_COOKIE_VALUE, url: ORIGIN },
+  ]);
+}
+
+type Offender = {
+  tag: string;
+  cls: string;
+  text: string;
+  sw: number;
+  cw: number;
+  sh: number;
+  ch: number;
+};
+
+type DetailMetrics = {
+  found: boolean;
+  docScrollW: number;
+  docClientW: number;
+  docScrollH: number;
+  docClientH: number;
+  /** Elements that hide part of their own text and are NOT a scroll owner. */
+  hidden: Offender[];
+  /** Sanctioned local scroll owners, with their reachable extent. */
+  owners: Offender[];
+};
+
+/**
+ * Reads, in one page evaluation, every element under `rootSelector` whose own
+ * box hides part of its own text. A scroll container is not an offender: it
+ * exposes the overflow instead of destroying it, and assertion 2 checks its end
+ * is reachable separately.
+ */
+async function readDetailMetrics(
+  page: Page,
+  rootSelector: string,
+): Promise<DetailMetrics> {
+  return page.evaluate(
+    ({ sel, tol }) => {
+      const html = document.documentElement;
+      const root = document.querySelector(sel) as HTMLElement | null;
+      const metrics = {
+        found: root !== null,
+        docScrollW: html.scrollWidth,
+        docClientW: html.clientWidth,
+        docScrollH: html.scrollHeight,
+        docClientH: html.clientHeight,
+        hidden: [] as Offender[],
+        owners: [] as Offender[],
+      };
+      if (!root) return metrics;
+
+      const describe = (el: HTMLElement): Offender => ({
+        tag: el.tagName.toLowerCase(),
+        cls: typeof el.className === "string" ? el.className : "",
+        text: (el.textContent || "").trim().slice(0, 70),
+        sw: el.scrollWidth,
+        cw: el.clientWidth,
+        sh: el.scrollHeight,
+        ch: el.clientHeight,
+      });
+
+      const all = [root].concat(
+        Array.from(root.querySelectorAll("*")) as HTMLElement[],
+      );
+
+      for (const el of all) {
+        const cs = getComputedStyle(el);
+        const scrollsY = cs.overflowY === "auto" || cs.overflowY === "scroll";
+        const scrollsX = cs.overflowX === "auto" || cs.overflowX === "scroll";
+        const hidesX = el.scrollWidth > el.clientWidth + tol;
+        const hidesY = el.scrollHeight > el.clientHeight + tol;
+
+        if ((scrollsY && hidesY) || (scrollsX && hidesX)) {
+          metrics.owners.push(describe(el));
+          continue;
+        }
+        if (!hidesX && !hidesY) continue;
+
+        // `visible` on both axes cannot hide anything: the text paints outside
+        // the box and is still readable. Only a clipping box is a defect.
+        const clips =
+          cs.overflow !== "visible" ||
+          cs.overflowX !== "visible" ||
+          cs.overflowY !== "visible";
+        if (clips) metrics.hidden.push(describe(el));
+      }
+
+      return metrics;
+    },
+    { sel: rootSelector, tol: TOLERANCE },
+  );
+}
+
+function assertNoHiddenText(metrics: DetailMetrics, label: string) {
+  expect(metrics.found, `${label}: detail surface present`).toBe(true);
+
+  const rendered = metrics.hidden
+    .map(
+      (o) =>
+        `${o.tag}.${o.cls.slice(0, 60)} sw/cw=${o.sw}/${o.cw} sh/ch=${o.sh}/${o.ch} "${o.text}"`,
+    )
+    .join("\n  ");
+
+  expect(
+    metrics.hidden,
+    `${label}: no element in a DETAIL surface may hide part of its own text.\n  ${rendered}`,
+  ).toEqual([]);
+}
+
+function assertNoDocumentScroll(metrics: DetailMetrics, label: string) {
+  expect(
+    metrics.docScrollW,
+    `${label}: document horizontal scroll must stay at zero`,
+  ).toBeLessThanOrEqual(metrics.docClientW + TOLERANCE);
+  expect(
+    metrics.docScrollH,
+    `${label}: document vertical scroll must stay at zero`,
+  ).toBeLessThanOrEqual(metrics.docClientH + TOLERANCE);
+}
+
+/**
+ * At most ONE local scroll owner per detail, and its end has to be reachable —
+ * a scroller nobody can drive is the same data loss with extra steps.
+ */
+async function assertSingleReachableScrollOwner(
+  page: Page,
+  metrics: DetailMetrics,
+  rootSelector: string,
+  label: string,
+) {
+  expect(
+    metrics.owners.length,
+    `${label}: at most one local scroll owner, found ${metrics.owners
+      .map((o) => o.cls.slice(0, 50))
+      .join(" | ")}`,
+  ).toBeLessThanOrEqual(1);
+
+  if (metrics.owners.length === 0) return;
+
+  const reachedEnd = await page.evaluate(
+    ({ sel, tol }) => {
+      const root = document.querySelector(sel) as HTMLElement | null;
+      if (!root) return false;
+      const all = [root].concat(
+        Array.from(root.querySelectorAll("*")) as HTMLElement[],
+      );
+      for (const el of all) {
+        const cs = getComputedStyle(el);
+        const scrolls = cs.overflowY === "auto" || cs.overflowY === "scroll";
+        if (!scrolls || el.scrollHeight <= el.clientHeight + tol) continue;
+        el.scrollTop = el.scrollHeight;
+        return el.scrollTop + el.clientHeight >= el.scrollHeight - tol;
+      }
+      return false;
+    },
+    { sel: rootSelector, tol: TOLERANCE },
+  );
+
+  expect(
+    reachedEnd,
+    `${label}: the end of the local scroll owner must be reachable`,
+  ).toBe(true);
+}
+
+/** The full string, not a prefix of it, is in the DOM of the detail. */
+async function assertFullTextPresent(
+  page: Page,
+  rootSelector: string,
+  values: readonly string[],
+  label: string,
+) {
+  const text = await page.locator(rootSelector).first().innerText();
+  const normalized = text.replace(/\s+/g, " ");
+  for (const value of values) {
+    expect(
+      normalized.includes(value.replace(/\s+/g, " ")),
+      `${label}: FULL_TEXT_PRESENT for "${value.slice(0, 45)}…"`,
+    ).toBe(true);
+  }
+}
+
+const DIALOG = '[data-module-dialog="true"]';
+
+async function openFirstDetail(page: Page) {
+  const trigger = page
+    .getByRole("button", { name: /^ver$/i })
+    .or(page.getByRole("button", { name: /ver detalle/i }))
+    .first();
+  await trigger.waitFor({ state: "visible" });
+  await trigger.click();
+  await page.locator(DIALOG).first().waitFor();
+}
+
+// ── Admin · particular tokens detail dialog ─────────────────────────────────
+test.describe("admin particular tokens detail keeps every clinical value", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "admin");
+      await page.route("**/api/admin/particular-tokens**", async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            count: 1,
+            particularTokens: [
+              {
+                id: 9101,
+                clinicId: 12,
+                reportId: null,
+                tokenLast4: "4201",
+                tutorLastName: "Gomez",
+                petName: LONG_TEXT_TOKEN.petName,
+                petAge: "3 anos",
+                petBreed: LONG_TEXT_TOKEN.petBreed,
+                petSex: "female",
+                petSpecies: "canine",
+                sampleLocation: LONG_TEXT_TOKEN.sampleLocation,
+                sampleEvolution: LONG_TEXT_TOKEN.sampleEvolution,
+                detailsLesion: LONG_TEXT_TOKEN.detailsLesion,
+                extractionDate: "2026-06-10T10:00:00.000Z",
+                shippingDate: "2026-06-11T10:00:00.000Z",
+                isActive: true,
+                lastLoginAt: null,
+                createdAt: "2026-06-12T09:15:00.000Z",
+                updatedAt: "2026-06-17T16:20:00.000Z",
+                createdByAdminId: 41,
+                createdByClinicUserId: null,
+                hasLinkedReport: false,
+              },
+            ],
+            pagination: { limit: 50, offset: 0 },
+            filters: { clinicId: null },
+          },
+        });
+      });
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard/admin?module=admin-particular-tokens");
+      await openFirstDetail(page);
+
+      const label = `admin tokens detail @ ${vp.slug}`;
+      await assertFullTextPresent(
+        page,
+        DIALOG,
+        [
+          LONG_TEXT_TOKEN.sampleLocation,
+          LONG_TEXT_TOKEN.sampleEvolution,
+          LONG_TEXT_TOKEN.detailsLesion,
+          LONG_TEXT_TOKEN.petBreed,
+        ],
+        label,
+      );
+
+      const metrics = await readDetailMetrics(page, DIALOG);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, DIALOG, label);
+    });
+  }
+});
+
+// ── Admin · report workflow detail dialog ───────────────────────────────────
+test.describe("admin report detail keeps patient, study and file name", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "admin");
+      await page.route("**/api/admin/report-workflow**", async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            reports: [
+              {
+                id: 7301,
+                clinicId: 12,
+                clinicName: LONG_TEXT_CLINIC_REPORT.clinicName,
+                patientName: LONG_TEXT_CLINIC_REPORT.patientName,
+                fileName: LONG_TEXT_CLINIC_REPORT.fileName,
+                studyType: LONG_TEXT_CLINIC_REPORT.studyType,
+                uploadDate: "2026-06-17T12:00:00.000Z",
+                createdAt: "2026-06-08T09:00:00.000Z",
+                workflowStage: "processing",
+                specialStainRequested: false,
+                specialStainAt: null,
+                workflowUpdatedAt: "2026-06-18T11:00:00.000Z",
+              },
+            ],
+            pagination: { limit: 50, offset: 0, hasMore: false },
+          },
+        });
+      });
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard/admin?module=admin-report-upload");
+      await openFirstDetail(page);
+
+      const label = `admin report detail @ ${vp.slug}`;
+      await assertFullTextPresent(
+        page,
+        DIALOG,
+        [
+          LONG_TEXT_CLINIC_REPORT.patientName,
+          LONG_TEXT_CLINIC_REPORT.studyType,
+          LONG_TEXT_CLINIC_REPORT.fileName,
+        ],
+        label,
+      );
+
+      const metrics = await readDetailMetrics(page, DIALOG);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, DIALOG, label);
+    });
+  }
+});
+
+// ── Admin · failed login attempt detail dialog ──────────────────────────────
+//
+// The ROW here legitimately truncates the user agent: the table is a
+// pitch-locked adaptive canvas, so wrapping it in the cell would clip it
+// vertically and move the A03 row capacity. What must hold is the other half
+// of the SAFE_TRUNCATION contract — the detail dialog renders it WHOLE.
+test.describe("admin failed login detail discloses the whole user agent", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "admin");
+      await page.route("**/api/admin/failed-login-alerts**", async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            failedLoginAlerts: [
+              {
+                id: 5501,
+                surface: "admin",
+                username: "operador_auditoria_e2e",
+                reason: "invalid_credentials",
+                ipAddress: "203.0.113.24",
+                userAgent: LONG_TEXT_USER_AGENT,
+                createdAt: "2026-06-18T11:20:00.000Z",
+              },
+            ],
+            total: 1,
+            limit: 25,
+            offset: 0,
+          },
+        });
+      });
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard/admin?module=admin");
+
+      // The card lives behind the "Alertas" tab of the Resumen module on desktop
+      // and behind the "Alertas" chip of the mobile command module. Both expose a
+      // control with that accessible name, so one step reaches it on every
+      // viewport without branching on width.
+      const alertas = page
+        .getByRole("tab", { name: /^Alertas$/i })
+        .or(page.getByRole("button", { name: /^Alertas$/i }))
+        .locator("visible=true")
+        .first();
+      await alertas.waitFor({ state: "visible" });
+      await alertas.click();
+
+      // The card mounts a desktop table AND a mobile list; only one is visible
+      // per viewport, so the locator must filter by visibility, never by order.
+      const trigger = page
+        .getByRole("button", { name: /Ver detalle del intento fallido/i })
+        .locator("visible=true")
+        .first();
+      await trigger.waitFor({ state: "visible" });
+      await trigger.click();
+      await page.locator(DIALOG).first().waitFor();
+
+      const label = `admin failed login detail @ ${vp.slug}`;
+      await assertFullTextPresent(page, DIALOG, [LONG_TEXT_USER_AGENT], label);
+
+      const metrics = await readDetailMetrics(page, DIALOG);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, DIALOG, label);
+    });
+  }
+});
+
+// ── Admin · users and roles detail dialog ───────────────────────────────────
+//
+// Same shape as the failed-login case: the ROW legitimately truncates the user
+// name and the clinic name (pitch-locked table), and the DIALOG is the half of
+// the contract that has to render them whole. `title` was rejected as the
+// mechanism, so this drives the real trigger with the keyboard.
+test.describe("admin users and roles detail discloses user and clinic", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "admin");
+      await page.route("**/api/admin/users-roles**", async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            users: [
+              {
+                userType: "clinic",
+                userId: 4101,
+                username: LONG_TEXT_USER_ROLE.username,
+                role: "clinic_admin",
+                clinicId: 77,
+                clinicName: LONG_TEXT_USER_ROLE.clinicName,
+                clinicLocality: "Ciudad Autonoma de Buenos Aires",
+                createdAt: "2026-01-05T09:00:00.000Z",
+                updatedAt: "2026-02-10T15:30:00.000Z",
+              },
+            ],
+            total: 1,
+            totalPages: 1,
+            limit: 25,
+            offset: 0,
+            totals: { admin: 0, clinic: 1 },
+            checkedBy: { adminUserId: 41, username: "admin_operaciones" },
+          },
+        });
+      });
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard/admin?module=admin-users-roles");
+
+      // The card mounts a desktop table AND a mobile list; only one is visible
+      // per viewport, so the locator must filter by visibility, never by order.
+      const trigger = page
+        .getByRole("button", { name: /Ver detalle del usuario/i })
+        .locator("visible=true")
+        .first();
+      await trigger.waitFor({ state: "visible" });
+
+      // Keyboard access is part of the contract this dialog exists to satisfy:
+      // focus the trigger and open it with the keyboard, never with a click.
+      await trigger.focus();
+      await page.keyboard.press("Enter");
+      await page.locator(DIALOG).first().waitFor();
+
+      const label = `admin users/roles detail @ ${vp.slug}`;
+      await assertFullTextPresent(
+        page,
+        DIALOG,
+        [LONG_TEXT_USER_ROLE.username, LONG_TEXT_USER_ROLE.clinicName],
+        label,
+      );
+
+      const metrics = await readDetailMetrics(page, DIALOG);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, DIALOG, label);
+    });
+  }
+});
+
+// ── Clinic · particular tokens detail dialog ────────────────────────────────
+test.describe("clinic particular tokens detail keeps sample, evolution and lesion", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "clinic");
+      await page.route("**/api/particular-tokens**", async (route) => {
+        await route.fulfill({
+          json: {
+            success: true,
+            count: 1,
+            particularTokens: [
+              {
+                id: 9101,
+                clinicId: 12,
+                reportId: null,
+                tokenLast4: "4201",
+                tutorLastName: "Gomez",
+                petName: LONG_TEXT_TOKEN.petName,
+                petAge: "3 anos",
+                petBreed: LONG_TEXT_TOKEN.petBreed,
+                petSex: "female",
+                petSpecies: "canine",
+                sampleLocation: LONG_TEXT_TOKEN.sampleLocation,
+                sampleEvolution: LONG_TEXT_TOKEN.sampleEvolution,
+                detailsLesion: LONG_TEXT_TOKEN.detailsLesion,
+                extractionDate: "2026-06-10T10:00:00.000Z",
+                shippingDate: "2026-06-11T10:00:00.000Z",
+                isActive: true,
+                lastLoginAt: null,
+                createdAt: "2026-06-12T09:15:00.000Z",
+                updatedAt: "2026-06-17T16:20:00.000Z",
+                createdByAdminId: 41,
+                createdByClinicUserId: null,
+                hasLinkedReport: false,
+              },
+            ],
+            pagination: { limit: 50, offset: 0 },
+          },
+        });
+      });
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard?module=tokens");
+      await openFirstDetail(page);
+
+      const label = `clinic tokens detail @ ${vp.slug}`;
+      await assertFullTextPresent(
+        page,
+        DIALOG,
+        [
+          LONG_TEXT_TOKEN.sampleLocation,
+          LONG_TEXT_TOKEN.sampleEvolution,
+          LONG_TEXT_TOKEN.detailsLesion,
+          LONG_TEXT_TOKEN.petBreed,
+        ],
+        label,
+      );
+
+      const metrics = await readDetailMetrics(page, DIALOG);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, DIALOG, label);
+    });
+  }
+});
+
+// ── Clinic · informes workspace summary detail dialog (server-rendered) ─────
+test.describe("clinic informes summary detail keeps patient, study and file", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "clinic");
+      await enableLongTextFixture(page);
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard?module=informes");
+      await openFirstDetail(page);
+
+      const label = `clinic informes summary detail @ ${vp.slug}`;
+      await assertFullTextPresent(
+        page,
+        DIALOG,
+        [
+          LONG_TEXT_CLINIC_REPORT.patientName,
+          LONG_TEXT_CLINIC_REPORT.studyType,
+        ],
+        label,
+      );
+
+      const metrics = await readDetailMetrics(page, DIALOG);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, DIALOG, label);
+    });
+  }
+});
+
+// ── Clinic · informes full route master-detail panel (server-rendered) ──────
+//
+// The only detail in the audit that is NOT a ModuleDialog: on `lg` and up it is
+// a bounded grid track, below it is the same canvas inside the dialog. Both
+// mounts render `renderReportDetailCanvas`, so both are covered by driving the
+// route at a desktop and a mobile viewport.
+test.describe("clinic informes master-detail panel keeps the whole record", () => {
+  for (const vp of VIEWPORTS) {
+    test(`full text and no hidden glyphs at ${vp.slug}`, async ({ page }) => {
+      await setSession(page, "clinic");
+      await enableLongTextFixture(page);
+
+      await page.setViewportSize({ width: vp.width, height: vp.height });
+      await page.goto("/dashboard/informes");
+
+      // Same settle contract the shipped informes specs use: the route is
+      // server-rendered and then re-pages itself against the MEASURED canvas,
+      // so the row set is only stable after the adaptive page size resolves.
+      const list = page.locator("#reports-master-list");
+      const rows = list.locator("[id^='report-']");
+      await expect(async () => {
+        await expect(list).toBeVisible();
+        expect(await rows.count()).toBeGreaterThan(0);
+      }).toPass({ timeout: 15_000 });
+      await expect(async () => {
+        const first = await rows.count();
+        await page.waitForTimeout(150);
+        expect(await rows.count()).toBe(first);
+      }).toPass({ timeout: 10_000 });
+
+      await rows.first().click();
+
+      const isDesktopPanel = vp.width >= 1024;
+      let root = '#report-detail[data-detail-state="selected"]';
+      if (!isDesktopPanel) {
+        const openDialog = page.getByRole("button", { name: /ver detalle/i }).first();
+        await openDialog.waitFor({ state: "visible" });
+        await openDialog.click();
+        await page.locator(DIALOG).first().waitFor();
+        root = DIALOG;
+      } else {
+        await page.locator(root).first().waitFor();
+      }
+
+      const label = `clinic informes ${
+        isDesktopPanel ? "panel" : "dialog"
+      } detail @ ${vp.slug}`;
+
+      await assertFullTextPresent(
+        page,
+        root,
+        [
+          LONG_TEXT_CLINIC_REPORT.patientName,
+          LONG_TEXT_CLINIC_REPORT.studyType,
+        ],
+        label,
+      );
+
+      const metrics = await readDetailMetrics(page, root);
+      assertNoHiddenText(metrics, label);
+      assertNoDocumentScroll(metrics, label);
+      await assertSingleReachableScrollOwner(page, metrics, root, label);
+    });
+  }
+});

--- a/frontend/e2e/platform/app-shell/dashboard-global-masked-master-detail.spec.ts
+++ b/frontend/e2e/platform/app-shell/dashboard-global-masked-master-detail.spec.ts
@@ -253,6 +253,22 @@ async function readScrollContract(page: Page): Promise<ScrollContract> {
 // follow-up render settles on the real value, so a naive read can catch that
 // transient instead of the converged count. Wait until the count stops
 // changing for a few consecutive polls before trusting it.
+/**
+ * Waits for a settled, NON-EMPTY adaptive row count.
+ *
+ * The "non-empty" half is not cosmetic. Zero is a perfectly stable count, so the
+ * previous version settled on the not-yet-rendered empty list whenever the rows
+ * needed more than ~200ms (three 50ms reads) to appear — and then returned 0 to
+ * a caller whose very next assertion is `toBeGreaterThan(0)`. On a quiet machine
+ * the rows win the race and it passes; under a full parallel cohort they do not,
+ * which is exactly how this surfaced. The mobile caller below never flaked
+ * because it already awaits `toBeVisible()` on the first row before settling;
+ * the desktop caller did not, and that asymmetry is the whole bug.
+ *
+ * Both callers require a positive count, so requiring it HERE only converts a
+ * silent bogus 0 into an honest wait — and, if the rows genuinely never arrive,
+ * into a timeout that names the surface instead of a confusing `0 > 0` failure.
+ */
 async function waitForSettledRowCount(
   locator: Locator,
   label: string,
@@ -268,6 +284,10 @@ async function waitForSettledRowCount(
       previousCount = currentCount;
       stableReads = 0;
     }
+    expect(
+      currentCount,
+      `${label}: rows must render before the count can settle (currently ${currentCount})`,
+    ).toBeGreaterThan(0);
     expect(
       stableReads,
       `${label}: adaptive row count must settle (currently ${currentCount})`,

--- a/frontend/e2e/suites/catalog.ts
+++ b/frontend/e2e/suites/catalog.ts
@@ -131,6 +131,7 @@ export const E2E_SUITE_CATALOG = [
   entry("e2e/platform/accessibility/dashboard-accessibility-keyboard.spec.ts", "platform", "accessibility", "dashboard keyboard accessibility", ["visual-contract"], ci),
   entry("e2e/platform/app-shell/dashboard-app-shell-visibility-contract.spec.ts", "platform", "app-shell", "app shell visibility", ["visual-contract"], ci),
   entry("e2e/platform/app-shell/dashboard-card-navigation-shell.spec.ts", "platform", "app-shell", "navigation and deep links", ["visual-contract"], ci),
+  entry("e2e/platform/app-shell/dashboard-detail-text-integrity.spec.ts", "platform", "app-shell", "detail text integrity", ["visual-contract"], ci, { criticality: "P1", fixture: "admin-populated-api-server", notes: "PR-TRUNC: DETAIL/DIALOG surfaces must render clinical values in full; long synthetic strings, admin + clinic." }),
   entry("e2e/platform/app-shell/dashboard-global-masked-master-detail.spec.ts", "platform", "app-shell", "masked master detail", ["visual-contract"], ci),
   entry("e2e/platform/app-shell/dashboard-internal-no-scroll-contract.spec.ts", "platform", "app-shell", "internal no-scroll", ["visual-contract"], ci),
   entry("e2e/platform/app-shell/dashboard-mobile-shell-nav-contract.spec.ts", "platform", "app-shell", "mobile shell navigation", ["visual-contract"], ci),

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -561,6 +561,7 @@ export function ClinicInformesWorkspaceSummary({
           }}
           title={`Informe #${selectedReport.id}`}
           description={selectedReport.patientName ?? "Sin nombre"}
+          scrollableBody
         >
           <div
             data-clinic-reports-detail-dialog="true"

--- a/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
+++ b/frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx
@@ -571,7 +571,7 @@ export function ClinicInformesWorkspaceSummary({
                 <p className="text-[0.6875rem] text-muted-foreground">
                   Caso / Paciente
                 </p>
-                <p className="truncate text-sm font-semibold text-vetneb-ink">
+                <p className="dashboard-detail-value text-sm font-semibold text-vetneb-ink">
                   {selectedReport.patientName ?? "Sin nombre"}
                 </p>
               </div>
@@ -582,22 +582,26 @@ export function ClinicInformesWorkspaceSummary({
               />
             </div>
 
-            <dl className="grid grid-cols-2 gap-x-3 gap-y-2 rounded-lg border border-vetneb-line/70 px-3 py-2">
-              <div>
+            <dl className="grid grid-cols-1 gap-x-3 gap-y-2 rounded-lg border border-vetneb-line/70 px-3 py-2 sm:grid-cols-2">
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">Estudio</dt>
-                <dd className="truncate font-medium">
+                <dd className="dashboard-detail-value font-medium">
                   {selectedReport.studyType ?? "Tipo sin registrar"}
                 </dd>
               </div>
-              <div>
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">Fecha</dt>
-                <dd>{formatDate(selectedReport.uploadDate)}</dd>
+                <dd className="dashboard-detail-value">
+                  {formatDate(selectedReport.uploadDate)}
+                </dd>
               </div>
-              <div className="col-span-2 min-w-0">
+              <div className="min-w-0 sm:col-span-2">
                 <dt className="text-[0.6875rem] text-muted-foreground">
                   Archivo / Informe
                 </dt>
-                <dd className="truncate">{formatReportFile(selectedReport)}</dd>
+                <dd className="dashboard-detail-value">
+                  {formatReportFile(selectedReport)}
+                </dd>
               </div>
             </dl>
 

--- a/frontend/src/app/dashboard/admin/AdminAuditDetailDialog.tsx
+++ b/frontend/src/app/dashboard/admin/AdminAuditDetailDialog.tsx
@@ -14,6 +14,7 @@ export function AdminAuditDetailDialog({ row }: AdminAuditDetailDialogProps) {
     <ModuleDialog
       title={`Evento #${row.id}`}
       description={`${row.eventLabel} · ${row.date}`}
+      scrollableBody
       trigger={
         <Button
           type="button"

--- a/frontend/src/app/dashboard/admin/AdminAuditDetailDialog.tsx
+++ b/frontend/src/app/dashboard/admin/AdminAuditDetailDialog.tsx
@@ -28,43 +28,43 @@ export function AdminAuditDetailDialog({ row }: AdminAuditDetailDialogProps) {
       }
     >
       <dl className="grid grid-cols-1 gap-x-4 gap-y-3 text-[13px] sm:grid-cols-2">
-        <div>
+        <div className="min-w-0">
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Código
           </dt>
-          <dd className="mt-0.5 break-words font-mono text-xs text-vetneb-ink">
+          <dd className="dashboard-detail-value mt-0.5 font-mono text-xs text-vetneb-ink">
             {row.eventCode}
           </dd>
         </div>
-        <div>
+        <div className="min-w-0">
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Fecha
           </dt>
-          <dd className="mt-0.5 text-vetneb-ink">{row.date}</dd>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">{row.date}</dd>
         </div>
-        <div>
+        <div className="min-w-0">
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Actor
           </dt>
-          <dd className="mt-0.5 text-vetneb-ink">{row.actor}</dd>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">{row.actor}</dd>
         </div>
-        <div>
+        <div className="min-w-0">
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Entidad
           </dt>
-          <dd className="mt-0.5 text-vetneb-ink">{row.entity}</dd>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">{row.entity}</dd>
         </div>
-        <div className="sm:col-span-2">
+        <div className="min-w-0 sm:col-span-2">
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Acción registrada
           </dt>
-          <dd className="mt-0.5 break-words text-vetneb-ink">{row.action}</dd>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">{row.action}</dd>
         </div>
-        <div className="rounded-lg border border-vetneb-line/70 bg-muted/25 px-3 py-2 sm:col-span-2">
+        <div className="min-w-0 rounded-lg border border-vetneb-line/70 bg-muted/25 px-3 py-2 sm:col-span-2">
           <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
             Detalle seguro
           </dt>
-          <dd className="mt-1 break-words text-xs leading-5 text-vetneb-ink/85">
+          <dd className="dashboard-detail-value mt-1 text-xs leading-5 text-vetneb-ink/85">
             {row.detail}
           </dd>
         </div>

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -436,7 +436,7 @@ export function AdminFailedLoginAlertsReadOnlyCard({
                   ))
                 ) : isPending ? (
                   <TableRow>
-                    <TableCell colSpan={7} className="p-3">
+                    <TableCell colSpan={8} className="p-3">
                       <LoadingState
                         variant="table"
                         compact
@@ -447,7 +447,7 @@ export function AdminFailedLoginAlertsReadOnlyCard({
                   </TableRow>
                 ) : (
                   <TableRow>
-                    <TableCell colSpan={7} className="clinical-table-state">
+                    <TableCell colSpan={8} className="clinical-table-state">
                       {error ? (
                         "No se pudieron cargar los intentos fallidos."
                       ) : (

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx
@@ -40,6 +40,7 @@ import type {
   AdminFailedLoginAlertsSnapshot,
   AdminFailedLoginAlertSurface,
 } from "@/types";
+import { AdminFailedLoginDetailDialog } from "./AdminFailedLoginDetailDialog";
 import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
 
 // Server pagination is now sized by the measured rows container (Zero-Scroll
@@ -380,6 +381,7 @@ export function AdminFailedLoginAlertsReadOnlyCard({
                   <TableHead>IP</TableHead>
                   <TableHead>User agent</TableHead>
                   <TableHead>Fecha</TableHead>
+                  <TableHead className="w-[4.5rem] text-right">Acción</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
@@ -407,11 +409,28 @@ export function AdminFailedLoginAlertsReadOnlyCard({
                       <TableCell className="text-xs text-muted-foreground">
                         {formatNullable(alert.ipAddress)}
                       </TableCell>
+                      {/* PR-TRUNC. The cell stays single-line: this table is a
+                          pitch-locked adaptive canvas (`row-pitch="compact"`,
+                          `td { block-size: var(--dash-row-pitch); overflow:
+                          hidden }`), so letting a ~130-character user agent
+                          wrap would trade a horizontal ellipsis for a VERTICAL
+                          clip and move the adaptive row capacity (A03). The
+                          truncation is legitimate ONLY because the "Ver" action
+                          below opens AdminFailedLoginDetailDialog, which renders
+                          the whole user agent — a real keyboard- and screen-
+                          reader-reachable surface, not a hover-only tooltip. */}
                       <TableCell className="max-w-xs truncate text-xs text-muted-foreground">
                         {formatNullable(alert.userAgent)}
                       </TableCell>
                       <TableCell className="text-xs text-muted-foreground">
                         {formatDateTime(alert.createdAt)}
+                      </TableCell>
+                      <TableCell className="text-right">
+                        <AdminFailedLoginDetailDialog
+                          alert={alert}
+                          surfaceLabel={formatSurface(alert.surface)}
+                          reasonLabel={formatReason(alert.reason)}
+                        />
                       </TableCell>
                     </TableRow>
                   ))
@@ -549,6 +568,13 @@ export function AdminFailedLoginAlertsReadOnlyCard({
                 </div>
                 <span className="shrink-0 font-mono text-[10px] text-muted-foreground">
                   #{alert.id}
+                </span>
+                <span className="shrink-0">
+                  <AdminFailedLoginDetailDialog
+                    alert={alert}
+                    surfaceLabel={formatSurface(alert.surface)}
+                    reasonLabel={formatReason(alert.reason)}
+                  />
                 </span>
               </article>
             ))

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginDetailDialog.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginDetailDialog.tsx
@@ -46,6 +46,7 @@ export function AdminFailedLoginDetailDialog({
     <ModuleDialog
       title={`Intento fallido #${alert.id}`}
       description={`${surfaceLabel} · ${reasonLabel}`}
+      scrollableBody
       trigger={
         <Button
           type="button"

--- a/frontend/src/app/dashboard/admin/AdminFailedLoginDetailDialog.tsx
+++ b/frontend/src/app/dashboard/admin/AdminFailedLoginDetailDialog.tsx
@@ -1,0 +1,125 @@
+"use client";
+
+import { Eye } from "lucide-react";
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import { Button } from "@/components/ui/button";
+import { formatDateTime } from "@/lib/utils";
+import type { AdminFailedLoginAlertSummary } from "@/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-TRUNC · full-value disclosure for a failed-login attempt.
+//
+// The desktop row renders `userAgent` in a `max-w-xs truncate` cell, and the
+// mobile row does not render it at all. That table is a pitch-locked adaptive
+// canvas (`row-pitch="compact"`; `td { block-size: var(--dash-row-pitch);
+// overflow: hidden }`), so letting a ~130-character user agent wrap in the cell
+// would trade a horizontal ellipsis for a VERTICAL clip and move the adaptive
+// row capacity (A03) — the truncation in the ROW is legitimate.
+//
+// What was missing is the other half of the SAFE_TRUNCATION contract: a clear,
+// accessible way to read the whole value. A `title` attribute is not that — it
+// is hover-only in practice, unreliable for assistive technology and invisible
+// to touch. This dialog is the same mechanism the admin audit table already
+// uses (`AdminAuditDetailDialog`): a real, keyboard-reachable, screen-reader
+// announced terminal surface that renders every field of the record in full.
+//
+// Being a terminal surface, nothing here may hide a value: every datum uses
+// `.dashboard-detail-value` (wrap + `overflow-wrap: anywhere`, no clipping),
+// and the census in test/architecture/dashboard-truncation-integrity.test.ts
+// pins it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AdminFailedLoginDetailDialogProps = {
+  alert: AdminFailedLoginAlertSummary;
+  /** Rendered label for the alert surface, resolved by the parent card. */
+  surfaceLabel: string;
+  /** Rendered label for the alert reason, resolved by the parent card. */
+  reasonLabel: string;
+};
+
+export function AdminFailedLoginDetailDialog({
+  alert,
+  surfaceLabel,
+  reasonLabel,
+}: AdminFailedLoginDetailDialogProps) {
+  return (
+    <ModuleDialog
+      title={`Intento fallido #${alert.id}`}
+      description={`${surfaceLabel} · ${reasonLabel}`}
+      trigger={
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          className="h-7 gap-1 px-2 text-xs"
+          aria-label={`Ver detalle del intento fallido ${alert.id}`}
+        >
+          <Eye className="h-3.5 w-3.5" aria-hidden="true" />
+          Ver
+        </Button>
+      }
+    >
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-3 text-[13px] sm:grid-cols-2">
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Superficie
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {surfaceLabel}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Fecha
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {formatDateTime(alert.createdAt)}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Usuario
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {alert.username && alert.username.trim() ? alert.username : "—"}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Motivo
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {reasonLabel}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            IP
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 font-mono text-xs text-vetneb-ink">
+            {alert.ipAddress ?? "—"}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Identificador
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 font-mono text-xs text-vetneb-ink">
+            #{alert.id}
+          </dd>
+        </div>
+        <div className="min-w-0 rounded-lg border border-vetneb-line/70 bg-muted/25 px-3 py-2 sm:col-span-2">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            User agent
+          </dt>
+          <dd className="dashboard-detail-value mt-1 font-mono text-xs leading-5 text-vetneb-ink/85">
+            {alert.userAgent ?? "—"}
+          </dd>
+        </div>
+      </dl>
+      <p className="mt-3 text-[11px] leading-4 text-muted-foreground">
+        La vista omite credenciales, cookies y metadata de sesión.
+      </p>
+    </ModuleDialog>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -1886,29 +1886,29 @@ export function AdminParticularTokensCard() {
                   <Badge variant={selectedToken.hasLinkedReport ? "default" : "outline"} className="h-5 px-1.5 text-[0.6875rem]">{selectedToken.hasLinkedReport ? "Informe vinculado" : "Sin informe"}</Badge>
                 </div>
                 <dl className="grid grid-cols-1 divide-y divide-vetneb-line/55 rounded-lg border border-vetneb-line/70 text-xs sm:grid-cols-2 sm:divide-x sm:divide-y-0">
-                  <div className="space-y-1 p-2.5">
+                  <div className="min-w-0 space-y-1 p-2.5">
                     <dt className="text-[0.6875rem] text-muted-foreground">Clínica / origen</dt>
-                    <dd className="font-medium">{formatTokenClinicLink(clinicOptions, selectedToken.clinicId)}</dd>
-                    <dd className="text-muted-foreground">{formatTokenSource(selectedToken)}</dd>
+                    <dd className="dashboard-detail-value font-medium">{formatTokenClinicLink(clinicOptions, selectedToken.clinicId)}</dd>
+                    <dd className="dashboard-detail-value text-muted-foreground">{formatTokenSource(selectedToken)}</dd>
                   </div>
-                  <div className="space-y-1 p-2.5">
+                  <div className="min-w-0 space-y-1 p-2.5">
                     <dt className="text-[0.6875rem] text-muted-foreground">Paciente / tutor</dt>
-                    <dd className="font-medium">{selectedToken.petName} · {selectedToken.tutorLastName}</dd>
-                    <dd className="text-muted-foreground">{selectedToken.petSpecies} · {selectedToken.petBreed} · {selectedToken.petSex} · {selectedToken.petAge}</dd>
+                    <dd className="dashboard-detail-value font-medium">{selectedToken.petName} · {selectedToken.tutorLastName}</dd>
+                    <dd className="dashboard-detail-value text-muted-foreground">{selectedToken.petSpecies} · {selectedToken.petBreed} · {selectedToken.petSex} · {selectedToken.petAge}</dd>
                   </div>
                 </dl>
-                <dl className="grid grid-cols-2 gap-x-3 gap-y-2 text-xs">
-                  <div><dt className="text-[0.6875rem] text-muted-foreground">Muestra</dt><dd className="truncate">{selectedToken.sampleLocation}</dd></div>
-                  <div><dt className="text-[0.6875rem] text-muted-foreground">Evolución</dt><dd className="truncate">{selectedToken.sampleEvolution}</dd></div>
-                  <div><dt className="text-[0.6875rem] text-muted-foreground">Extracción</dt><dd>{formatDate(selectedToken.extractionDate)}</dd></div>
-                  <div><dt className="text-[0.6875rem] text-muted-foreground">Envío</dt><dd>{formatDate(selectedToken.shippingDate)}</dd></div>
-                  <div><dt className="text-[0.6875rem] text-muted-foreground">Último acceso</dt><dd>{selectedToken.lastLoginAt ? formatDate(selectedToken.lastLoginAt) : "—"}</dd></div>
-                  <div><dt className="text-[0.6875rem] text-muted-foreground">Token seguro</dt><dd className="font-mono">Token ****{selectedToken.tokenLast4}</dd></div>
+                <dl className="grid grid-cols-1 gap-x-3 gap-y-2 text-xs sm:grid-cols-2">
+                  <div className="min-w-0"><dt className="text-[0.6875rem] text-muted-foreground">Muestra</dt><dd className="dashboard-detail-value">{selectedToken.sampleLocation}</dd></div>
+                  <div className="min-w-0"><dt className="text-[0.6875rem] text-muted-foreground">Evolución</dt><dd className="dashboard-detail-value">{selectedToken.sampleEvolution}</dd></div>
+                  <div className="min-w-0"><dt className="text-[0.6875rem] text-muted-foreground">Extracción</dt><dd className="dashboard-detail-value">{formatDate(selectedToken.extractionDate)}</dd></div>
+                  <div className="min-w-0"><dt className="text-[0.6875rem] text-muted-foreground">Envío</dt><dd className="dashboard-detail-value">{formatDate(selectedToken.shippingDate)}</dd></div>
+                  <div className="min-w-0"><dt className="text-[0.6875rem] text-muted-foreground">Último acceso</dt><dd className="dashboard-detail-value">{selectedToken.lastLoginAt ? formatDate(selectedToken.lastLoginAt) : "—"}</dd></div>
+                  <div className="min-w-0"><dt className="text-[0.6875rem] text-muted-foreground">Token seguro</dt><dd className="dashboard-detail-value font-mono">Token ****{selectedToken.tokenLast4}</dd></div>
                 </dl>
                 {selectedToken.detailsLesion ? (
-                  <div className="rounded-lg border border-vetneb-line/65 px-2.5 py-2 text-xs">
+                  <div className="min-w-0 rounded-lg border border-vetneb-line/65 px-2.5 py-2 text-xs">
                     <p className="text-[0.6875rem] text-muted-foreground">Detalle de lesión</p>
-                    <p className="line-clamp-2">{selectedToken.detailsLesion}</p>
+                    <p className="dashboard-detail-value">{selectedToken.detailsLesion}</p>
                   </div>
                 ) : null}
                 {selectedToken.hasLinkedReport && selectedToken.reportId ? (

--- a/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx
@@ -1861,6 +1861,7 @@ export function AdminParticularTokensCard() {
           busy={revokingTokenId === selectedToken.id || isSelectedTrackingUpdating}
           title={`Token ****${selectedToken.tokenLast4}`}
           description={formatTokenTitle(clinicOptions, selectedToken)}
+          scrollableBody
           footer={
             <Button type="button" variant="destructive" size="sm" disabled={revokingTokenId === selectedToken.id} onClick={() => void handleDeleteToken(selectedToken)}>
               {revokingTokenId === selectedToken.id ? "Eliminando…" : "Eliminar token"}

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -902,28 +902,28 @@ export function AdminReportsCard() {
           }
         >
           <div className="space-y-3 text-[0.8125rem]">
-            <div className="grid grid-cols-2 gap-x-3 gap-y-2 rounded-md border border-vetneb-line/70 px-3 py-2">
-              <div>
+            <div className="grid grid-cols-1 gap-x-3 gap-y-2 rounded-md border border-vetneb-line/70 px-3 py-2 sm:grid-cols-2">
+              <div className="min-w-0">
                 <p className="text-[0.6875rem] text-muted-foreground">Paciente</p>
-                <p className="truncate font-medium">
+                <p className="dashboard-detail-value font-medium">
                   {selectedReport.patientName || "Sin registrar"}
                 </p>
               </div>
-              <div>
+              <div className="min-w-0">
                 <p className="text-[0.6875rem] text-muted-foreground">Estudio</p>
-                <p className="truncate font-medium">{studyLabel(selectedReport.studyType)}</p>
+                <p className="dashboard-detail-value font-medium">{studyLabel(selectedReport.studyType)}</p>
               </div>
-              <div>
+              <div className="min-w-0">
                 <p className="text-[0.6875rem] text-muted-foreground">Carga</p>
-                <p>{formatDate(selectedReport.uploadDate ?? selectedReport.createdAt)}</p>
+                <p className="dashboard-detail-value">{formatDate(selectedReport.uploadDate ?? selectedReport.createdAt)}</p>
               </div>
-              <div>
+              <div className="min-w-0">
                 <p className="text-[0.6875rem] text-muted-foreground">Última actualización</p>
-                <p>{formatDate(selectedReport.workflowUpdatedAt)}</p>
+                <p className="dashboard-detail-value">{formatDate(selectedReport.workflowUpdatedAt)}</p>
               </div>
-              <div className="col-span-2 min-w-0">
+              <div className="min-w-0 sm:col-span-2">
                 <p className="text-[0.6875rem] text-muted-foreground">Archivo</p>
-                <p className="truncate">{selectedReport.fileName || "Sin archivo disponible"}</p>
+                <p className="dashboard-detail-value">{selectedReport.fileName || "Sin archivo disponible"}</p>
               </div>
             </div>
 

--- a/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminReportsCard.tsx
@@ -900,6 +900,7 @@ export function AdminReportsCard() {
           description={
             selectedReport.clinicName || `Clínica #${selectedReport.clinicId}`
           }
+          scrollableBody
         >
           <div className="space-y-3 text-[0.8125rem]">
             <div className="grid grid-cols-1 gap-x-3 gap-y-2 rounded-md border border-vetneb-line/70 px-3 py-2 sm:grid-cols-2">

--- a/frontend/src/app/dashboard/admin/AdminUserRoleDetailDialog.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUserRoleDetailDialog.tsx
@@ -57,6 +57,7 @@ export function AdminUserRoleDetailDialog({
     <ModuleDialog
       title={`Usuario #${user.userId}`}
       description={`${userTypeLabel} · ${roleLabel}`}
+      scrollableBody
       trigger={
         <Button
           type="button"

--- a/frontend/src/app/dashboard/admin/AdminUserRoleDetailDialog.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUserRoleDetailDialog.tsx
@@ -1,0 +1,133 @@
+"use client";
+
+import { Eye } from "lucide-react";
+import { ModuleDialog } from "@/components/dashboard/ModuleDialog";
+import { Button } from "@/components/ui/button";
+import { formatDateTime } from "@/lib/utils";
+import type { AdminRoleUserSummary } from "@/types";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-TRUNC · full-value disclosure for a users/roles record.
+//
+// The row legitimately truncates `username` and the clinic name: the table is a
+// pitch-locked adaptive canvas (`row-pitch="compact"`; `td { block-size:
+// var(--dash-row-pitch); overflow: hidden }`), so wrapping either value in the
+// cell would trade a horizontal ellipsis for a VERTICAL clip and move the
+// adaptive row capacity (A03).
+//
+// What was missing is the other half of the SAFE_TRUNCATION contract. The card
+// shipped with a `title` attribute as its only mitigation, and `title` is not an
+// accessible disclosure: hover-only in practice, unreliable for assistive
+// technology, invisible to touch, and not selectable for copy. This dialog is
+// the same mechanism the admin audit and failed-login tables already use — a
+// real, keyboard-reachable, screen-reader announced terminal surface.
+//
+// STRICTLY READ-ONLY. Role changes stay where they already are (the "Cambiar
+// rol" control in the same action cell); this surface renders the record and
+// nothing else. It adds no fetching and no business logic: every value comes
+// from the row the card already holds, and the labels are resolved by the card
+// and passed in, exactly like AdminFailedLoginDetailDialog does.
+//
+// Being a terminal surface, nothing here may hide a value: every datum uses
+// `.dashboard-detail-value` (wrap + `overflow-wrap: anywhere`, no clipping) and
+// the census in test/architecture/dashboard-truncation-integrity.test.ts pins
+// it.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type AdminUserRoleDetailDialogProps = {
+  user: AdminRoleUserSummary;
+  /** Rendered label for the user type, resolved by the parent card. */
+  userTypeLabel: string;
+  /** Rendered label for the role, resolved by the parent card. */
+  roleLabel: string;
+  /** Clinic name as the row shows it, already falling back per user type. */
+  clinicLabel: string;
+  /** Optional clinic metadata line the row renders under the clinic name. */
+  clinicMetadata: string | null;
+};
+
+export function AdminUserRoleDetailDialog({
+  user,
+  userTypeLabel,
+  roleLabel,
+  clinicLabel,
+  clinicMetadata,
+}: AdminUserRoleDetailDialogProps) {
+  return (
+    <ModuleDialog
+      title={`Usuario #${user.userId}`}
+      description={`${userTypeLabel} · ${roleLabel}`}
+      trigger={
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          aria-label={`Ver detalle del usuario ${user.username}`}
+        >
+          <Eye className="h-3.5 w-3.5" aria-hidden="true" />
+        </Button>
+      }
+    >
+      <dl className="grid grid-cols-1 gap-x-4 gap-y-3 text-[13px] sm:grid-cols-2">
+        <div className="min-w-0 sm:col-span-2">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Usuario
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 font-medium text-vetneb-ink">
+            {user.username}
+          </dd>
+        </div>
+        <div className="min-w-0 sm:col-span-2">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Clínica
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {clinicLabel}
+          </dd>
+          {clinicMetadata ? (
+            <dd className="dashboard-detail-value mt-0.5 text-xs text-muted-foreground">
+              {clinicMetadata}
+            </dd>
+          ) : null}
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Tipo
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {userTypeLabel}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Rol
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 text-vetneb-ink">
+            {roleLabel}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Creado
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 tabular-nums text-vetneb-ink">
+            {formatDateTime(user.createdAt)}
+          </dd>
+        </div>
+        <div className="min-w-0">
+          <dt className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground">
+            Actualizado
+          </dt>
+          <dd className="dashboard-detail-value mt-0.5 tabular-nums text-vetneb-ink">
+            {formatDateTime(user.updatedAt)}
+          </dd>
+        </div>
+      </dl>
+      <p className="mt-3 text-[11px] leading-4 text-muted-foreground">
+        Vista de sólo lectura. El cambio de rol se realiza desde la acción de la
+        fila.
+      </p>
+    </ModuleDialog>
+  );
+}

--- a/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
+++ b/frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx
@@ -32,6 +32,7 @@ import type {
   AdminUsersRolesSnapshot,
   ClinicUserRole,
 } from "@/types";
+import { AdminUserRoleDetailDialog } from "./AdminUserRoleDetailDialog";
 import { AdminMobileOpsPager } from "./AdminMobileOpsPager";
 
 // Server pagination is now sized by the measured rows container (Zero-Scroll
@@ -625,23 +626,42 @@ export function AdminUsersRolesReadOnlyCard() {
                           {formatDateTime(user.updatedAt)}
                         </TableCell>
                         <TableCell className="text-right">
-                          {user.userType === "clinic" ? (
-                            <Button
-                              type="button"
-                              variant="outline"
-                              size="sm"
-                              className="h-7 px-2 text-xs"
-                              disabled={disableUserActions}
-                              aria-busy={isChanging ? true : undefined}
-                              onClick={() => void handleChangeClinicRole(user)}
-                            >
-                              {isChanging ? "Cambiando..." : "Cambiar rol"}
-                            </Button>
-                          ) : (
-                            <span className="text-[11px] text-muted-foreground">
-                              No editable
-                            </span>
-                          )}
+                          {/* PR-TRUNC. The detail trigger reuses the EXISTING
+                              action cell, so the table keeps its column count
+                              and its widths: no geometry moves and the
+                              pitch-locked capacity (A03) is untouched. The
+                              trigger is icon-only for the same reason, and
+                              carries the user name in its accessible name. */}
+                          <span className="flex items-center justify-end gap-1">
+                            {user.userType === "clinic" ? (
+                              <Button
+                                type="button"
+                                variant="outline"
+                                size="sm"
+                                className="h-7 px-2 text-xs"
+                                disabled={disableUserActions}
+                                aria-busy={isChanging ? true : undefined}
+                                onClick={() => void handleChangeClinicRole(user)}
+                              >
+                                {isChanging ? "Cambiando..." : "Cambiar rol"}
+                              </Button>
+                            ) : (
+                              <span className="text-[11px] text-muted-foreground">
+                                No editable
+                              </span>
+                            )}
+                            <AdminUserRoleDetailDialog
+                              user={user}
+                              userTypeLabel={formatUserType(user.userType)}
+                              roleLabel={formatRole(user.role)}
+                              clinicLabel={
+                                user.userType === "clinic"
+                                  ? user.clinicName || `Clínica #${user.clinicId}`
+                                  : "Administración VETNEB"
+                              }
+                              clinicMetadata={getClinicMetadata(user)}
+                            />
+                          </span>
                         </TableCell>
                       </TableRow>
                     );
@@ -876,6 +896,17 @@ export function AdminUsersRolesReadOnlyCard() {
                       No editable
                     </span>
                   )}
+                  <AdminUserRoleDetailDialog
+                    user={user}
+                    userTypeLabel={formatUserType(user.userType)}
+                    roleLabel={formatRole(user.role)}
+                    clinicLabel={
+                      user.userType === "clinic"
+                        ? user.clinicName || `Clínica #${user.clinicId}`
+                        : "Administración VETNEB"
+                    }
+                    clinicMetadata={getClinicMetadata(user)}
+                  />
                 </article>
               );
             })

--- a/frontend/src/app/dashboard/admin/page.tsx
+++ b/frontend/src/app/dashboard/admin/page.tsx
@@ -486,8 +486,14 @@ export default async function AdminPage({
             ? `${corsOrigins.length} origen(es) activo(s)`
             : "Sin orígenes configurados"}
         </p>
+        {/* PR-TRUNC. This is the terminal render of the active CORS origins —
+            the system-status INSPECTOR has no deeper surface — and `truncate`
+            showed only the first origin of the list. The sibling "Contacto
+            email" card already wraps `contactRecipients.join(", ")` with no
+            truncation in the same grid, so wrapping here is the consistent
+            behaviour, not a new risk. */}
         {corsOrigins.length > 0 ? (
-          <p className="mt-1 truncate text-xs text-muted-foreground">
+          <p className="dashboard-detail-value mt-1 text-xs text-muted-foreground">
             {corsOrigins.join(", ")}
           </p>
         ) : null}

--- a/frontend/src/app/dashboard/informes/InformesReportsList.tsx
+++ b/frontend/src/app/dashboard/informes/InformesReportsList.tsx
@@ -767,7 +767,7 @@ export function InformesReportsList({
             >
               <div
                 data-informes-detail-dialog="true"
-                className="flex min-h-0 flex-col overflow-hidden"
+                className="flex min-h-0 flex-1 flex-col overflow-hidden"
               >
                 {renderReportDetailCanvas({
                   actionDockSurface: "dialog",

--- a/frontend/src/app/dashboard/informes/InformesReportsList.tsx
+++ b/frontend/src/app/dashboard/informes/InformesReportsList.tsx
@@ -346,8 +346,18 @@ export function InformesReportsList({
   }
 
   // Bounded detail canvas (desktop panel + mobile dialog body): compact
-  // header, segmented sections and a persistent action dock. No core
-  // scroller — every section fits its canvas; long values truncate.
+  // header, segmented sections and a persistent action dock.
+  //
+  // PR-TRUNC. This canvas used to keep every section inside its box by
+  // TRUNCATING the values — measured on the shipped build, the report title,
+  // the clinic, the patient, the study type and the file name were all
+  // `truncate`, so at 360x800 a long study type rendered ~15% of its
+  // characters and the rest was unreachable: the panel IS the terminal surface
+  // for those fields, there is nothing deeper to open. Values now wrap
+  // (`.dashboard-detail-value`) and the SECTION panel below owns the single
+  // local scroll owner, so extra height is scrolled inside the section instead
+  // of being clipped, and the header, the tablist and the action dock stay
+  // pinned and visible without scrolling.
   function renderReportDetailCanvas({
     actionDockSurface,
     exposeActionDock,
@@ -363,128 +373,144 @@ export function InformesReportsList({
 
     return (
       <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-hidden">
-        <div className="flex shrink-0 items-start justify-between gap-3 border-b border-vetneb-line/70 pb-3">
-          <div className="min-w-0">
-            <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
-              Detalle del informe
-            </p>
-            <h2
-              id="report-detail-heading"
-              className="mt-0.5 truncate text-base font-semibold text-vetneb-ink"
-            >
-              {getReportTitle(report)}
-            </h2>
-            <p className="truncate text-xs text-muted-foreground">
-              Clínica {report.clinicName ?? `#${report.clinicId}`}
-            </p>
-          </div>
-          <StatusBadge
-            status={report.status}
-            label={getReportStatusLabel(report.status)}
-          />
-        </div>
+        {/* The ONE local scroll owner of this detail. It wraps the header, the
+            tablist and the section body — everything that can grow once the
+            values wrap — while the action dock below stays OUTSIDE it and
+            therefore always visible without scrolling (AGENTS §10, "acciones
+            críticas visibles = 100%").
 
+            Measured need: at 1366x768 with a long report title and a long
+            clinic name the canvas reported scrollHeight 278 against
+            clientHeight 228, i.e. the bounded grid track clipped 50px of the
+            detail. Putting the owner only on the section body was not enough —
+            the header itself is what grew. */}
         <div
-          role="tablist"
-          aria-label="Secciones del detalle del informe"
-          data-informes-detail-sections="true"
-          className="dashboard-module-tablist shrink-0"
+          data-informes-detail-scroll-owner="true"
+          className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto overscroll-contain"
         >
-          {REPORT_DETAIL_SECTIONS.map((section) => (
-            <button
-              key={section.id}
-              type="button"
-              role="tab"
-              aria-selected={detailSection === section.id}
-              data-informes-detail-section-tab={section.id}
-              onClick={() => setDetailSection(section.id)}
-              className="dashboard-module-tab focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85"
-            >
-              {section.label}
-            </button>
-          ))}
-        </div>
-
-        <div
-          className="flex min-h-0 flex-1 flex-col overflow-hidden"
-          data-informes-detail-section-panel={detailSection}
-        >
-          {detailSection === "resumen" ? (
-            <dl className="grid min-h-0 grid-cols-2 content-start gap-2 overflow-hidden xl:grid-cols-3">
-              <div className="surface-soft min-w-0">
-                <dt className="text-xs text-muted-foreground">Paciente</dt>
-                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
-                  {report.patientName ?? "—"}
-                </dd>
-              </div>
-              <div className="surface-soft min-w-0">
-                <dt className="text-xs text-muted-foreground">Tipo de estudio</dt>
-                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
-                  {report.studyType ?? "—"}
-                </dd>
-              </div>
-              <div className="surface-soft min-w-0">
-                <dt className="text-xs text-muted-foreground">Fecha</dt>
-                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
-                  {formatDate(report.uploadDate)}
-                </dd>
-              </div>
-              <div className="surface-soft min-w-0">
-                <dt className="text-xs text-muted-foreground">Creado</dt>
-                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
-                  {formatDate(report.createdAt)}
-                </dd>
-              </div>
-              <div className="surface-soft min-w-0">
-                <dt className="text-xs text-muted-foreground">Actualizado</dt>
-                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
-                  {formatDate(report.updatedAt)}
-                </dd>
-              </div>
-              <div className="surface-soft min-w-0">
-                <dt className="text-xs text-muted-foreground">Estado</dt>
-                <dd className="mt-1 truncate font-semibold text-vetneb-ink">
-                  {getReportStatusLabel(report.status)}
-                </dd>
-              </div>
-            </dl>
-          ) : null}
-
-          {detailSection === "archivos" ? (
-            <div className="surface-soft min-w-0">
-              <p className="text-xs text-muted-foreground">Archivo / Informe</p>
-              <p className="mt-1 truncate font-semibold text-vetneb-ink">
-                {report.fileName ?? (report.hasFile ? "Disponible" : "—")}
+          <div className="flex shrink-0 items-start justify-between gap-3 border-b border-vetneb-line/70 pb-3">
+            <div className="min-w-0">
+              <p className="text-xs font-semibold uppercase tracking-[0.1em] text-muted-foreground">
+                Detalle del informe
               </p>
-              <p className="mt-1 text-xs text-muted-foreground">
-                {report.hasFile
-                  ? "El documento está disponible en el dock de acciones."
-                  : "El informe aún no tiene archivo vinculado."}
+              <h2
+                id="report-detail-heading"
+                className="dashboard-detail-value mt-0.5 text-base font-semibold text-vetneb-ink"
+              >
+                {getReportTitle(report)}
+              </h2>
+              <p className="dashboard-detail-value text-xs text-muted-foreground">
+                Clínica {report.clinicName ?? `#${report.clinicId}`}
               </p>
             </div>
-          ) : null}
+            <StatusBadge
+              status={report.status}
+              label={getReportStatusLabel(report.status)}
+            />
+          </div>
 
-          {detailSection === "timeline" ? (
-            <section
-              className="flex min-h-0 flex-col gap-2 overflow-hidden"
-              aria-labelledby="study-timeline-heading"
-            >
-              <div className="shrink-0">
-                <h3
-                  id="study-timeline-heading"
-                  className="text-sm font-semibold text-vetneb-ink"
-                >
-                  Línea de tiempo del estudio
-                </h3>
-                <p className="truncate text-xs text-muted-foreground">
-                  Pasos derivados del estado y fechas ya disponibles.
+          <div
+            role="tablist"
+            aria-label="Secciones del detalle del informe"
+            data-informes-detail-sections="true"
+            className="dashboard-module-tablist shrink-0"
+          >
+            {REPORT_DETAIL_SECTIONS.map((section) => (
+              <button
+                key={section.id}
+                type="button"
+                role="tab"
+                aria-selected={detailSection === section.id}
+                data-informes-detail-section-tab={section.id}
+                onClick={() => setDetailSection(section.id)}
+                className="dashboard-module-tab focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/85"
+              >
+                {section.label}
+              </button>
+            ))}
+          </div>
+
+          <div
+            className="flex min-h-0 flex-1 flex-col"
+            data-informes-detail-section-panel={detailSection}
+          >
+            {detailSection === "resumen" ? (
+              <dl className="grid min-h-0 grid-cols-1 content-start gap-2 sm:grid-cols-2 xl:grid-cols-3">
+                <div className="surface-soft min-w-0">
+                  <dt className="text-xs text-muted-foreground">Paciente</dt>
+                  <dd className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                    {report.patientName ?? "—"}
+                  </dd>
+                </div>
+                <div className="surface-soft min-w-0">
+                  <dt className="text-xs text-muted-foreground">Tipo de estudio</dt>
+                  <dd className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                    {report.studyType ?? "—"}
+                  </dd>
+                </div>
+                <div className="surface-soft min-w-0">
+                  <dt className="text-xs text-muted-foreground">Fecha</dt>
+                  <dd className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                    {formatDate(report.uploadDate)}
+                  </dd>
+                </div>
+                <div className="surface-soft min-w-0">
+                  <dt className="text-xs text-muted-foreground">Creado</dt>
+                  <dd className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                    {formatDate(report.createdAt)}
+                  </dd>
+                </div>
+                <div className="surface-soft min-w-0">
+                  <dt className="text-xs text-muted-foreground">Actualizado</dt>
+                  <dd className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                    {formatDate(report.updatedAt)}
+                  </dd>
+                </div>
+                <div className="surface-soft min-w-0">
+                  <dt className="text-xs text-muted-foreground">Estado</dt>
+                  <dd className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                    {getReportStatusLabel(report.status)}
+                  </dd>
+                </div>
+              </dl>
+            ) : null}
+
+            {detailSection === "archivos" ? (
+              <div className="surface-soft min-w-0">
+                <p className="text-xs text-muted-foreground">Archivo / Informe</p>
+                <p className="dashboard-detail-value mt-1 font-semibold text-vetneb-ink">
+                  {report.fileName ?? (report.hasFile ? "Disponible" : "—")}
+                </p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  {report.hasFile
+                    ? "El documento está disponible en el dock de acciones."
+                    : "El informe aún no tiene archivo vinculado."}
                 </p>
               </div>
-              <div className="min-h-0 flex-1 overflow-hidden">
-                <StudyTimeline steps={selectedReportTimelineSteps} />
-              </div>
-            </section>
-          ) : null}
+            ) : null}
+
+            {detailSection === "timeline" ? (
+              <section
+                className="flex min-h-0 flex-col gap-2 overflow-hidden"
+                aria-labelledby="study-timeline-heading"
+              >
+                <div className="shrink-0">
+                  <h3
+                    id="study-timeline-heading"
+                    className="text-sm font-semibold text-vetneb-ink"
+                  >
+                    Línea de tiempo del estudio
+                  </h3>
+                  <p className="dashboard-detail-value text-xs text-muted-foreground">
+                    Pasos derivados del estado y fechas ya disponibles.
+                  </p>
+                </div>
+                <div className="min-h-0 flex-1 overflow-hidden">
+                  <StudyTimeline steps={selectedReportTimelineSteps} />
+                </div>
+              </section>
+            ) : null}
+          </div>
         </div>
 
         <section
@@ -499,7 +525,7 @@ export function InformesReportsList({
           >
             Acciones
           </h3>
-          <p className="truncate text-xs text-muted-foreground">
+          <p className="dashboard-detail-value text-xs text-muted-foreground">
             Visualización y descarga del archivo disponible.
           </p>
           <div className="mt-2">

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1524,6 +1524,7 @@ export function ClinicParticularTokensCard() {
           }}
           title={`Token ****${selectedToken.tokenLast4}`}
           description={`${selectedToken.petName} · ${selectedToken.tutorLastName}`}
+          scrollableBody
         >
           <div
             data-clinic-access-detail-dialog="true"

--- a/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
+++ b/frontend/src/components/dashboard/ClinicParticularTokensCard.tsx
@@ -1545,65 +1545,71 @@ export function ClinicParticularTokensCard() {
             </div>
 
             <dl className="grid grid-cols-1 divide-y divide-vetneb-line/55 rounded-lg border border-vetneb-line/70 sm:grid-cols-2 sm:divide-x sm:divide-y-0">
-              <div className="space-y-1 p-2.5">
+              <div className="min-w-0 space-y-1 p-2.5">
                 <dt className="text-[0.6875rem] text-muted-foreground">
                   Paciente
                 </dt>
-                <dd className="font-medium text-vetneb-ink">
+                <dd className="dashboard-detail-value font-medium text-vetneb-ink">
                   {selectedToken.petName} · {selectedToken.tutorLastName}
                 </dd>
-                <dd className="text-muted-foreground">
+                <dd className="dashboard-detail-value text-muted-foreground">
                   {selectedToken.petSpecies} · {selectedToken.petBreed} ·{" "}
                   {selectedToken.petSex} · {selectedToken.petAge}
                 </dd>
               </div>
-              <div className="space-y-1 p-2.5">
+              <div className="min-w-0 space-y-1 p-2.5">
                 <dt className="text-[0.6875rem] text-muted-foreground">
                   Vínculo
                 </dt>
-                <dd className="font-medium text-vetneb-ink">
+                <dd className="dashboard-detail-value font-medium text-vetneb-ink">
                   Tutor: {selectedToken.tutorLastName}
                 </dd>
-                <dd className="text-muted-foreground">
+                <dd className="dashboard-detail-value text-muted-foreground">
                   Origen: {formatTokenSource(selectedToken)}
                 </dd>
               </div>
             </dl>
 
-            <dl className="grid grid-cols-2 gap-x-3 gap-y-2">
-              <div>
+            <dl className="grid grid-cols-1 gap-x-3 gap-y-2 sm:grid-cols-2">
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">Muestra</dt>
-                <dd className="truncate text-vetneb-ink">
+                <dd className="dashboard-detail-value text-vetneb-ink">
                   {selectedToken.sampleLocation}
                 </dd>
               </div>
-              <div>
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">Evolución</dt>
-                <dd className="truncate text-vetneb-ink">
+                <dd className="dashboard-detail-value text-vetneb-ink">
                   {selectedToken.sampleEvolution}
                 </dd>
               </div>
-              <div>
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">
                   Extracción
                 </dt>
-                <dd>{formatDate(selectedToken.extractionDate)}</dd>
+                <dd className="dashboard-detail-value">
+                  {formatDate(selectedToken.extractionDate)}
+                </dd>
               </div>
-              <div>
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">Envío</dt>
-                <dd>{formatDate(selectedToken.shippingDate)}</dd>
+                <dd className="dashboard-detail-value">
+                  {formatDate(selectedToken.shippingDate)}
+                </dd>
               </div>
-              <div>
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">
                   Informe
                 </dt>
-                <dd>{selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}</dd>
+                <dd className="dashboard-detail-value">
+                  {selectedToken.reportId ? `#${selectedToken.reportId}` : "—"}
+                </dd>
               </div>
-              <div>
+              <div className="min-w-0">
                 <dt className="text-[0.6875rem] text-muted-foreground">
                   Último acceso
                 </dt>
-                <dd>
+                <dd className="dashboard-detail-value">
                   {selectedToken.lastLoginAt
                     ? formatDate(selectedToken.lastLoginAt)
                     : "—"}
@@ -1612,11 +1618,11 @@ export function ClinicParticularTokensCard() {
             </dl>
 
             {selectedToken.detailsLesion ? (
-              <div className="rounded-lg border border-vetneb-line/65 px-2.5 py-2">
+              <div className="min-w-0 rounded-lg border border-vetneb-line/65 px-2.5 py-2">
                 <p className="text-[0.6875rem] text-muted-foreground">
                   Detalle de lesión
                 </p>
-                <p className="line-clamp-2 text-vetneb-ink">
+                <p className="dashboard-detail-value text-vetneb-ink">
                   {selectedToken.detailsLesion}
                 </p>
               </div>

--- a/frontend/src/components/dashboard/ModuleDialog.tsx
+++ b/frontend/src/components/dashboard/ModuleDialog.tsx
@@ -33,9 +33,17 @@ export type ModuleDialogProps = {
 
 /**
  * Compact, centered dialog for App Shell forms and confirmations. Content is
- * meant to be short or step-based; the panel is capped to the viewport and does
- * not introduce internal scroll on desktop (forms are split into steps/dialogs
- * rather than scrolled).
+ * meant to be short or step-based; the panel is capped to the viewport.
+ *
+ * Scroll ownership. The panel is `max-h-[88vh]` and `.clinical-modal` is
+ * `overflow-hidden`, so before PR-TRUNC any body taller than that remainder was
+ * CLIPPED with no way to reach the hidden part — the dialog is the terminal
+ * surface for a datum, so that clipping was silent data loss (measured on the
+ * admin/clinic token detail at 360x800: the panel reported scrollWidth 364 vs
+ * clientWidth 326). The body below is therefore the ONE local scroll owner of
+ * the dialog: it only scrolls when the content genuinely exceeds the cap, so
+ * short dialogs are byte-identical and no consumer gains a second scroller.
+ * Header and footer stay outside it and remain visible without scrolling.
  */
 export function ModuleDialog({
   open,
@@ -101,14 +109,14 @@ export function ModuleDialog({
             <div className="min-w-0">
               <Dialog.Title
                 id={titleId}
-                className="text-base font-semibold text-vetneb-ink"
+                className="break-words text-base font-semibold text-vetneb-ink"
               >
                 {title}
               </Dialog.Title>
               {description ? (
                 <Dialog.Description
                   id={descId}
-                  className="mt-0.5 text-xs text-muted-foreground"
+                  className="mt-0.5 break-words text-xs text-muted-foreground"
                 >
                   {description}
                 </Dialog.Description>
@@ -127,7 +135,12 @@ export function ModuleDialog({
             </Dialog.Close>
           </div>
 
-          <div className="min-h-0 flex-1 px-5 py-4">{children}</div>
+          <div
+            data-module-dialog-body="true"
+            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4"
+          >
+            {children}
+          </div>
 
           {footer ? (
             <div className="flex shrink-0 flex-wrap items-center justify-end gap-2 border-t border-vetneb-line/70 px-5 py-3">

--- a/frontend/src/components/dashboard/ModuleDialog.tsx
+++ b/frontend/src/components/dashboard/ModuleDialog.tsx
@@ -20,6 +20,19 @@ export type ModuleDialogProps = {
   busy?: boolean;
   closeLabel?: string;
   /**
+   * PR-TRUNC follow-up. Opt-in local scroll owner for the body, scoped to
+   * this dialog instance only. Off by default: the panel stays the original
+   * compact/step-based contract (capped to the viewport, no internal
+   * scroller) so short forms and confirmations are byte-identical to before.
+   * Set only by long-form DETAIL/DIALOG/INSPECTOR consumers whose content can
+   * genuinely exceed `max-h-[88vh]` — the body becomes their single reachable
+   * scroll owner instead of letting `.clinical-modal`'s `overflow-hidden`
+   * clip it. A consumer that already owns its own internal scroll region
+   * (e.g. the informes master-detail canvas) must NOT set this: it would
+   * compete with that region instead of letting it size correctly.
+   */
+  scrollableBody?: boolean;
+  /**
    * B05: mount the Radix portal under `[data-dashboard-portal-root="true"]`
    * (a dedicated, always-empty child of `.dashboard-app-shell`) instead of
    * `document.body`, so CSS custom properties declared on `.dashboard-app-shell`
@@ -33,17 +46,22 @@ export type ModuleDialogProps = {
 
 /**
  * Compact, centered dialog for App Shell forms and confirmations. Content is
- * meant to be short or step-based; the panel is capped to the viewport.
+ * meant to be short or step-based; the panel is capped to the viewport and
+ * does not scroll internally by default.
  *
  * Scroll ownership. The panel is `max-h-[88vh]` and `.clinical-modal` is
- * `overflow-hidden`, so before PR-TRUNC any body taller than that remainder was
- * CLIPPED with no way to reach the hidden part — the dialog is the terminal
- * surface for a datum, so that clipping was silent data loss (measured on the
- * admin/clinic token detail at 360x800: the panel reported scrollWidth 364 vs
- * clientWidth 326). The body below is therefore the ONE local scroll owner of
- * the dialog: it only scrolls when the content genuinely exceeds the cap, so
- * short dialogs are byte-identical and no consumer gains a second scroller.
- * Header and footer stay outside it and remain visible without scrolling.
+ * `overflow-hidden`, so a body taller than that remainder is CLIPPED with no
+ * way to reach the hidden part unless something scrolls it — the dialog is
+ * the terminal surface for a datum, so that clipping is silent data loss
+ * (measured on the admin/clinic token detail at 360x800: the panel reported
+ * scrollWidth 364 vs clientWidth 326). A GLOBAL scroller on every instance
+ * would fix that but breaks the original compact/step-based contract for
+ * short forms and can bury a consumer's own critical actions or internal
+ * scroll region under a second, redundant one. So the body is a flex column
+ * (letting a consumer's child stretch to its full height when it needs to)
+ * and only becomes a scroll owner when `scrollableBody` opts in, per
+ * instance. Header and footer always stay outside it and remain visible
+ * without scrolling.
  */
 export function ModuleDialog({
   open,
@@ -56,6 +74,7 @@ export function ModuleDialog({
   busy = false,
   closeLabel = "Cerrar",
   dashboardScopedPortal = false,
+  scrollableBody = false,
 }: ModuleDialogProps) {
   const titleId = useId();
   const descId = useId();
@@ -137,7 +156,9 @@ export function ModuleDialog({
 
           <div
             data-module-dialog-body="true"
-            className="min-h-0 flex-1 overflow-y-auto overscroll-contain px-5 py-4"
+            className={`flex min-h-0 flex-1 flex-col px-5 py-4 ${
+              scrollableBody ? "overflow-y-auto overscroll-contain" : ""
+            }`}
           >
             {children}
           </div>

--- a/frontend/src/styles/dashboard/surfaces.css
+++ b/frontend/src/styles/dashboard/surfaces.css
@@ -698,3 +698,41 @@
   background-color: var(--dash-color-field);
 }
 /* dashboard-b05-field-inversion:end */
+
+/* dashboard-detail-value-integrity:start */
+/*
+  PR-TRUNC · Terminal-surface text integrity.
+
+  A DETAIL / DIALOG / INSPECTOR is the LAST place a datum is rendered: there is
+  no deeper surface to open, so anything hidden there is hidden for good. The
+  audit measured that loss on the shipped dialogs — admin token detail at
+  360x800 showed "Muestra" with scrollWidth 528 against clientWidth 137 (26% of
+  the value readable) and clamped "Detalle de lesión" to 32px of a 96px text —
+  and the same shape repeated on the clinic token, admin report and clinic
+  report details at every one of the 13 canonical viewports.
+
+  This class is the single grammar those surfaces now use, so the guard in
+  test/architecture/dashboard-truncation-integrity.test.ts can census exactly
+  where full text is contractual instead of banning `truncate` repo-wide (a
+  collection row may still truncate legitimately — see §6 of the audit).
+
+  - `white-space: normal` undoes any inherited `nowrap`.
+  - `overflow-wrap: anywhere` is what actually rescues the unbroken values
+    (file names, opaque identifiers): unlike `break-word` it also lowers the
+    min-content contribution, so a grid/flex track can shrink to the container
+    instead of forcing horizontal overflow the panel would then clip.
+  - `min-width: 0` for the same reason on the element itself; the parent cell
+    carries it too where the value sits inside a grid item.
+  - No `overflow`, no `max-height`, no `-webkit-line-clamp`: nothing here may
+    hide a glyph. Height is absorbed by the dialog body's own scroll owner
+    (ModuleDialog) or the detail section canvas, never by clipping.
+*/
+@layer components {
+  .dashboard-detail-value {
+    min-width: 0;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+  }
+}
+/* dashboard-detail-value-integrity:end */

--- a/test/architecture/dashboard-capacity-single-owner.test.ts
+++ b/test/architecture/dashboard-capacity-single-owner.test.ts
@@ -166,16 +166,83 @@ test("migrated consumers observe at most the canvas, and never the rows", () => 
   }
 });
 
+// PR-TRUNC. The ban below means what its message says: a scroller must never be
+// an escape from a ROWS-CAPACITY bug. It used to be spelled as "no
+// `overflow-y-auto` anywhere in the file", which also caught regions that own
+// no rows, no capacity and no pager — and the informes DETAIL canvas is exactly
+// that. Its previous way of staying inside its bounded track was to TRUNCATE
+// every value in it and let `overflow: hidden` swallow the rest (measured: 156px
+// of a clinical record clipped at 1366x768, with normal data), which is the
+// defect PR-TRUNC exists to remove.
+//
+// So the exemption is granted to ONE explicitly anchored element, and it is paid
+// for twice: the anchor must not sit on the rows canvas (asserted below), and
+// the runtime contract in
+// frontend/e2e/clinic/reports/clinic-informes-zero-internal-scroll.spec.ts
+// asserts there is at most one of them and that its end is reachable.
+const SANCTIONED_SCROLL_OWNER_ANCHOR = 'data-informes-detail-scroll-owner="true"';
+const FORBIDDEN_SCROLLER =
+  /overflow-y-auto|overflow-y:\s*auto|overflow:\s*scroll|overflow-scroll/;
+
+/** Drops the opening tag of the sanctioned owner so the ban can run on the rest. */
+function stripSanctionedScrollOwner(source: string): string {
+  return source.replace(
+    new RegExp(`<[a-zA-Z]+\\s[^>]*${SANCTIONED_SCROLL_OWNER_ANCHOR}[^>]*>`, "g"),
+    "",
+  );
+}
+
 test("migrated consumers introduce no forbidden internal scroller", () => {
   for (const path of MIGRATED_CONSUMERS) {
     const source = readSource(path);
 
     assert.ok(
-      !/overflow-y-auto|overflow-y:\s*auto|overflow:\s*scroll|overflow-scroll/.test(
-        source,
-      ),
+      !FORBIDDEN_SCROLLER.test(stripSanctionedScrollOwner(source)),
       `${path}: an internal scroller is not an escape from a capacity bug`,
     );
+  }
+});
+
+test("the sanctioned detail scroll owner is never the rows canvas", () => {
+  const owners = MIGRATED_CONSUMERS.filter((path) =>
+    readSource(path).includes(SANCTIONED_SCROLL_OWNER_ANCHOR),
+  );
+
+  assert.equal(
+    owners.length,
+    1,
+    `exactly one migrated consumer may declare the sanctioned detail scroll owner, found ${owners.length}`,
+  );
+
+  for (const path of owners) {
+    const source = readSource(path);
+
+    // The exemption covers a DETAIL region. If the anchor ever lands on the
+    // element that also declares the rows canvas — or its pager reserve — the
+    // scroller IS papering over a capacity bug and the ban must bite again.
+    const openingTags = [
+      ...source.matchAll(
+        new RegExp(
+          `<[a-zA-Z]+\\s[^>]*${SANCTIONED_SCROLL_OWNER_ANCHOR}[^>]*>`,
+          "g",
+        ),
+      ),
+    ].map((match) => match[0]);
+
+    assert.ok(openingTags.length > 0, `${path}: sanctioned owner tag not found`);
+
+    for (const tag of openingTags) {
+      assert.equal(
+        tag.includes("data-dashboard-adaptive-rows-canvas"),
+        false,
+        `${path}: the rows canvas may never be the scroll owner`,
+      );
+      assert.equal(
+        tag.includes("data-dashboard-adaptive-reserved-region"),
+        false,
+        `${path}: a reserved region may never be the scroll owner`,
+      );
+    }
   }
 });
 

--- a/test/architecture/dashboard-truncation-integrity.test.ts
+++ b/test/architecture/dashboard-truncation-integrity.test.ts
@@ -1,0 +1,428 @@
+import test from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+
+import { readDashboardCssSource } from "../helpers/read-dashboard-css-source.ts";
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PR-TRUNC · Terminal-surface text integrity, static contract.
+//
+// WHY THIS GUARD IS NOT `assert(!source.includes("truncate"))`
+//
+// Truncation is not a defect by itself. A COLLECTION row may legitimately
+// truncate: it is a compact representation, it is not where the record is read,
+// and a detail surface next to it carries the full value. The audit kept those
+// (admin audit dense table → AdminAuditDetailDialog; admin clinics table →
+// ClinicEditDrawer; clinic logistics rows → the visit dialog).
+//
+// What is never legitimate is truncation on the TERMINAL surface — the
+// DETAIL / DIALOG / INSPECTOR a row opens into. There is nothing deeper to
+// open, so a value hidden there is hidden for good. Measured on the shipped
+// build with long synthetic values at 360x800: the admin token detail rendered
+// "Muestra" at scrollWidth 528 against clientWidth 137, clamped "Detalle de
+// lesión" to 32px of a 96px text, and the admin report detail showed 15% of a
+// long study type.
+//
+// So this guard CENSUSES the terminal regions explicitly, by component and by
+// the exact region inside it, and bans the hiding grammars only there. Adding a
+// new detail surface without registering it here is the one gap it cannot see;
+// the E2E counterpart
+// (frontend/e2e/platform/app-shell/dashboard-detail-text-integrity.spec.ts)
+// closes it at runtime by measuring the rendered boxes.
+//
+// Fail-closed: every census asserts its region actually matched before scanning
+// it, so a rename or a refactor fails here instead of passing vacuously.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MODULE_DIALOG_TSX = "frontend/src/components/dashboard/ModuleDialog.tsx";
+
+/** Grammars that hide part of a value. None may appear in a terminal region. */
+const HIDING_GRAMMARS: readonly { readonly pattern: RegExp; readonly name: string }[] = [
+  { pattern: /\btruncate\b/, name: "truncate" },
+  { pattern: /\bline-clamp-\d\b/, name: "line-clamp-N" },
+  { pattern: /\bsm:truncate\b/, name: "sm:truncate" },
+  { pattern: /\bwhitespace-nowrap\b/, name: "whitespace-nowrap" },
+  { pattern: /text-overflow:\s*ellipsis/, name: "text-overflow: ellipsis" },
+];
+
+type TerminalRegion = {
+  /** Human label used in every failure message. */
+  readonly label: string;
+  readonly file: string;
+  /** Literal that opens the region; the census fails if it is absent. */
+  readonly start: string;
+  /** Literal that closes it. */
+  readonly end: string;
+  /** Values whose full text is contractual on this surface. */
+  readonly contractualValues: readonly string[];
+};
+
+// The census. One entry per DETAIL / DIALOG / INSPECTOR body that renders a
+// datum as its terminal surface, on BOTH roles.
+const TERMINAL_REGIONS: readonly TerminalRegion[] = [
+  {
+    label: "ADMIN · particular token detail dialog (summary tab)",
+    file: "frontend/src/app/dashboard/admin/AdminParticularTokensCard.tsx",
+    start: 'role="tabpanel" aria-label="Resumen del token"',
+    end: "detailTab === \"tracking\"",
+    contractualValues: [
+      "selectedToken.sampleLocation",
+      "selectedToken.sampleEvolution",
+      "selectedToken.detailsLesion",
+      "selectedToken.petBreed",
+    ],
+  },
+  {
+    label: "ADMIN · report workflow detail dialog",
+    file: "frontend/src/app/dashboard/admin/AdminReportsCard.tsx",
+    start: 'title={`Informe #${selectedReport.id}`}',
+    end: "Etapa operativa",
+    contractualValues: [
+      "selectedReport.patientName",
+      "selectedReport.fileName",
+      "studyLabel(selectedReport.studyType)",
+    ],
+  },
+  {
+    label: "ADMIN · audit event detail dialog",
+    file: "frontend/src/app/dashboard/admin/AdminAuditDetailDialog.tsx",
+    start: "<dl className=",
+    end: "</dl>",
+    contractualValues: [
+      "row.eventCode",
+      "row.actor",
+      "row.entity",
+      "row.action",
+      "row.detail",
+    ],
+  },
+  {
+    label: "ADMIN · failed login attempt detail dialog",
+    file: "frontend/src/app/dashboard/admin/AdminFailedLoginDetailDialog.tsx",
+    start: "<dl className=",
+    end: "</dl>",
+    contractualValues: [
+      "alert.username",
+      "alert.ipAddress",
+      "alert.userAgent",
+      "alert.createdAt",
+      "surfaceLabel",
+      "reasonLabel",
+    ],
+  },
+  {
+    label: "ADMIN · users and roles detail dialog",
+    file: "frontend/src/app/dashboard/admin/AdminUserRoleDetailDialog.tsx",
+    start: "<dl className=",
+    end: "</dl>",
+    contractualValues: [
+      "user.username",
+      "clinicLabel",
+      "clinicMetadata",
+      "userTypeLabel",
+      "roleLabel",
+      "user.createdAt",
+      "user.updatedAt",
+    ],
+  },
+  {
+    label: "CLINIC · particular token detail dialog",
+    file: "frontend/src/components/dashboard/ClinicParticularTokensCard.tsx",
+    start: "<dl className=\"grid grid-cols-1 divide-y divide-vetneb-line/55",
+    end: "Seguimiento",
+    contractualValues: [
+      "selectedToken.sampleLocation",
+      "selectedToken.sampleEvolution",
+      "selectedToken.detailsLesion",
+      "selectedToken.petBreed",
+    ],
+  },
+  {
+    label: "CLINIC · informes workspace summary detail dialog",
+    file: "frontend/src/app/dashboard/ClinicInformesWorkspaceSummary.tsx",
+    start: 'data-clinic-reports-detail-dialog="true"',
+    end: "Documento seguro",
+    contractualValues: [
+      "selectedReport.patientName",
+      "selectedReport.studyType",
+      "formatReportFile(selectedReport)",
+    ],
+  },
+  {
+    label: "CLINIC · logistics visit detail dialog",
+    file: "frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx",
+    start: 'data-clinic-logistics-detail-dialog="true"',
+    end: "Abrir visitas en módulo completo",
+    contractualValues: ["selectedVisit.clinicName", "selectedVisit.address"],
+  },
+  {
+    label: "CLINIC · informes master-detail canvas (desktop panel + mobile dialog)",
+    file: "frontend/src/app/dashboard/informes/InformesReportsList.tsx",
+    start: "function renderReportDetailCanvas(",
+    end: "Visualización y descarga del archivo disponible.",
+    contractualValues: [
+      "getReportTitle(report)",
+      "report.clinicName",
+      "report.patientName",
+      "report.studyType",
+      "report.fileName",
+    ],
+  },
+];
+
+function read(file: string): string {
+  return readFileSync(file, "utf8").replace(/\r\n/g, "\n");
+}
+
+function sliceRegion(source: string, region: TerminalRegion): string {
+  const startIndex = source.indexOf(region.start);
+  assert.notEqual(
+    startIndex,
+    -1,
+    `${region.label}: region start marker not found in ${region.file}. ` +
+      "The detail surface was renamed or removed; realign this census, do not delete it.",
+  );
+
+  const endIndex = source.indexOf(region.end, startIndex + region.start.length);
+  assert.notEqual(
+    endIndex,
+    -1,
+    `${region.label}: region end marker not found after the start marker in ${region.file}.`,
+  );
+
+  const slice = source.slice(startIndex, endIndex);
+  assert.ok(
+    slice.length > 120,
+    `${region.label}: region resolved to ${slice.length} characters, which cannot be a real detail body. ` +
+      "A vacuous census is a failure, not a pass.",
+  );
+  return slice;
+}
+
+test("PR-TRUNC · the terminal-surface census is non-empty and covers both roles", () => {
+  assert.ok(
+    TERMINAL_REGIONS.length >= 9,
+    "the census must keep covering every audited detail surface",
+  );
+
+  const roles = new Set(TERMINAL_REGIONS.map((r) => r.label.split(" ·")[0]));
+  assert.ok(roles.has("ADMIN"), "the census must cover admin detail surfaces");
+  assert.ok(roles.has("CLINIC"), "the census must cover clinic detail surfaces");
+});
+
+test("PR-TRUNC · no DETAIL/DIALOG/INSPECTOR region hides part of a value", () => {
+  for (const region of TERMINAL_REGIONS) {
+    const slice = sliceRegion(read(region.file), region);
+
+    for (const grammar of HIDING_GRAMMARS) {
+      assert.equal(
+        grammar.pattern.test(slice),
+        false,
+        `${region.label}: \`${grammar.name}\` is forbidden on a terminal surface. ` +
+          "There is no deeper surface to open, so anything it hides is lost. " +
+          "Use `.dashboard-detail-value` (wrap + overflow-wrap) instead; if the " +
+          "content genuinely exceeds the viewport, let the sanctioned local " +
+          "scroll owner absorb it.",
+      );
+    }
+  }
+});
+
+test("PR-TRUNC · every contractual value is still rendered by its detail region", () => {
+  for (const region of TERMINAL_REGIONS) {
+    const slice = sliceRegion(read(region.file), region);
+
+    for (const value of region.contractualValues) {
+      assert.ok(
+        slice.includes(value),
+        `${region.label}: \`${value}\` must stay rendered by this detail region. ` +
+          "Removing a field is not a valid way to satisfy the truncation contract.",
+      );
+    }
+  }
+});
+
+test("PR-TRUNC · the detail-value grammar exists and cannot clip", () => {
+  const css = readDashboardCssSource();
+
+  assert.ok(
+    css.includes(".dashboard-detail-value"),
+    "`.dashboard-detail-value` must be declared in the dashboard CSS composition root",
+  );
+
+  const start = css.indexOf(".dashboard-detail-value");
+  const end = css.indexOf("}", start);
+  assert.notEqual(end, -1, "`.dashboard-detail-value` block must be closed");
+  const block = css.slice(start, end);
+
+  for (const declaration of [
+    "white-space: normal",
+    "overflow-wrap: anywhere",
+    "min-width: 0",
+  ]) {
+    assert.ok(
+      block.includes(declaration),
+      `\`.dashboard-detail-value\` must declare \`${declaration}\``,
+    );
+  }
+
+  for (const forbidden of [
+    "overflow: hidden",
+    "-webkit-line-clamp",
+    "text-overflow: ellipsis",
+    "white-space: nowrap",
+    "max-height",
+  ]) {
+    assert.equal(
+      block.includes(forbidden),
+      false,
+      `\`.dashboard-detail-value\` must never declare \`${forbidden}\`: it is the grammar that GUARANTEES full text`,
+    );
+  }
+});
+
+test("PR-TRUNC · ModuleDialog owns exactly one local scroll owner for its body", () => {
+  const source = read(MODULE_DIALOG_TSX);
+
+  assert.ok(
+    source.includes('data-module-dialog-body="true"'),
+    "the ModuleDialog body must carry its anchor so the E2E contract can measure it",
+  );
+
+  const bodyIndex = source.indexOf('data-module-dialog-body="true"');
+  const bodyEnd = source.indexOf("{children}", bodyIndex);
+  assert.notEqual(bodyEnd, -1, "the ModuleDialog body must still render its children");
+  const body = source.slice(bodyIndex, bodyEnd);
+
+  assert.ok(
+    body.includes("overflow-y-auto"),
+    "the ModuleDialog body must be the local scroll owner: `.clinical-modal` is " +
+      "`overflow-hidden` and the panel is capped at `max-h-[88vh]`, so without it " +
+      "any taller body is CLIPPED with no way to reach the hidden part",
+  );
+  assert.ok(
+    body.includes("min-h-0"),
+    "the ModuleDialog body must keep `min-h-0` so the flex column can actually shrink it",
+  );
+
+  // The header and the footer stay OUT of the scroll owner: critical actions
+  // must remain visible without scrolling (AGENTS §10).
+  const header = source.slice(0, bodyIndex);
+  assert.equal(
+    header.includes("overflow-y-auto"),
+    false,
+    "the ModuleDialog header must not become a second scroll owner",
+  );
+  const footer = source.slice(source.indexOf("{footer ?"));
+  assert.equal(
+    footer.includes("overflow-y-auto"),
+    false,
+    "the ModuleDialog footer must not become a second scroll owner",
+  );
+});
+
+test("PR-TRUNC · collection surfaces that legitimately truncate still expose the full value", () => {
+  // The three retained SAFE_TRUNCATION collections, each pinned to the exact
+  // mechanism that makes them safe. If the mechanism goes, the truncation is no
+  // longer safe and this guard says so.
+  const cases: readonly { file: string; mechanism: string; why: string }[] = [
+    {
+      file: "frontend/src/app/dashboard/admin/AdminAuditDenseTable.tsx",
+      mechanism: "<AdminAuditDetailDialog row={row} />",
+      why: "the dense audit row truncates; the detail dialog is what makes it safe",
+    },
+    {
+      file: "frontend/src/app/dashboard/admin/AdminClinicsManagementCard.tsx",
+      mechanism: "setEditingClinic(clinic)",
+      why: "the clinics row truncates; ClinicEditDrawer carries the full values",
+    },
+    {
+      file: "frontend/src/app/dashboard/ClinicLogisticaWorkspaceSummary.tsx",
+      mechanism: "setSelectedVisitId(visit.id)",
+      why: "the logistics row truncates; the visit detail dialog carries the full values",
+    },
+  ];
+
+  for (const testCase of cases) {
+    const source = read(testCase.file);
+    assert.ok(
+      source.includes(testCase.mechanism),
+      `${testCase.file}: ${testCase.why}. Missing \`${testCase.mechanism}\`.`,
+    );
+  }
+
+  // Failed logins: the row truncates the user agent in a pitch-locked table, so
+  // the DIALOG is what makes that truncation safe. `title` was rejected as the
+  // mechanism — hover-only, unreliable for assistive technology, invisible to
+  // touch — so the pin is the dialog, on BOTH presentations of the card.
+  const failedLogins = read(
+    "frontend/src/app/dashboard/admin/AdminFailedLoginAlertsReadOnlyCard.tsx",
+  );
+  const failedLoginTriggers = failedLogins.split(
+    "<AdminFailedLoginDetailDialog",
+  ).length - 1;
+  assert.equal(
+    failedLoginTriggers,
+    2,
+    "AdminFailedLoginAlertsReadOnlyCard truncates the user agent in a pitch-locked table: the detail dialog is its full-value mechanism and must be mounted on BOTH the desktop row and the mobile row",
+  );
+  assert.equal(
+    failedLogins.includes("title={alert.userAgent"),
+    false,
+    "a `title` attribute must not be reintroduced as the full-value mechanism: it is hover-only and not an accessible disclosure",
+  );
+
+  // Users/roles: the finding is CLOSED the same way. The row keeps truncating
+  // `username` and the clinic name (the table is pitch-locked, so wrapping there
+  // would clip vertically and move A03), and the detail dialog is what makes
+  // that truncation safe — on BOTH presentations, never a `title`.
+  const usersRoles = read(
+    "frontend/src/app/dashboard/admin/AdminUsersRolesReadOnlyCard.tsx",
+  );
+
+  // 1. The collection may still truncate: that is not the defect.
+  assert.ok(
+    /truncate[^"]*"[\s\S]{0,80}\{user\.username\}/.test(usersRoles),
+    "the users/roles row is a compact pitch-locked representation and may keep truncating the username",
+  );
+
+  // 2 + 5. An accessible terminal disclosure exists, on desktop AND mobile.
+  const usersRolesTriggers =
+    usersRoles.split("<AdminUserRoleDetailDialog").length - 1;
+  assert.equal(
+    usersRolesTriggers,
+    2,
+    "AdminUsersRolesReadOnlyCard must mount the detail dialog on BOTH the desktop row and the mobile row; a disclosure that only exists on one presentation leaves the other truncation unsafe",
+  );
+
+  // 4 + 6. `title` must never be the mechanism again for these two fields.
+  for (const titleOnly of [
+    "title={user.username}",
+    "title={getClinicMetadata(user)",
+  ]) {
+    assert.equal(
+      usersRoles.includes(titleOnly),
+      false,
+      `\`${titleOnly}\` must not come back as the full-value mechanism: \`title\` is hover-only, unreliable for assistive technology and invisible to touch`,
+    );
+  }
+
+  // 3. The dialog must actually carry both values, not just exist. The census
+  // above already forbids hiding grammars inside it.
+  const usersRolesDialog = read(
+    "frontend/src/app/dashboard/admin/AdminUserRoleDetailDialog.tsx",
+  );
+  for (const value of ["{user.username}", "{clinicLabel}"]) {
+    assert.ok(
+      usersRolesDialog.includes(value),
+      `AdminUserRoleDetailDialog must render ${value} in full — it is the terminal surface for that datum`,
+    );
+  }
+
+  // The disclosure is READ-ONLY: role mutation stays in the row's own control.
+  assert.equal(
+    /handleChangeClinicRole|onChange|<input|<select/.test(usersRolesDialog),
+    false,
+    "AdminUserRoleDetailDialog must stay read-only: it discloses a record, it does not edit users or roles",
+  );
+});

--- a/test/architecture/e2e-suite-catalog-completeness.test.ts
+++ b/test/architecture/e2e-suite-catalog-completeness.test.ts
@@ -23,15 +23,17 @@ const TEST_FILE = fileURLToPath(import.meta.url);
 const REPO_ROOT = resolve(dirname(TEST_FILE), "..", "..");
 process.chdir(REPO_ROOT);
 
-const EXPECTED_WORKSPACE_SPEC_COUNT = 86;
-const EXPECTED_CATALOG_SPEC_COUNT = 86;
+const EXPECTED_WORKSPACE_SPEC_COUNT = 87;
+const EXPECTED_CATALOG_SPEC_COUNT = 87;
 const EXPECTED_MANUAL_ONLY_SPEC_COUNT = 0;
 const EXPECTED_DOMAIN_COUNTS = new Map([
   ["admin", 19],
   ["clinic", 22],
   ["public", 8],
   ["particular", 3],
-  ["platform", 18],
+  // +1: PR-TRUNC detail text integrity (platform/app-shell), routed to
+  // visual-contract like the other app-shell contracts (AGENTS.md §7).
+  ["platform", 19],
   // +1: B10 clinic app-shell unification, the runtime half of the shared
   // ClinicDashboardShell contract.
   ["regression", 16],
@@ -40,15 +42,15 @@ const EXPECTED_CURRENT_COUNTS = new Map([
   ["smoke", 9],
   ["admin-mobile", 13],
   // +1: B10, routed to visual-contract like B08 and B09 (AGENTS.md §7).
-  ["visual-contract", 18],
+  ["visual-contract", 19],
   ["public-clinic", 12],
 ]);
 const EXPECTED_EXECUTION_COUNTS = new Map<E2eExecutionCohort, number>([
-  ["ci", 52],
+  ["ci", 53],
   ["extended", 29],
   ["evidence", 2],
   ["visual-linux", 3],
-  ["full", 86],
+  ["full", 87],
   ["affected", 0],
 ]);
 const EXECUTION_PARTITION_COHORTS = [
@@ -263,7 +265,7 @@ function validateCatalog(
   }
 
   const currentUnion = unique([...currentMemberships.keys()]).sort();
-  assert.equal(currentUnion.length, 52);
+  assert.equal(currentUnion.length, 53);
   assert.deepEqual(E2E_COHORT_SPECS.ci, currentUnion, "ci must equal the current four-cohort union");
 
   for (const cohort of ["extended", "evidence", "visual-linux", "full"] as const) {
@@ -317,11 +319,11 @@ test("catalog validation catches missing and duplicate entries in memory", async
 
   assert.throws(
     () => validateCatalog(missing, workspaceSpecs, E2E_MANUAL_ONLY_SPECS),
-    /85|classified/,
+    /86|classified/,
   );
   assert.throws(
     () => validateCatalog(duplicated, workspaceSpecs, E2E_MANUAL_ONLY_SPECS),
-    /86|unique/,
+    /87|unique/,
   );
 });
 
@@ -359,7 +361,7 @@ test("affected selection fails closed for empty or shared changes", async () => 
 
   const sharedSelection = runner.classifyAffectedPaths(["frontend/e2e/helpers/admin-mobile-contracts.ts"]);
   assert.equal(sharedSelection.fallback, true);
-  assert.equal(sharedSelection.specs.length, 52);
+  assert.equal(sharedSelection.specs.length, 53);
   assert.match(sharedSelection.reason, /shared E2E infrastructure/);
 });
 

--- a/test/unit/infrastructure/e2e-completeness-workflow.test.ts
+++ b/test/unit/infrastructure/e2e-completeness-workflow.test.ts
@@ -177,7 +177,8 @@ test("automatic workflow coverage is derived from catalog cohorts and equals ful
   assert.deepEqual(result.automaticRoutes.get(FRONTEND_WORKFLOW), ["ci"]);
   assert.deepEqual(result.automaticRoutes.get(COMPLETENESS_WORKFLOW), ["full"]);
   // +1: B10 clinic app-shell unification (regression/dashboard-shell).
-  assert.equal(E2E_SUITE_CATALOG.length, 86);
+  // +1: PR-TRUNC detail text integrity (platform/app-shell).
+  assert.equal(E2E_SUITE_CATALOG.length, 87);
 
   const partitionUnion = new Set(PARTITION_COHORTS.flatMap((cohort) => E2E_COHORT_SPECS[cohort]));
   assert.deepEqual([...partitionUnion].sort(), [...E2E_COHORT_SPECS.full].sort());


### PR DESCRIPTION
## Summary
- Change type: bug fix
- Context / issue: unsafe truncation and clipping hid terminal Admin/Clinic detail values; new long-text tests also exposed a settled-row E2E race.
- What changed: preserve complete detail text, add accessible read-only disclosures for pitch-locked rows, add sanctioned local detail scroll owners, regression coverage, and harden the settled-row helper without weakening assertions.
- Governance metadata: aligned with the repository PR template; retry marker 2026-08-25.

## Scope
Select every affected **primary** scope. Documentation and tests that only support one primary scope do not need an additional checkbox.

- [ ] backend runtime
- [x] frontend runtime
- [ ] tests
- [ ] workflows/ci
- [ ] migrations/schema
- [ ] docs
- [ ] dependencies
- [ ] scripts/tooling
- [ ] repository configuration
- [ ] other
- [ ] mixed-scope exception (requires every affected primary scope above and a substantive justification below)

## Validation
- [ ] `pnpm typecheck`
- [ ] `pnpm typecheck:test`
- [ ] `pnpm test` — inherited 2 failures reproduced on base; no new failure attributed to this PR
- [ ] `pnpm build` (if backend affected)
- [x] `pnpm --dir frontend lint` (if frontend affected)
- [x] `pnpm --dir frontend typecheck` (if frontend affected)
- [x] `pnpm --dir frontend build` (if frontend affected)
- [ ] `pnpm audit --prod` (if dependencies affected)
- [ ] `pnpm audit` (if dependencies affected)
- [ ] Relevant CI checks passed (`PR Governance`, `Backend CI`, `Frontend CI` when applicable) — pending GitHub Actions

Additional validation:
- `pnpm security:public-surface`: PASSED
- `pnpm --dir frontend e2e:verify-catalog`: PASSED
- `pnpm --dir frontend e2e:visual-contract`: PASSED — 457 passed, 1 skipped, 0 failed
- `pnpm --dir frontend e2e:admin-mobile`: PASSED — 133 passed
- detail-text-integrity: PASSED — 35/35
- truncation-integrity: PASSED — 6/6
- capacity-single-owner: PASSED — 17/17
- A03 users/roles, 13 viewports: PASSED, zero drift
- A08 zero-scroll: PASS
- `git diff --check`: CLEAN

## Security / Regression Checklist
- [x] No secret/token exposure in code, logs, or config.
- [x] AuthN/AuthZ and data-access impact reviewed; no auth/backend changes.
- [x] Dependency and supply-chain impact reviewed; no dependency changes.
- [x] No unintended regression in out-of-scope domains.
- [x] Migration/schema impact explicitly not applicable.

## Rollback
- Trigger: any regression in detail accessibility, A03 capacity, A08 zero-scroll, or dashboard navigation/shell behavior attributable to this change.
- Steps: revert the squash commit for PR #1675; no schema, dependency, backend, workflow, or data migration rollback is required.
- Data impact: none; frontend/test-only behavior and presentation contract changes.

## Evidence
- unsafe truncations fixed: 26
- full detail text accessible: YES
- vertical glyph clipping: 0
- horizontal overflow: 0
- document scroll: 0
- A03 drift: ZERO
- A08 zero-scroll: PASS

## Scope fences
- B10 rollback: NO
- B11/B12/B13/B14/B15: NO scope crossing
- C13 DetailsPane: NOT implemented
- backend/API/auth/DB/dependencies/workflows: untouched
- A02 baseline: not recaptured
- A03 capacity behavior: unchanged

## Base
`9af6ea4456b1e59de9aa8f9cee3d3af13f4d56d9`